### PR TITLE
Add --remove flag to delete unused declarations from source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.2.0
+
+- Add `--remove` to delete unused declarations from source after reporting
+  them, with a confirmation prompt; `--remove --force` skips the prompt.
+- Skip operator overloads (`operator +`, `operator ==`, …) by default — the
+  analysis server can't resolve infix operator syntax back to the
+  declaration, so a used operator was always reported as unused. Pass
+  `--operators` to include them anyway.
+- Report declarations referenced only from a dartdoc `[Xxx]` comment link as
+  a separate, informational "doc-only" category (in `text`, `json`, and
+  `github` output) instead of hiding them entirely. Doc-only findings are
+  never deleted by `--remove`.
+- Clarify installation instructions: global activation vs. adding `ciach` as
+  a dev dependency.
+
 ## 0.1.0
 
 Initial implementation.

--- a/README.md
+++ b/README.md
@@ -89,12 +89,14 @@ Install it globally with `dart pub global activate --source path .` and then run
 | `--[no-]public` | on | Report unused public declarations too. Disable to report only private (`_`-prefixed) ones. |
 | `--[no-]generated` | off | Scan generated files (`*.g.dart`, `*.freezed.dart`, `*.mocks.dart`, …). |
 | `--[no-]overrides` | off | Report `@override` members too. Off by default — see limitations. |
+| `--[no-]operators` | off | Report operator overloads (`operator +`, `operator ==`, …) too. Off by default — see limitations. |
+| `--ignore-doc-references` | off | Don't count dartdoc `[Xxx]` comment links as a use. Off by default — see limitations. |
 | `--set-exit-if-changed` | off | Exit with status `1` when anything is found (for CI). Named after `dart format`. |
 | `--remove` | off | Remove unused declarations after reporting them. Prompts for confirmation first. |
 | `--force` | off | Skip the confirmation prompt for `--remove`. Requires `--remove`. |
 | `-e, --exclude <glob>` | — | Skip files matching the glob (repeatable). |
 | `-i, --include <glob>` | — | Only scan files matching the glob (repeatable). |
-| `-k, --kinds <list>` | all | Restrict to kinds: `class, mixin, interface, enum, extension, function, method, constructor, field, property, getter, setter, variable, constant, enum-value, operator`. |
+| `-k, --kinds <list>` | all | Restrict to kinds: `class, mixin, interface, enum, extension, function, method, constructor, field, property, getter, setter, variable, constant, enum-value`. |
 | `-f, --format <fmt>` | `text` | `text`, `json`, or `github` (GitHub Actions `::warning` annotations). |
 | `-j, --concurrency <n>` | `16` | Reference queries kept in flight against the analysis server. |
 | `--[no-]color` | auto | Colorize text output. |
@@ -142,22 +144,42 @@ alone unless every declarator in them is unused) but not about spacing, so
 expect the odd extra blank line.
 
 Because removal acts on whatever the finder reports, it inherits the same
-false positives described in [Limitations](#limitations) below — most
-notably operator overloads and `@override` targets — so review the diff (or
-your test suite) after removing, the same as you would after any automated
-refactor.
+false-positive risk as the report itself (see [What it skips by
+default](#what-it-skips-by-default) and [Limitations](#limitations) below) —
+enabling `--overrides` or `--operators` widens that risk considerably. Review
+the diff (or your test suite) after removing, the same as you would after any
+automated refactor.
 
 ## What it skips by default
 
-- **`main`** — the program entry point.
+These are all off by default because they're known sources of false
+positives — a used declaration reported as unused. Each has a flag to opt
+back in, at the cost of reintroducing that risk:
+
+- **`main`** — the program entry point. Always skipped; there's no flag for
+  this one.
 - **`@override` members** — they are frequently reached polymorphically or by a
   framework (Flutter's `build`, `initState`, `dispose`, `toString`, `==`, …),
   which a name-based reference search can miss. Use `--overrides` to include
   them.
+- **Operator overloads** (`operator +`, `operator ==`, …) — the analysis
+  server's reference search does not resolve infix operator syntax (`a + b`)
+  back to the operator's declaration, so a used operator is reported as
+  unused every time. See `example/lib/extensions.dart`. Use `--operators` to
+  include them.
 - **`@pragma('vm:entry-point')`** — reachable from native code / reflection.
 - **Generated files** — by filename convention and the
   `GENERATED CODE - DO NOT MODIFY BY HAND` banner. Use `--generated` to include.
 - **`type parameters`** and non-declaration symbols.
+
+By contrast, **dartdoc `[Xxx]` reference links count as a use** — this
+errs the other way, toward under-reporting: a link resolves to a real
+declaration, so the analysis server treats it as a reference even if nothing
+actually calls the declaration. This can hide genuinely dead code (e.g. `///
+See [Dog.sound]` keeps `Dog.sound` looking used). Pass
+`--ignore-doc-references` to disregard those comment-only references and
+surface declarations like that as unused — at the cost of flagging things
+that are legitimately referenced only from documentation.
 
 ## Limitations
 
@@ -172,14 +194,6 @@ than delete blindly:
   visible to a reference search.
 - **Entry points beyond `main`** (isolate entry points, plugin registrants) may
   need excluding or annotating with `@pragma('vm:entry-point')`.
-- **Operator overloads** (`operator +`, `operator ==`, …) are effectively always
-  reported: the analysis server's reference search does not resolve infix
-  operator syntax (`a + b`) back to the operator's declaration, even though the
-  call is perfectly real. See `example/lib/extensions.dart`.
-- **Dartdoc `[Xxx]` reference links** count as references too, which can hide
-  real dead code: linking to a method that overrides or implements another
-  (e.g. `/// See [Dog.sound]`) can mark the interface member it overrides as
-  "used" as a side effect.
 - Results are only as good as the analysis: a package that does not analyze
   cleanly (missing `pub get`, errors) may yield incomplete references.
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ ciach --remove --force
 | `--[no-]generated` | off | Scan generated files (`*.g.dart`, `*.freezed.dart`, `*.mocks.dart`, …). |
 | `--[no-]overrides` | off | Report `@override` members too. Off by default — see limitations. |
 | `--[no-]operators` | off | Report operator overloads (`operator +`, `operator ==`, …) too. Off by default — see limitations. |
-| `--ignore-doc-references` | off | Don't count dartdoc `[Xxx]` comment links as a use. Off by default — see limitations. |
 | `--set-exit-if-changed` | off | Exit with status `1` when anything is found (for CI). Named after `dart format`. |
 | `--remove` | off | Remove unused declarations after reporting them. Prompts for confirmation first. |
 | `--force` | off | Skip the confirmation prompt for `--remove`. Requires `--remove`. |
@@ -129,6 +128,32 @@ ciach --remove --force
 
 Exit codes: `0` success, `1` unused found with `--set-exit-if-changed`, `2`
 usage or analysis error.
+
+### Doc-only findings
+
+A dartdoc `[Xxx]` comment link resolves to a real declaration, so the
+analysis server counts it as a reference — but "someone linked to this in a
+comment" isn't the same confidence level as "something actually calls this".
+Declarations with no *code* references, only a comment link, are reported
+separately as **doc-only**, in every format:
+
+```
+$ ciach
+lib/greeting.dart
+  15:6  function  danglingFunction  (public)
+
+Referenced only from doc comments — not counted as unused, never removed:
+lib/greeting.dart
+  40:6  function  docOnlyMentioned  (public)
+
+Found 1 unused declaration in 1 file (scanned 6 files, 44 declarations, 0.5s). 1 more referenced only from doc comments.
+```
+
+Doc-only findings are informational: they never count toward
+`--set-exit-if-changed`, are never touched by `--remove`, and get a `::notice`
+(not `::warning`) in `-f github` output. If one really is dead code, remove
+its doc comment link (or the comment itself) and re-run to have it reported
+as properly unused.
 
 ### GitHub Actions
 
@@ -174,9 +199,10 @@ expect the odd extra blank line.
 Because removal acts on whatever the finder reports, it inherits the same
 false-positive risk as the report itself (see [What it skips by
 default](#what-it-skips-by-default) and [Limitations](#limitations) below) —
-enabling `--overrides` or `--operators` widens that risk considerably. Review
-the diff (or your test suite) after removing, the same as you would after any
-automated refactor.
+enabling `--overrides` or `--operators` widens that risk considerably.
+[Doc-only findings](#doc-only-findings) are never included, regardless of
+those flags. Review the diff (or your test suite) after removing, the same as
+you would after any automated refactor.
 
 ## What it skips by default
 
@@ -200,14 +226,12 @@ back in, at the cost of reintroducing that risk:
   `GENERATED CODE - DO NOT MODIFY BY HAND` banner. Use `--generated` to include.
 - **`type parameters`** and non-declaration symbols.
 
-By contrast, **dartdoc `[Xxx]` reference links count as a use** — this
-errs the other way, toward under-reporting: a link resolves to a real
-declaration, so the analysis server treats it as a reference even if nothing
-actually calls the declaration. This can hide genuinely dead code (e.g. `///
-See [Dog.sound]` keeps `Dog.sound` looking used). Pass
-`--ignore-doc-references` to disregard those comment-only references and
-surface declarations like that as unused — at the cost of flagging things
-that are legitimately referenced only from documentation.
+**dartdoc `[Xxx]` reference links** are a related wrinkle, handled a bit
+differently: a link resolves to a real declaration, so the analysis server
+counts it as a reference, which would otherwise hide genuinely dead code
+(e.g. `/// See [Dog.sound]` would keep `Dog.sound` looking used). Rather than
+a flag, these get their own always-on category — see [Doc-only
+findings](#doc-only-findings).
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ dart run ciach --no-public -f json
 
 # GitHub Actions annotations; fail the job if anything is found
 dart run ciach -f github --set-exit-if-changed
+
+# Remove what's found, after confirming
+dart run ciach --remove
+
+# Remove without asking (e.g. from a script)
+dart run ciach --force
 ```
 
 Install it globally with `dart pub global activate --source path .` and then run
@@ -84,6 +90,8 @@ Install it globally with `dart pub global activate --source path .` and then run
 | `--[no-]generated` | off | Scan generated files (`*.g.dart`, `*.freezed.dart`, `*.mocks.dart`, …). |
 | `--[no-]overrides` | off | Report `@override` members too. Off by default — see limitations. |
 | `--set-exit-if-changed` | off | Exit with status `1` when anything is found (for CI). Named after `dart format`. |
+| `--remove` | off | Remove unused declarations after reporting them. Prompts for confirmation first. |
+| `--force` | off | Remove without asking. Implies `--remove`. |
 | `-e, --exclude <glob>` | — | Skip files matching the glob (repeatable). |
 | `-i, --include <glob>` | — | Only scan files matching the glob (repeatable). |
 | `-k, --kinds <list>` | all | Restrict to kinds: `class, mixin, interface, enum, extension, function, method, constructor, field, property, getter, setter, variable, constant, enum-value, operator`. |
@@ -106,6 +114,37 @@ Each finding becomes a `::warning` annotation shown inline on the PR diff. Run
 it from the repository root so annotation paths resolve; when scanning a
 sub-package (e.g. `ciach -f github app`), the scan path is
 prepended automatically so annotations still point at the right files.
+
+### Removing declarations
+
+`--remove` deletes every reported declaration from source — its doc comment
+and annotations included — after showing what it's about to remove and asking
+for confirmation:
+
+```
+$ dart run ciach --remove
+lib/greeting.dart
+  15:6  function  danglingFunction  (public)
+...
+Found 4 unused declarations in 2 files (scanned 6 files, 44 declarations, 0.5s).
+Remove 4 unused declarations? [y/N] y
+Removed 4 unused declarations from 2 files.
+```
+
+`--force` skips the prompt (implies `--remove`); use it in a script once
+you're confident in the results. Without a terminal to confirm on (e.g. piped
+into another program) and without `--force`, nothing is removed.
+
+Run `dart format` afterward — removal is conservative about *what* to delete
+(it leaves ambiguous multi-variable statements like `int a = 1, b = 2;`
+alone unless every declarator in them is unused) but not about spacing, so
+expect the odd extra blank line.
+
+Because removal acts on whatever the finder reports, it inherits the same
+false positives described in [Limitations](#limitations) below — most
+notably operator overloads and `@override` targets — so review the diff (or
+your test suite) after removing, the same as you would after any automated
+refactor.
 
 ## What it skips by default
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ dart run ciach -f github --set-exit-if-changed
 dart run ciach --remove
 
 # Remove without asking (e.g. from a script)
-dart run ciach --force
+dart run ciach --remove --force
 ```
 
 Install it globally with `dart pub global activate --source path .` and then run
@@ -91,7 +91,7 @@ Install it globally with `dart pub global activate --source path .` and then run
 | `--[no-]overrides` | off | Report `@override` members too. Off by default — see limitations. |
 | `--set-exit-if-changed` | off | Exit with status `1` when anything is found (for CI). Named after `dart format`. |
 | `--remove` | off | Remove unused declarations after reporting them. Prompts for confirmation first. |
-| `--force` | off | Remove without asking. Implies `--remove`. |
+| `--force` | off | Skip the confirmation prompt for `--remove`. Requires `--remove`. |
 | `-e, --exclude <glob>` | — | Skip files matching the glob (repeatable). |
 | `-i, --include <glob>` | — | Only scan files matching the glob (repeatable). |
 | `-k, --kinds <list>` | all | Restrict to kinds: `class, mixin, interface, enum, extension, function, method, constructor, field, property, getter, setter, variable, constant, enum-value, operator`. |
@@ -131,9 +131,10 @@ Remove 4 unused declarations? [y/N] y
 Removed 4 unused declarations from 2 files.
 ```
 
-`--force` skips the prompt (implies `--remove`); use it in a script once
-you're confident in the results. Without a terminal to confirm on (e.g. piped
-into another program) and without `--force`, nothing is removed.
+`--remove --force` skips the prompt; use it in a script once you're confident
+in the results (`--force` on its own, without `--remove`, is a usage error).
+Without a terminal to confirm on (e.g. piped into another program) and
+without `--force`, nothing is removed.
 
 Run `dart format` afterward — removal is conservative about *what* to delete
 (it leaves ambiguous multi-variable statements like `int a = 1, b = 2;`

--- a/README.md
+++ b/README.md
@@ -56,30 +56,54 @@ Because the whole package is analyzed, references from anywhere — including te
 files — count as usage, so the tool won't flag production code that is only used
 by tests.
 
+## Installation
+
+There are two ways to get the `ciach` command, depending on how you want to
+run it:
+
+- **Global activation** — a single `ciach` command available everywhere,
+  independent of any particular project:
+
+  ```bash
+  dart pub global activate ciach
+  ciach
+  ```
+
+  This puts `ciach` in `~/.pub-cache/bin`; add that to your `PATH` if
+  `dart pub global activate` warns that it isn't there already.
+
+- **As a dev dependency** — pinned per-project, so everyone on the team (and
+  CI) uses the same version:
+
+  ```bash
+  dart pub add --dev ciach
+  dart run ciach
+  ```
+
+The rest of this README shows bare `ciach …` commands; prefix them with
+`dart run` if you installed it as a dev dependency instead of globally.
+
 ## Usage
 
 ```bash
 # Scan the current package
-dart run ciach
+ciach
 
 # Scan a specific package
-dart run ciach path/to/package
+ciach path/to/package
 
 # Only the highest-confidence dead code (private, never-referenced), as JSON
-dart run ciach --no-public -f json
+ciach --no-public -f json
 
 # GitHub Actions annotations; fail the job if anything is found
-dart run ciach -f github --set-exit-if-changed
+ciach -f github --set-exit-if-changed
 
 # Remove what's found, after confirming
-dart run ciach --remove
+ciach --remove
 
 # Remove without asking (e.g. from a script)
-dart run ciach --remove --force
+ciach --remove --force
 ```
-
-Install it globally with `dart pub global activate --source path .` and then run
-`ciach` directly.
 
 ### Options
 
@@ -108,7 +132,11 @@ usage or analysis error.
 
 ### GitHub Actions
 
+Add `ciach` as a dev dependency (see [Installation](#installation)) so the
+version is pinned and `dart pub get` is all the setup CI needs:
+
 ```yaml
+- run: dart pub get
 - run: dart run ciach -f github --set-exit-if-changed
 ```
 
@@ -124,7 +152,7 @@ and annotations included — after showing what it's about to remove and asking
 for confirmation:
 
 ```
-$ dart run ciach --remove
+$ ciach --remove
 lib/greeting.dart
   15:6  function  danglingFunction  (public)
 ...
@@ -221,8 +249,8 @@ The biggest lever is **how much you ask**:
   diminishing returns for the analysis server's internal parallelism.
 
 For repeated runs, compile once to skip the JIT warmup:
-`dart compile exe bin/ciach.dart -o ciach` (or
-`dart pub global activate --source path .`).
+`dart compile exe bin/ciach.dart -o ciach` — `dart pub global activate` already
+does this for you.
 
 ## Library usage
 

--- a/bin/ciach.dart
+++ b/bin/ciach.dart
@@ -74,6 +74,11 @@ Future<int> _run(List<String> arguments) async {
     return 2;
   }
 
+  if (args.flag('force') && !args.flag('remove')) {
+    stderr.writeln('--force requires --remove.');
+    return 2;
+  }
+
   final Set<SymbolKind> kinds;
   try {
     kinds = _parseKinds(args.multiOption('kinds'));
@@ -150,7 +155,7 @@ Future<int> _run(List<String> arguments) async {
       stdout.writeln(Reporter.text(result, useColor: useColor));
   }
 
-  if (result.unused.isNotEmpty && (args.flag('remove') || args.flag('force'))) {
+  if (result.unused.isNotEmpty && args.flag('remove')) {
     await _removeUnused(result, rootDir.absolute.path, args, format, useColor);
   }
 
@@ -270,9 +275,7 @@ ArgParser _buildParser() {
     )
     ..addFlag(
       'force',
-      help:
-          'Remove unused declarations without asking for confirmation.\n'
-          'Implies --remove.',
+      help: 'Skip the confirmation prompt for --remove. Requires --remove.',
     )
     ..addMultiOption(
       'exclude',
@@ -357,7 +360,7 @@ Examples:
   ciach --remove
 
   # Remove without asking (e.g. in a script)
-  ciach --force''';
+  ciach --remove --force''';
 
 /// Prints single-line, overwriting progress to stderr.
 class _ProgressPrinter {

--- a/bin/ciach.dart
+++ b/bin/ciach.dart
@@ -32,7 +32,6 @@ const _kindAliases = <String, SymbolKind>{
   'variable': .variable,
   'constant': .constant,
   'enum-value': .enumMember,
-  'operator': .operator$,
 };
 
 Future<void> main(List<String> arguments) async {
@@ -117,6 +116,8 @@ Future<int> _run(List<String> arguments) async {
     includePublic: args.flag('public'),
     includeGenerated: args.flag('generated'),
     skipOverrides: !args.flag('overrides'),
+    skipOperators: !args.flag('operators'),
+    ignoreDocReferences: args.flag('ignore-doc-references'),
     concurrency: concurrency,
     dartExecutable: args.option('dart'),
     onProgress: showProgress ? _ProgressPrinter().update : null,
@@ -260,6 +261,22 @@ ArgParser _buildParser() {
           'Report members annotated with @override too. Off by default,\n'
           'since overrides are often reached polymorphically and a plain\n'
           'reference search can miss those uses.',
+    )
+    ..addFlag(
+      'operators',
+      help:
+          'Report operator overloads (operator +, operator ==, …) too. Off\n'
+          'by default: the analysis server never resolves infix operator\n'
+          "syntax (a + b) back to the operator's declaration, so a used\n"
+          'operator is reported as unused every time.',
+    )
+    ..addFlag(
+      'ignore-doc-references',
+      help:
+          "Don't count dartdoc [Xxx] comment links as a use. Off by\n"
+          'default: such a link resolves to a real declaration, so\n'
+          'treating it as unused risks flagging something that really is\n'
+          'referenced, just only from documentation.',
     )
     ..addFlag(
       'set-exit-if-changed',

--- a/bin/ciach.dart
+++ b/bin/ciach.dart
@@ -117,7 +117,6 @@ Future<int> _run(List<String> arguments) async {
     includeGenerated: args.flag('generated'),
     skipOverrides: !args.flag('overrides'),
     skipOperators: !args.flag('operators'),
-    ignoreDocReferences: args.flag('ignore-doc-references'),
     concurrency: concurrency,
     dartExecutable: args.option('dart'),
     onProgress: showProgress ? _ProgressPrinter().update : null,
@@ -269,14 +268,6 @@ ArgParser _buildParser() {
           'by default: the analysis server never resolves infix operator\n'
           "syntax (a + b) back to the operator's declaration, so a used\n"
           'operator is reported as unused every time.',
-    )
-    ..addFlag(
-      'ignore-doc-references',
-      help:
-          "Don't count dartdoc [Xxx] comment links as a use. Off by\n"
-          'default: such a link resolves to a real declaration, so\n'
-          'treating it as unused risks flagging something that really is\n'
-          'referenced, just only from documentation.',
     )
     ..addFlag(
       'set-exit-if-changed',

--- a/bin/ciach.dart
+++ b/bin/ciach.dart
@@ -150,10 +150,58 @@ Future<int> _run(List<String> arguments) async {
       stdout.writeln(Reporter.text(result, useColor: useColor));
   }
 
+  if (result.unused.isNotEmpty && (args.flag('remove') || args.flag('force'))) {
+    await _removeUnused(result, rootDir.absolute.path, args, format, useColor);
+  }
+
   if (result.unused.isNotEmpty && args.flag('set-exit-if-changed')) {
     return 1;
   }
   return 0;
+}
+
+/// Reports what would be removed, confirms unless [ArgResults.flag]
+/// `'force'` is set, and deletes the unused declarations from disk.
+Future<void> _removeUnused(
+  FinderResult result,
+  String rootPath,
+  ArgResults args,
+  String format,
+  bool useColor,
+) async {
+  final count = result.unused.length;
+  final plural = count == 1 ? '' : 's';
+
+  var proceed = args.flag('force');
+  if (!proceed) {
+    // The chosen --format may not be human-readable; show the findings
+    // again so the confirmation prompt is never a shot in the dark.
+    if (format != 'text') {
+      stderr.writeln(Reporter.text(result, useColor: useColor));
+    }
+    if (!stdin.hasTerminal) {
+      stdout.writeln(
+        'Refusing to remove declarations without a terminal to confirm on; '
+        'pass --force to remove without asking.',
+      );
+      return;
+    }
+    stdout.write('Remove $count unused declaration$plural? [y/N] ');
+    final answer = stdin.readLineSync()?.trim().toLowerCase();
+    proceed = answer == 'y' || answer == 'yes';
+  }
+
+  if (!proceed) {
+    stdout.writeln('Skipped removal.');
+    return;
+  }
+
+  final filesChanged = removeDeclarations(result.unused, rootPath);
+  stdout.writeln(
+    'Removed $count unused declaration$plural from $filesChanged '
+    'file${filesChanged == 1 ? '' : 's'}. '
+    "Run 'dart format' to tidy up spacing.",
+  );
 }
 
 Set<SymbolKind> _parseKinds(List<String> raw) {
@@ -213,6 +261,18 @@ ArgParser _buildParser() {
       help:
           'Exit with a non-zero status when any unused declaration is found\n'
           '(useful in CI).',
+    )
+    ..addFlag(
+      'remove',
+      help:
+          'Remove unused declarations from source after reporting them.\n'
+          'Prompts for confirmation first, unless --force is also given.',
+    )
+    ..addFlag(
+      'force',
+      help:
+          'Remove unused declarations without asking for confirmation.\n'
+          'Implies --remove.',
     )
     ..addMultiOption(
       'exclude',
@@ -291,7 +351,13 @@ Examples:
   ciach --no-public -e 'test/**' -f json lib/
 
   # GitHub Actions annotations, fail the job if anything is found
-  ciach -f github --set-exit-if-changed''';
+  ciach -f github --set-exit-if-changed
+
+  # Remove what's found, after confirming
+  ciach --remove
+
+  # Remove without asking (e.g. in a script)
+  ciach --force''';
 
 /// Prints single-line, overwriting progress to stderr.
 class _ProgressPrinter {

--- a/example/lib/greeting.dart
+++ b/example/lib/greeting.dart
@@ -34,7 +34,8 @@ int staleCounter = 0;
 /// ever gets.
 void _referencesOnlyInDocs() {}
 
-/// Never called from real code, only named by the link above -> that link
-/// counts as a reference, so this looks USED by default even though nothing
-/// calls it. Pass --ignore-doc-references to have it reported as UNUSED too.
+/// Never called from real code, only named by the link above -> DOC-ONLY,
+/// not UNUSED: the link counts as a reference, so a plain reference search
+/// can't tell this apart from something genuinely called. Reported
+/// separately, and never touched by --remove.
 void _docOnlyMentioned() {}

--- a/example/lib/greeting.dart
+++ b/example/lib/greeting.dart
@@ -28,3 +28,13 @@ int visitCount = 0;
 
 /// Never referenced anywhere -> UNUSED (mutable top-level variable).
 int staleCounter = 0;
+
+/// Never called from real code -> UNUSED (private function). Its own doc
+/// comment link to [_docOnlyMentioned] is the only "reference" that function
+/// ever gets.
+void _referencesOnlyInDocs() {}
+
+/// Never called from real code, only named by the link above -> that link
+/// counts as a reference, so this looks USED by default even though nothing
+/// calls it. Pass --ignore-doc-references to have it reported as UNUSED too.
+void _docOnlyMentioned() {}

--- a/lib/ciach.dart
+++ b/lib/ciach.dart
@@ -29,4 +29,10 @@ export 'package:pro_lsp/pro_lsp.dart' show SymbolKind;
 
 export 'src/finder.dart' show Ciach;
 export 'src/models.dart'
-    show FinderOptions, FinderResult, SymbolKindLabel, UnusedDeclaration;
+    show
+        DeclarationRange,
+        FinderOptions,
+        FinderResult,
+        SymbolKindLabel,
+        UnusedDeclaration;
+export 'src/remover.dart' show removeDeclarations;

--- a/lib/src/finder.dart
+++ b/lib/src/finder.dart
@@ -24,6 +24,7 @@ typedef _Candidate = ({
   String path,
   DocumentSymbol symbol,
   String? container,
+  bool isEnumValue,
 });
 
 /// Finds declarations that are never referenced by driving the Dart analysis
@@ -164,23 +165,34 @@ class Ciach {
     final symbols = await client.documentSymbol(uri);
     final lines = content.split('\n');
     final out = <_Candidate>[];
-    _collectCandidates(uri, path, symbols, null, lines, out);
+    _collectCandidates(uri, path, symbols, null, false, lines, out);
     return out;
   }
 
   /// Recursively walks the symbol tree, keeping only symbols worth checking,
   /// and records the enclosing type name as their container.
+  ///
+  /// [parentIsEnum] marks children of an enum declaration: the analysis
+  /// server reports enum values with the same [SymbolKind.enum$] kind as the
+  /// enum type itself, so this is the only way to tell them apart.
   void _collectCandidates(
     Uri uri,
     String path,
     List<DocumentSymbol> symbols,
     String? container,
+    bool parentIsEnum,
     List<String> lines,
     List<_Candidate> out,
   ) {
     for (final symbol in symbols) {
       if (_shouldConsider(symbol, lines)) {
-        out.add((uri: uri, path: path, symbol: symbol, container: container));
+        out.add((
+          uri: uri,
+          path: path,
+          symbol: symbol,
+          container: container,
+          isEnumValue: parentIsEnum && symbol.kind == .enum$,
+        ));
       }
       final childContainer = _typeLikeKinds.contains(symbol.kind)
           ? symbol.name
@@ -190,6 +202,7 @@ class Ciach {
         path,
         symbol.children ?? const [],
         childContainer,
+        symbol.kind == .enum$,
         lines,
         out,
       );
@@ -233,6 +246,13 @@ class Ciach {
       column: start.character + 1,
       isPrivate: _isPrivateName(name),
       container: candidate.container,
+      isEnumValue: candidate.isEnumValue,
+      range: (
+        startLine: symbol.range.start.line,
+        startColumn: symbol.range.start.character,
+        endLine: symbol.range.end.line,
+        endColumn: symbol.range.end.character,
+      ),
     );
   }
 

--- a/lib/src/finder.dart
+++ b/lib/src/finder.dart
@@ -15,7 +15,7 @@ import 'package:ciach/src/file_discovery.dart';
 import 'package:ciach/src/lsp/lsp_client.dart';
 import 'package:ciach/src/models.dart';
 import 'package:path/path.dart' as p;
-import 'package:pro_lsp/pro_lsp.dart' show DocumentSymbol, SymbolKind;
+import 'package:pro_lsp/pro_lsp.dart' show DocumentSymbol, Location, SymbolKind;
 
 /// A declaration to check: the symbol plus enough context to query references
 /// for it and to report it later.
@@ -48,6 +48,55 @@ class Ciach {
     .enum$,
     .struct,
   };
+
+  /// Names of Dart's overloadable operators. The analysis server reports an
+  /// `operator +`/`operator ==`/… declaration as a plain [SymbolKind.method]
+  /// named exactly one of these — there is no distinct operator symbol kind —
+  /// so this is the only reliable way to recognize one.
+  static const _operatorNames = <String>{
+    '+',
+    '-',
+    '*',
+    '/',
+    '%',
+    '~/',
+    '&',
+    '|',
+    '^',
+    '~',
+    '<<',
+    '>>',
+    '>>>',
+    '<',
+    '<=',
+    '>',
+    '>=',
+    '==',
+    '[]',
+    '[]=',
+  };
+
+  bool _isOperator(DocumentSymbol symbol) =>
+      symbol.kind == .method && _operatorNames.contains(symbol.name);
+
+  /// Lines of every scanned file, keyed by absolute path, populated as each
+  /// file is opened in [_collectCandidatesFor]. Reused to classify reference
+  /// locations as doc comments without re-reading files from disk.
+  final _fileLines = <String, List<String>>{};
+
+  /// Whether [location] points at a dartdoc `[Xxx]`-style reference rather
+  /// than real code — i.e. its line, in the file it points into, starts with
+  /// `///`. Block (`/** */`) doc comments aren't recognized; `///` is the
+  /// standard and lint-enforced style.
+  bool _isDocReference(Location location) {
+    final path = Uri.parse(location.uri).toFilePath();
+    final lines = _fileLines[path] ??= _readFile(path)?.split('\n') ?? const [];
+    final line = location.range.start.line;
+    if (line < 0 || line >= lines.length) {
+      return false;
+    }
+    return lines[line].trim().startsWith('///');
+  }
 
   void _report(String message) => options.onProgress?.call(message);
 
@@ -128,7 +177,10 @@ class Ciach {
               '${p.relative(candidate.path, from: rootPath)}',
             );
           }
-          return refs.isEmpty;
+          final realRefs = options.ignoreDocReferences
+              ? refs.where((loc) => !_isDocReference(loc))
+              : refs;
+          return realRefs.isEmpty;
         },
       );
 
@@ -164,6 +216,7 @@ class Ciach {
     client.didOpen(uri, content);
     final symbols = await client.documentSymbol(uri);
     final lines = content.split('\n');
+    _fileLines[path] = lines;
     final out = <_Candidate>[];
     _collectCandidates(uri, path, symbols, null, false, lines, out);
     return out;
@@ -219,6 +272,9 @@ class Ciach {
     }
     final private = _isPrivateName(symbol.name);
     if (!private && !options.includePublic) {
+      return false;
+    }
+    if (options.skipOperators && _isOperator(symbol)) {
       return false;
     }
 

--- a/lib/src/finder.dart
+++ b/lib/src/finder.dart
@@ -27,6 +27,18 @@ typedef _Candidate = ({
   bool isEnumValue,
 });
 
+/// How a candidate's references classify it.
+enum _RefStatus {
+  /// At least one real (non-doc-comment) reference.
+  used,
+
+  /// No real references, but at least one dartdoc `[Xxx]` comment link.
+  docOnly,
+
+  /// No references of any kind.
+  unused,
+}
+
 /// Finds declarations that are never referenced by driving the Dart analysis
 /// server over LSP.
 ///
@@ -111,6 +123,7 @@ class Ciach {
     if (files.isEmpty) {
       return .new(
         unused: const [],
+        docOnly: const [],
         filesScanned: 0,
         declarationsChecked: 0,
         elapsed: stopwatch.elapsed,
@@ -123,6 +136,7 @@ class Ciach {
     );
 
     final unused = <UnusedDeclaration>[];
+    final docOnly = <UnusedDeclaration>[];
     var declarationsChecked = 0;
 
     try {
@@ -160,7 +174,7 @@ class Ciach {
       final totalFiles = files.length;
       var filesDone = totalFiles - remainingPerFile.length;
 
-      final isUnused = await _mapPooled<_Candidate, bool>(
+      final statuses = await _mapPooled<_Candidate, _RefStatus>(
         candidates,
         options.concurrency,
         (candidate) async {
@@ -177,16 +191,22 @@ class Ciach {
               '${p.relative(candidate.path, from: rootPath)}',
             );
           }
-          final realRefs = options.ignoreDocReferences
-              ? refs.where((loc) => !_isDocReference(loc))
-              : refs;
-          return realRefs.isEmpty;
+          if (refs.isEmpty) {
+            return _RefStatus.unused;
+          }
+          final hasRealRef = refs.any((loc) => !_isDocReference(loc));
+          return hasRealRef ? _RefStatus.used : _RefStatus.docOnly;
         },
       );
 
       for (var i = 0; i < candidates.length; i++) {
-        if (isUnused[i]) {
-          unused.add(_toUnused(candidates[i], rootPath));
+        switch (statuses[i]) {
+          case _RefStatus.unused:
+            unused.add(_toUnused(candidates[i], rootPath));
+          case _RefStatus.docOnly:
+            docOnly.add(_toUnused(candidates[i], rootPath));
+          case _RefStatus.used:
+            break;
         }
       }
     } finally {
@@ -194,9 +214,11 @@ class Ciach {
     }
 
     unused.sort(_byLocation);
+    docOnly.sort(_byLocation);
     stopwatch.stop();
     return .new(
       unused: unused,
+      docOnly: docOnly,
       filesScanned: files.length,
       declarationsChecked: declarationsChecked,
       elapsed: stopwatch.elapsed,

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -34,7 +34,6 @@ class FinderOptions {
     this.includeGenerated = false,
     this.skipOverrides = true,
     this.skipOperators = true,
-    this.ignoreDocReferences = false,
     this.concurrency = 16,
     this.dartExecutable,
     this.onProgress,
@@ -70,15 +69,6 @@ class FinderOptions {
   /// overload is reported as unused every time — on by default to avoid that
   /// false positive.
   final bool skipOperators;
-
-  /// Whether to disregard dartdoc `[Xxx]`-style comment links when deciding
-  /// if a declaration is unused. Off by default: such a link resolves to a
-  /// real declaration, so the analysis server counts it as a reference,
-  /// which can hide dead code (a method only ever mentioned in a `/// See
-  /// Foo.bar` doc comment is not flagged). Enabling this ignores those
-  /// comment-only references — findings are more complete, at the cost of
-  /// flagging declarations that are intentionally documented-but-unused.
-  final bool ignoreDocReferences;
 
   /// How many `textDocument/references` requests to keep in flight at once.
   /// Higher values keep the analysis server busier; there are diminishing
@@ -197,13 +187,24 @@ class FinderResult {
   /// Creates a result describing a completed finder run.
   const FinderResult({
     required this.unused,
+    required this.docOnly,
     required this.filesScanned,
     required this.declarationsChecked,
     required this.elapsed,
   });
 
-  /// Unused declarations, sorted by file then position.
+  /// Declarations with zero references of any kind — the tool's actual
+  /// "unused" verdict. Sorted by file then position. These, and only these,
+  /// are eligible for `--remove`.
   final List<UnusedDeclaration> unused;
+
+  /// Declarations with no *code* references, but at least one dartdoc
+  /// `[Xxx]`-style comment link — informational, not a removal candidate.
+  /// A link resolves to a real declaration, so the analysis server counts it
+  /// as a reference; reporting these separately surfaces likely-dead code
+  /// without risking deletion of something that really is pointed to, just
+  /// only from documentation. Sorted by file then position.
+  final List<UnusedDeclaration> docOnly;
 
   /// Number of files scanned for declarations.
   final int filesScanned;

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -10,6 +10,18 @@
 
 import 'package:pro_lsp/pro_lsp.dart' show SymbolKind;
 
+/// A `[start, end)` span within a file, using 0-based line/column positions
+/// (columns are UTF-16 code units), matching the Language Server Protocol.
+///
+/// Identifies the full extent of a declaration — including its body — so it
+/// can be located again for removal.
+typedef DeclarationRange = ({
+  int startLine,
+  int startColumn,
+  int endLine,
+  int endColumn,
+});
+
 /// Configuration for a single run of the finder.
 class FinderOptions {
   /// Creates options for analyzing the package rooted at [rootPath].
@@ -107,7 +119,9 @@ class UnusedDeclaration {
     required this.line,
     required this.column,
     required this.isPrivate,
+    required this.range,
     this.container,
+    this.isEnumValue = false,
   });
 
   /// Simple (unqualified) name of the declaration.
@@ -130,6 +144,16 @@ class UnusedDeclaration {
 
   /// Enclosing declaration name (e.g. the class for a method), if any.
   final String? container;
+
+  /// The full source span of the declaration (including its body), used to
+  /// locate it again for removal. Unlike [line]/[column] (the name's
+  /// position), this covers the whole node.
+  final DeclarationRange range;
+
+  /// Whether this is an enum value (e.g. `south` in `enum Direction`).
+  /// Removing one requires also tidying up a neighboring comma, unlike other
+  /// declaration kinds.
+  final bool isEnumValue;
 
   /// Fully qualified display name, e.g. `MyClass.myMethod`.
   String get qualifiedName => container == null ? name : '$container.$name';

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -33,6 +33,8 @@ class FinderOptions {
     this.includePublic = true,
     this.includeGenerated = false,
     this.skipOverrides = true,
+    this.skipOperators = true,
+    this.ignoreDocReferences = false,
     this.concurrency = 16,
     this.dartExecutable,
     this.onProgress,
@@ -62,6 +64,22 @@ class FinderOptions {
   /// reached polymorphically, which a plain reference search can miss).
   final bool skipOverrides;
 
+  /// Whether to skip operator overloads (`operator +`, `operator ==`, …).
+  /// The analysis server's reference search does not resolve infix operator
+  /// syntax (`a + b`) back to the operator's declaration, so a used operator
+  /// overload is reported as unused every time — on by default to avoid that
+  /// false positive.
+  final bool skipOperators;
+
+  /// Whether to disregard dartdoc `[Xxx]`-style comment links when deciding
+  /// if a declaration is unused. Off by default: such a link resolves to a
+  /// real declaration, so the analysis server counts it as a reference,
+  /// which can hide dead code (a method only ever mentioned in a `/// See
+  /// Foo.bar` doc comment is not flagged). Enabling this ignores those
+  /// comment-only references — findings are more complete, at the cost of
+  /// flagging declarations that are intentionally documented-but-unused.
+  final bool ignoreDocReferences;
+
   /// How many `textDocument/references` requests to keep in flight at once.
   /// Higher values keep the analysis server busier; there are diminishing
   /// returns past its internal parallelism.
@@ -77,6 +95,10 @@ class FinderOptions {
   /// The declaration kinds reported by default. Deliberately excludes
   /// [SymbolKind.typeParameter] (always "used" within its scope) and the
   /// primitive value kinds the server never emits for Dart declarations.
+  ///
+  /// Operator overloads are *not* a separate kind here: the analysis server
+  /// reports them as plain [SymbolKind.method] declarations named `+`, `==`,
+  /// etc. — see [skipOperators] for how they're excluded by default instead.
   static const defaultKinds = <SymbolKind>{
     .class$,
     .interface$,
@@ -90,7 +112,6 @@ class FinderOptions {
     .variable,
     .constant,
     .enumMember,
-    .operator$,
   };
 }
 

--- a/lib/src/remover.dart
+++ b/lib/src/remover.dart
@@ -1,0 +1,419 @@
+import 'dart:io';
+
+import 'package:ciach/src/models.dart';
+import 'package:path/path.dart' as p;
+import 'package:pro_lsp/pro_lsp.dart' show SymbolKind;
+
+/// Symbol kinds whose [DeclarationRange] covers only the declarator (name and
+/// initializer), not the shared `final`/`const`/type prefix or the
+/// terminating `;` — because the analysis server reports a variable's range
+/// as the `VariableDeclaration`, not the whole
+/// `VariableDeclarationList`/`FieldDeclaration` statement it lives in.
+const _declaratorKinds = <SymbolKind>{.field, .variable, .constant};
+
+/// A `[start, end)` character-offset span within a file's content.
+typedef _Span = ({int start, int end});
+
+/// Deletes [declarations] from the files under [rootPath], rewriting each
+/// affected file in a single pass.
+///
+/// Declarations whose range is fully contained within another declaration's
+/// range (e.g. a method of a class that is itself unused) are removed once,
+/// as part of removing the enclosing declaration. A declarator that shares a
+/// statement with other, still-used declarators (e.g. `int a = 1, b = 2;`) is
+/// only removed on its own when that can be done unambiguously; otherwise it
+/// is left in place rather than risk producing invalid source.
+///
+/// Returns the number of files that were actually modified.
+int removeDeclarations(List<UnusedDeclaration> declarations, String rootPath) {
+  final byFile = <String, List<UnusedDeclaration>>{};
+  for (final decl in declarations) {
+    byFile.putIfAbsent(decl.filePath, () => []).add(decl);
+  }
+
+  var filesChanged = 0;
+  for (final entry in byFile.entries) {
+    final file = File(p.joinAll([rootPath, ...p.posix.split(entry.key)]));
+    final content = file.readAsStringSync();
+    final updated = _removeFromContent(content, entry.value);
+    if (updated != content) {
+      file.writeAsStringSync(updated);
+      filesChanged++;
+    }
+  }
+  return filesChanged;
+}
+
+String _removeFromContent(String content, List<UnusedDeclaration> decls) {
+  final lines = content.split('\n');
+  final lineStarts = List<int>.filled(lines.length, 0);
+  for (var i = 1; i < lines.length; i++) {
+    lineStarts[i] = lineStarts[i - 1] + lines[i - 1].length + 1;
+  }
+  int offsetOf(int line, int column) => lineStarts[line] + column;
+
+  final declarators = <UnusedDeclaration>[];
+  final spans = <_Span>[];
+  for (final decl in decls) {
+    if (_declaratorKinds.contains(decl.kind)) {
+      declarators.add(decl);
+    } else {
+      final span = _spanFor(decl, content, lines, offsetOf);
+      if (span != null) {
+        spans.add(span);
+      }
+    }
+  }
+  spans.addAll(_declaratorSpans(declarators, content, lines, offsetOf));
+
+  if (spans.isEmpty) {
+    return content;
+  }
+
+  final buffer = StringBuffer();
+  var cursor = 0;
+  for (final span in _mergeSpans(spans)) {
+    buffer.write(content.substring(cursor, span.start));
+    cursor = span.end;
+  }
+  buffer.write(content.substring(cursor));
+  return buffer.toString();
+}
+
+/// Computes the span to delete for an enum value or a "whole-node" kind
+/// (class, function, method, property, …) whose [DeclarationRange] already
+/// covers the full declaration.
+_Span? _spanFor(
+  UnusedDeclaration decl,
+  String content,
+  List<String> lines,
+  int Function(int line, int column) offsetOf,
+) {
+  final range = decl.range;
+  final baseStart = offsetOf(range.startLine, range.startColumn);
+  final baseEnd = offsetOf(range.endLine, range.endColumn);
+  final topLine = _extendedTopLine(range.startLine, lines);
+
+  var start = baseStart;
+  var end = baseEnd;
+
+  if (decl.isEnumValue) {
+    (start, end) = _extendEnumValue(
+      content,
+      commentStart: offsetOf(topLine, 0),
+      baseStart: baseStart,
+      baseEnd: baseEnd,
+    );
+  } else {
+    start = topLine < range.startLine ? offsetOf(topLine, 0) : baseStart;
+    // A whole-node range that shares its line with other content (unusual,
+    // but possible) is left alone rather than risk eating it; otherwise its
+    // leading indentation is safe to take too.
+    if (start == baseStart) {
+      final prefix = lines[range.startLine].substring(0, range.startColumn);
+      if (prefix.trim().isEmpty) {
+        start = offsetOf(range.startLine, 0);
+      }
+    }
+    // Some whole-node kinds (bodyless constructors, arrow-bodied members)
+    // don't include their terminating `;` in the range.
+    if (end < content.length && content[end] == ';') {
+      end++;
+    }
+  }
+
+  return (start: start, end: _consumeTrailingBlankLine(content, end));
+}
+
+/// Computes the spans to delete for `field`/`variable`/`constant` decls,
+/// which share a statement — and possibly a `final`/`const`/type prefix —
+/// with any number of sibling declarators.
+///
+/// Declarators are grouped by the statement's terminating `;`. When every
+/// declarator in a statement is present in [decls], the whole statement
+/// (prefix, every declarator, and the `;`) is removed as one span; otherwise
+/// each targeted declarator is trimmed out of the list individually.
+List<_Span> _declaratorSpans(
+  List<UnusedDeclaration> decls,
+  String content,
+  List<String> lines,
+  int Function(int line, int column) offsetOf,
+) {
+  final groups = <int, List<UnusedDeclaration>>{};
+  for (final decl in decls) {
+    final baseEnd = offsetOf(decl.range.endLine, decl.range.endColumn);
+    final statementEnd = _finalStatementEnd(content, baseEnd);
+    if (statementEnd == null) {
+      // Can't even find where the statement ends; leave it alone.
+      continue;
+    }
+    groups.putIfAbsent(statementEnd, () => []).add(decl);
+  }
+
+  int startOf(UnusedDeclaration d) =>
+      offsetOf(d.range.startLine, d.range.startColumn);
+
+  final spans = <_Span>[];
+  for (final entry in groups.entries) {
+    final members = entry.value
+      ..sort((a, b) => startOf(a).compareTo(startOf(b)));
+    final whole = _wholeStatementSpan(
+      content,
+      lines,
+      members,
+      entry.key,
+      offsetOf,
+    );
+    if (whole != null) {
+      spans.add(whole);
+      continue;
+    }
+    for (final decl in members) {
+      final span = _partialDeclaratorSpan(decl, content, offsetOf);
+      if (span != null) {
+        spans.add(span);
+      }
+    }
+  }
+  return spans;
+}
+
+/// Whether every declarator of the statement ending at [statementEnd] is
+/// present in [sortedMembers] (sorted by source position) — verified by
+/// checking that nothing but a bare `,` separates consecutive members, that
+/// nothing but whitespace follows the last one up to [statementEnd], and
+/// that no earlier declarator precedes the first one on its line.
+///
+/// The last check assumes the statement's type/modifier prefix and its first
+/// declarator share a line — true for any `dart format`-formatted source.
+_Span? _wholeStatementSpan(
+  String content,
+  List<String> lines,
+  List<UnusedDeclaration> sortedMembers,
+  int statementEnd,
+  int Function(int line, int column) offsetOf,
+) {
+  final first = sortedMembers.first;
+  final lineStart = offsetOf(first.range.startLine, 0);
+  final firstStart = offsetOf(first.range.startLine, first.range.startColumn);
+  if (_lastTopLevelComma(content.substring(lineStart, firstStart)) != null) {
+    return null;
+  }
+
+  for (var i = 0; i < sortedMembers.length - 1; i++) {
+    final end = offsetOf(
+      sortedMembers[i].range.endLine,
+      sortedMembers[i].range.endColumn,
+    );
+    final nextStart = offsetOf(
+      sortedMembers[i + 1].range.startLine,
+      sortedMembers[i + 1].range.startColumn,
+    );
+    if (content.substring(end, nextStart).trim() != ',') {
+      return null;
+    }
+  }
+
+  final last = sortedMembers.last;
+  final lastEnd = offsetOf(last.range.endLine, last.range.endColumn);
+  if (content.substring(lastEnd, statementEnd).trim().isNotEmpty) {
+    return null;
+  }
+
+  final topLine = _extendedTopLine(first.range.startLine, lines);
+  return (
+    start: offsetOf(topLine, 0),
+    end: _consumeTrailingBlankLine(content, statementEnd + 1),
+  );
+}
+
+/// Trims a single declarator out of a statement that has other declarators
+/// left over, by dropping one neighboring comma. Returns `null` if the
+/// statement's shape can't be confidently resolved.
+_Span? _partialDeclaratorSpan(
+  UnusedDeclaration decl,
+  String content,
+  int Function(int line, int column) offsetOf,
+) {
+  final range = decl.range;
+  final lineStart = offsetOf(range.startLine, 0);
+  final baseStart = offsetOf(range.startLine, range.startColumn);
+  final baseEnd = offsetOf(range.endLine, range.endColumn);
+
+  final beforeText = content.substring(lineStart, baseStart);
+  final leadingComma = _lastTopLevelComma(beforeText);
+  final separator = _nextTopLevelSeparator(content, baseEnd);
+  if (separator == null) {
+    return null;
+  }
+
+  if (separator.$2 == ',') {
+    final start = leadingComma == null
+        ? baseStart
+        : lineStart + leadingComma + 1;
+    return (start: start, end: separator.$1 + 1);
+  }
+  if (leadingComma == null) {
+    // Unreachable in practice: a sole declarator is always caught by
+    // `_wholeStatementSpan` first. Handled anyway for robustness.
+    return (start: lineStart, end: separator.$1 + 1);
+  }
+  // The last of several declarators: drop the now-orphaned leading comma,
+  // but leave the `;` in place — it still terminates the statement.
+  return (start: lineStart + leadingComma, end: baseEnd);
+}
+
+/// Extends [startLine] upward over contiguous doc-comment/annotation lines
+/// (stopping at the first blank line), so a declaration's leading metadata is
+/// removed along with it.
+int _extendedTopLine(int startLine, List<String> lines) {
+  var topLine = startLine;
+  while (topLine - 1 >= 0) {
+    final trimmed = lines[topLine - 1].trim();
+    if (trimmed.isEmpty || !_looksLikeMetadata(trimmed)) {
+      break;
+    }
+    topLine--;
+  }
+  return topLine;
+}
+
+bool _looksLikeMetadata(String trimmedLine) =>
+    trimmedLine.startsWith('@') ||
+    trimmedLine.startsWith('//') ||
+    trimmedLine.startsWith('/*') ||
+    trimmedLine.startsWith('*') ||
+    trimmedLine.endsWith('*/');
+
+/// Enum values are comma-separated, not self-terminating: dropping one
+/// without also dropping a neighboring comma leaves invalid syntax. Prefers
+/// consuming a trailing comma (keeps the shape for the common
+/// trailing-comma style); falls back to the leading comma for the last value
+/// in a list without one.
+(int, int) _extendEnumValue(
+  String content, {
+  required int commentStart,
+  required int baseStart,
+  required int baseEnd,
+}) {
+  final forward = _nextNonWhitespace(content, baseEnd);
+  if (forward != null && content[forward] == ',') {
+    return (commentStart, forward + 1);
+  }
+  final backward = _previousNonWhitespace(content, commentStart);
+  if (backward != null && content[backward] == ',') {
+    return (backward, baseEnd);
+  }
+  return (commentStart, baseEnd);
+}
+
+/// Walks forward from [from] through zero or more top-level `,` separators,
+/// returning the index of the statement's terminating top-level `;`, or
+/// `null` if one can't be found unambiguously.
+int? _finalStatementEnd(String content, int from) {
+  var pos = from;
+  while (true) {
+    final separator = _nextTopLevelSeparator(content, pos);
+    if (separator == null) {
+      return null;
+    }
+    if (separator.$2 == ';') {
+      return separator.$1;
+    }
+    pos = separator.$1 + 1;
+  }
+}
+
+/// The index of the last top-level (not nested in `()`, `[]`, `{}`, or `<>`)
+/// comma in [text], or `null` if there isn't one.
+int? _lastTopLevelComma(String text) {
+  var depth = 0;
+  int? last;
+  for (var i = 0; i < text.length; i++) {
+    final ch = text[i];
+    if (ch == '(' || ch == '[' || ch == '{' || ch == '<') {
+      depth++;
+    } else if (ch == ')' || ch == ']' || ch == '}' || ch == '>') {
+      if (depth > 0) {
+        depth--;
+      }
+    } else if (depth == 0 && ch == ',') {
+      last = i;
+    }
+  }
+  return last;
+}
+
+/// Scans forward from [from] for the first top-level `,` or `;`, treating
+/// `(`, `[`, and `{` as nesting (not `<>`: an initializer expression can
+/// legitimately contain a `<` comparison). Returns its index and character,
+/// or `null` if the scan runs off the end unbalanced or unresolved.
+(int, String)? _nextTopLevelSeparator(String content, int from) {
+  var depth = 0;
+  for (var i = from; i < content.length; i++) {
+    final ch = content[i];
+    if (ch == '(' || ch == '[' || ch == '{') {
+      depth++;
+    } else if (ch == ')' || ch == ']' || ch == '}') {
+      if (depth == 0) {
+        return null;
+      }
+      depth--;
+    } else if (depth == 0 && (ch == ',' || ch == ';')) {
+      return (i, ch);
+    }
+  }
+  return null;
+}
+
+/// If nothing but whitespace follows [end] on its line, extends it past the
+/// line break — so deleting a declaration doesn't leave a blank line behind.
+int _consumeTrailingBlankLine(String content, int end) {
+  final nextNewline = content.indexOf('\n', end);
+  final restOfLine = content.substring(
+    end,
+    nextNewline == -1 ? content.length : nextNewline,
+  );
+  if (restOfLine.trim().isNotEmpty) {
+    return end;
+  }
+  return nextNewline == -1 ? content.length : nextNewline + 1;
+}
+
+int? _nextNonWhitespace(String content, int from) {
+  for (var i = from; i < content.length; i++) {
+    if (!_isWhitespace(content[i])) {
+      return i;
+    }
+  }
+  return null;
+}
+
+int? _previousNonWhitespace(String content, int before) {
+  for (var i = before - 1; i >= 0; i--) {
+    if (!_isWhitespace(content[i])) {
+      return i;
+    }
+  }
+  return null;
+}
+
+bool _isWhitespace(String ch) =>
+    ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r';
+
+List<_Span> _mergeSpans(List<_Span> spans) {
+  final sorted = [...spans]..sort((a, b) => a.start.compareTo(b.start));
+  final merged = <_Span>[];
+  for (final span in sorted) {
+    if (merged.isNotEmpty && span.start <= merged.last.end) {
+      final last = merged.removeLast();
+      merged.add((
+        start: last.start,
+        end: span.end > last.end ? span.end : last.end,
+      ));
+    } else {
+      merged.add(span);
+    }
+  }
+  return merged;
+}

--- a/lib/src/reporter.dart
+++ b/lib/src/reporter.dart
@@ -18,8 +18,32 @@ abstract final class Reporter {
   /// A grouped, aligned, human-readable report.
   static String text(FinderResult result, {bool useColor = false}) {
     final buffer = StringBuffer();
+    _writeGroup(buffer, result.unused, useColor);
+
+    if (result.docOnly.isNotEmpty) {
+      buffer.writeln(
+        _style(
+          'Referenced only from doc comments — not counted as unused, '
+          'never removed:',
+          _dim,
+          useColor,
+        ),
+      );
+      _writeGroup(buffer, result.docOnly, useColor);
+    }
+
+    buffer.write(_summary(result));
+    return buffer.toString();
+  }
+
+  /// Writes one file-grouped, aligned block of [decls] to [buffer].
+  static void _writeGroup(
+    StringBuffer buffer,
+    List<UnusedDeclaration> decls,
+    bool useColor,
+  ) {
     final byFile = <String, List<UnusedDeclaration>>{};
-    for (final decl in result.unused) {
+    for (final decl in decls) {
       byFile.putIfAbsent(decl.filePath, () => []).add(decl);
     }
 
@@ -47,9 +71,6 @@ abstract final class Reporter {
       }
       buffer.writeln();
     }
-
-    buffer.write(_summary(result));
-    return buffer.toString();
   }
 
   /// A machine-readable JSON report.
@@ -60,15 +81,17 @@ abstract final class Reporter {
         'filesScanned': result.filesScanned,
         'declarationsChecked': result.declarationsChecked,
         'unusedCount': result.unused.length,
+        'docOnlyCount': result.docOnly.length,
         'elapsedMs': result.elapsed.inMilliseconds,
       },
       'unused': [for (final decl in result.unused) decl.toJson()],
+      'docOnly': [for (final decl in result.docOnly) decl.toJson()],
     });
   }
 
   /// [GitHub Actions workflow commands][] — one `::warning` annotation per
-  /// finding, so unused declarations surface inline on the PR diff and Checks
-  /// tab.
+  /// unused finding (surfacing them inline on the PR diff and Checks tab) and
+  /// one lower-severity `::notice` per doc-only finding.
   ///
   /// Annotation paths are resolved relative to the repository root. [pathPrefix]
   /// (POSIX, `/`-separated) is prepended to each finding's path so that scans of
@@ -79,22 +102,51 @@ abstract final class Reporter {
   static String github(FinderResult result, {String pathPrefix = '.'}) {
     final buffer = StringBuffer();
     for (final decl in result.unused) {
-      final file = pathPrefix == '.' || pathPrefix.isEmpty
-          ? decl.filePath
-          : p.posix.normalize('$pathPrefix/${decl.filePath}');
-      final visibility = decl.isPrivate ? 'private ' : '';
-      final message =
-          "Unused $visibility${decl.kind.label} '${decl.qualifiedName}'";
-      buffer.writeln(
-        '::warning '
-        'file=${_escapeProperty(file)},'
-        'line=${decl.line},'
-        'col=${decl.column},'
-        'title=Unused declaration'
-        '::${_escapeData(message)}',
+      _writeAnnotation(
+        buffer,
+        decl,
+        pathPrefix,
+        level: 'warning',
+        title: 'Unused declaration',
+        message:
+            "Unused ${decl.isPrivate ? 'private ' : ''}${decl.kind.label} "
+            "'${decl.qualifiedName}'",
+      );
+    }
+    for (final decl in result.docOnly) {
+      _writeAnnotation(
+        buffer,
+        decl,
+        pathPrefix,
+        level: 'notice',
+        title: 'Referenced only from a doc comment',
+        message:
+            "${decl.kind.label} '${decl.qualifiedName}' has no code "
+            'references, only a dartdoc link',
       );
     }
     return buffer.toString();
+  }
+
+  static void _writeAnnotation(
+    StringBuffer buffer,
+    UnusedDeclaration decl,
+    String pathPrefix, {
+    required String level,
+    required String title,
+    required String message,
+  }) {
+    final file = pathPrefix == '.' || pathPrefix.isEmpty
+        ? decl.filePath
+        : p.posix.normalize('$pathPrefix/${decl.filePath}');
+    buffer.writeln(
+      '::$level '
+      'file=${_escapeProperty(file)},'
+      'line=${decl.line},'
+      'col=${decl.column},'
+      'title=${_escapeProperty(title)}'
+      '::${_escapeData(message)}',
+    );
   }
 
   // Escaping per the workflow-command spec.
@@ -110,15 +162,21 @@ abstract final class Reporter {
     final count = result.unused.length;
     final fileCount = result.unused.map((d) => d.filePath).toSet().length;
     final seconds = (result.elapsed.inMilliseconds / 1000).toStringAsFixed(1);
+    final docOnlyCount = result.docOnly.length;
+    final docOnlySuffix = docOnlyCount == 0
+        ? ''
+        : ' $docOnlyCount more referenced only from doc comments.';
     if (count == 0) {
       return 'No unused declarations found '
           '(scanned ${result.filesScanned} files, '
-          '${result.declarationsChecked} declarations, ${seconds}s).';
+          '${result.declarationsChecked} declarations, ${seconds}s).'
+          '$docOnlySuffix';
     }
     return 'Found $count unused declaration${count == 1 ? '' : 's'} '
         'in $fileCount file${fileCount == 1 ? '' : 's'} '
         '(scanned ${result.filesScanned} files, '
-        '${result.declarationsChecked} declarations, ${seconds}s).';
+        '${result.declarationsChecked} declarations, ${seconds}s).'
+        '$docOnlySuffix';
   }
 
   // Minimal ANSI styling helpers.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: ciach
 description: >-
   Finds unused (never-referenced) declarations in a Dart/Flutter package by
   driving the Dart analysis server over LSP and querying textDocument/references.
-version: 0.1.0+1
+version: 0.2.0
 repository: https://github.com/leancodepl/ciach
 homepage: https://github.com/leancodepl/ciach
 

--- a/test/finder_test.dart
+++ b/test/finder_test.dart
@@ -42,6 +42,8 @@ void main() {
   Future<FinderResult> runFinder({
     bool includePublic = true,
     bool skipOverrides = true,
+    bool skipOperators = true,
+    bool ignoreDocReferences = false,
     Set<SymbolKind>? kinds,
     List<String> exclude = const [],
     List<String> include = const [],
@@ -50,6 +52,8 @@ void main() {
       rootPath: fixturePath,
       includePublic: includePublic,
       skipOverrides: skipOverrides,
+      skipOperators: skipOperators,
+      ignoreDocReferences: ignoreDocReferences,
       kinds: kinds ?? FinderOptions.defaultKinds,
       excludeGlobs: exclude,
       includeGlobs: include,
@@ -59,6 +63,8 @@ void main() {
   Future<Set<String>> findUnused({
     bool includePublic = true,
     bool skipOverrides = true,
+    bool skipOperators = true,
+    bool ignoreDocReferences = false,
     Set<SymbolKind>? kinds,
     List<String> exclude = const [],
     List<String> include = const [],
@@ -66,6 +72,8 @@ void main() {
     final result = await runFinder(
       includePublic: includePublic,
       skipOverrides: skipOverrides,
+      skipOperators: skipOperators,
+      ignoreDocReferences: ignoreDocReferences,
       kinds: kinds,
       exclude: exclude,
       include: include,
@@ -79,6 +87,7 @@ void main() {
       '_danglingPrivate',
       'unusedConstant',
       'staleCounter',
+      '_referencesOnlyInDocs',
       'UsedClass.named',
       'UsedClass.shout',
       'UsedClass.unusedMethod',
@@ -91,10 +100,27 @@ void main() {
       'Direction.west',
       'Loud.whisper',
       'tripled',
-      'Vector2.+',
-      'Vector2.-',
     });
   });
+
+  test('including operators also reports operator overloads', () async {
+    final unused = await findUnused(skipOperators: false);
+    expect(unused, containsAll(['Vector2.+', 'Vector2.-']));
+  });
+
+  test('ignoring doc references also reports declarations only mentioned in '
+      'a doc comment link', () async {
+    final unused = await findUnused(ignoreDocReferences: true);
+    expect(unused, contains('_docOnlyMentioned'));
+  });
+
+  test(
+    'by default, a doc comment link keeps a declaration looking used',
+    () async {
+      final unused = await findUnused();
+      expect(unused, isNot(contains('_docOnlyMentioned')));
+    },
+  );
 
   test('spans multiple files, one group per file in the report', () async {
     final result = await runFinder();
@@ -148,6 +174,7 @@ void main() {
   test('--no-public reports only private declarations', () async {
     expect(await findUnused(includePublic: false), {
       '_danglingPrivate',
+      '_referencesOnlyInDocs',
       'UsedClass._unusedField',
     });
   });

--- a/test/finder_test.dart
+++ b/test/finder_test.dart
@@ -43,7 +43,6 @@ void main() {
     bool includePublic = true,
     bool skipOverrides = true,
     bool skipOperators = true,
-    bool ignoreDocReferences = false,
     Set<SymbolKind>? kinds,
     List<String> exclude = const [],
     List<String> include = const [],
@@ -53,7 +52,6 @@ void main() {
       includePublic: includePublic,
       skipOverrides: skipOverrides,
       skipOperators: skipOperators,
-      ignoreDocReferences: ignoreDocReferences,
       kinds: kinds ?? FinderOptions.defaultKinds,
       excludeGlobs: exclude,
       includeGlobs: include,
@@ -64,7 +62,6 @@ void main() {
     bool includePublic = true,
     bool skipOverrides = true,
     bool skipOperators = true,
-    bool ignoreDocReferences = false,
     Set<SymbolKind>? kinds,
     List<String> exclude = const [],
     List<String> include = const [],
@@ -73,12 +70,16 @@ void main() {
       includePublic: includePublic,
       skipOverrides: skipOverrides,
       skipOperators: skipOperators,
-      ignoreDocReferences: ignoreDocReferences,
       kinds: kinds,
       exclude: exclude,
       include: include,
     );
     return result.unused.map((d) => d.qualifiedName).toSet();
+  }
+
+  Future<Set<String>> findDocOnly({bool includePublic = true}) async {
+    final result = await runFinder(includePublic: includePublic);
+    return result.docOnly.map((d) => d.qualifiedName).toSet();
   }
 
   test('reports exactly the expected unused declarations by default', () async {
@@ -108,19 +109,13 @@ void main() {
     expect(unused, containsAll(['Vector2.+', 'Vector2.-']));
   });
 
-  test('ignoring doc references also reports declarations only mentioned in '
-      'a doc comment link', () async {
-    final unused = await findUnused(ignoreDocReferences: true);
-    expect(unused, contains('_docOnlyMentioned'));
+  test('reports a declaration only mentioned in a doc comment link as '
+      'doc-only, not unused', () async {
+    final docOnly = await findDocOnly();
+    expect(docOnly, contains('_docOnlyMentioned'));
+    final unused = await findUnused();
+    expect(unused, isNot(contains('_docOnlyMentioned')));
   });
-
-  test(
-    'by default, a doc comment link keeps a declaration looking used',
-    () async {
-      final unused = await findUnused();
-      expect(unused, isNot(contains('_docOnlyMentioned')));
-    },
-  );
 
   test('spans multiple files, one group per file in the report', () async {
     final result = await runFinder();

--- a/test/remover_test.dart
+++ b/test/remover_test.dart
@@ -1,0 +1,287 @@
+import 'dart:io';
+
+import 'package:ciach/ciach.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('ciach_remover_test_');
+  });
+
+  tearDown(() {
+    tempDir.deleteSync(recursive: true);
+  });
+
+  /// Writes [content] to `<tempDir>/lib.dart`, removes [decls] from it, and
+  /// returns the resulting content.
+  String applyRemoval(String content, List<UnusedDeclaration> decls) {
+    File(p.join(tempDir.path, 'lib.dart')).writeAsStringSync(content);
+    removeDeclarations(decls, tempDir.path);
+    return File(p.join(tempDir.path, 'lib.dart')).readAsStringSync();
+  }
+
+  UnusedDeclaration decl({
+    required int startLine,
+    required int startColumn,
+    required int endLine,
+    required int endColumn,
+    SymbolKind kind = .function,
+    bool isEnumValue = false,
+  }) => .new(
+    name: 'x',
+    kind: kind,
+    filePath: 'lib.dart',
+    line: startLine + 1,
+    column: startColumn + 1,
+    isPrivate: false,
+    isEnumValue: isEnumValue,
+    range: (
+      startLine: startLine,
+      startColumn: startColumn,
+      endLine: endLine,
+      endColumn: endColumn,
+    ),
+  );
+
+  test('removes a top-level function along with its doc comment', () {
+    const source = '''
+void kept() {}
+
+/// Never referenced.
+void danglingFunction() {}
+
+void alsoKept() {}
+''';
+    // `void danglingFunction() {}` is line index 3, columns 0..26.
+    final result = applyRemoval(source, [
+      decl(startLine: 3, startColumn: 0, endLine: 3, endColumn: 26),
+    ]);
+    expect(result, isNot(contains('danglingFunction')));
+    expect(result, isNot(contains('Never referenced')));
+    expect(result, contains('void kept() {}'));
+    expect(result, contains('void alsoKept() {}'));
+  });
+
+  test('removes a sole-declarator field including its type prefix and `;`', () {
+    const source = '''
+class C {
+  /// Doc.
+  final int _unusedField = 0;
+
+  void method() {}
+}
+''';
+    // The field's own range covers only `_unusedField = 0` — no
+    // `final int ` prefix and no trailing `;` — matching what the
+    // analysis server reports for a `VariableDeclaration`.
+    const fieldLine = '  final int _unusedField = 0;';
+    final start = fieldLine.indexOf('_unusedField');
+    final end = fieldLine.indexOf(' = 0') + ' = 0'.length;
+    final result = applyRemoval(source, [
+      decl(
+        startLine: 2,
+        startColumn: start,
+        endLine: 2,
+        endColumn: end,
+        kind: .field,
+      ),
+    ]);
+    expect(result, isNot(contains('_unusedField')));
+    expect(result, isNot(contains('final int')));
+    expect(result, isNot(contains('Doc.')));
+    expect(result, contains('class C {'));
+    expect(result, contains('void method() {}'));
+    _expectBalanced(result);
+  });
+
+  group('multi-declarator statement `int a = 1, b = 2, c = 3;`', () {
+    const source = 'int a = 1, b = 2, c = 3;\n';
+    // Columns of each declarator's `name = value` span within the line.
+    const aRange = (start: 4, end: 9);
+    const bRange = (start: 11, end: 16);
+    const cRange = (start: 18, end: 23);
+
+    UnusedDeclaration declaratorAt(({int start, int end}) range) => decl(
+      startLine: 0,
+      startColumn: range.start,
+      endLine: 0,
+      endColumn: range.end,
+      kind: .variable,
+    );
+
+    test('drops the trailing comma when removing the first declarator', () {
+      final result = applyRemoval(source, [declaratorAt(aRange)]);
+      // The shared `int ` prefix is left for the surviving declarators; the
+      // resulting double space is cosmetic and `dart format` cleans it up.
+      expect(result.trim(), 'int  b = 2, c = 3;');
+    });
+
+    test('drops one neighboring comma when removing a middle declarator', () {
+      final result = applyRemoval(source, [declaratorAt(bRange)]);
+      expect(result.trim(), 'int a = 1, c = 3;');
+    });
+
+    test('drops the leading comma but keeps `;` when removing the last '
+        'declarator', () {
+      final result = applyRemoval(source, [declaratorAt(cRange)]);
+      expect(result.trim(), 'int a = 1, b = 2;');
+    });
+
+    test('removes the whole statement when every declarator is unused', () {
+      final result = applyRemoval(source, [
+        declaratorAt(aRange),
+        declaratorAt(bRange),
+        declaratorAt(cRange),
+      ]);
+      expect(result.trim(), isEmpty);
+    });
+  });
+
+  test('does not mistake a comma inside a generic type for a declarator '
+      'separator', () {
+    const source = 'Map<String, int> _cache = {};\n';
+    // Range covers `_cache = {}` only, as the analysis server reports it.
+    final start = source.indexOf('_cache');
+    final end = source.indexOf(';');
+    final result = applyRemoval(source, [
+      decl(
+        startLine: 0,
+        startColumn: start,
+        endLine: 0,
+        endColumn: end,
+        kind: .field,
+      ),
+    ]);
+    expect(result.trim(), isEmpty);
+  });
+
+  test("leaves a declarator alone when a top-level separator can't be found "
+      '(unresolvable shape)', () {
+    // A synthetic, deliberately-unbalanced range: the forward scan for a
+    // terminating `,`/`;` hits an unmatched `)` first and bails out rather
+    // than guess.
+    const source = 'int a = 1);\n';
+    final result = applyRemoval(source, [
+      decl(
+        startLine: 0,
+        startColumn: 4,
+        endLine: 0,
+        endColumn: 9,
+        kind: .variable,
+      ),
+    ]);
+    expect(result, source);
+  });
+
+  group('enum values', () {
+    test('removes a middle value along with its trailing comma', () {
+      const source = '''
+enum Direction {
+  north,
+  south,
+  east,
+}
+''';
+      final result = applyRemoval(source, [
+        decl(
+          startLine: 2,
+          startColumn: 2,
+          endLine: 2,
+          endColumn: 2 + 'south'.length,
+          isEnumValue: true,
+        ),
+      ]);
+      expect(result, isNot(contains('south')));
+      expect(result, contains('north,'));
+      expect(result, contains('east,'));
+      expect(result, isNot(contains(',,')));
+    });
+
+    test('removes the last value when there is no trailing comma', () {
+      const source = '''
+enum Direction {
+  north,
+  south
+}
+''';
+      final result = applyRemoval(source, [
+        decl(
+          startLine: 2,
+          startColumn: 2,
+          endLine: 2,
+          endColumn: 2 + 'south'.length,
+          isEnumValue: true,
+        ),
+      ]);
+      expect(result, isNot(contains('south')));
+      expect(result, contains('north'));
+      expect(result, isNot(contains('north,,')));
+      _expectBalanced(result);
+    });
+  });
+
+  test('collapses a fully-unused class into a single removal', () {
+    const lines = [
+      'class Kept {}',
+      '',
+      '/// Never referenced.',
+      'class UnusedClass {',
+      '  /// Never referenced.',
+      '  void orphanMethod() {}',
+      '}',
+      '',
+      'class AlsoKept {}',
+      '',
+    ];
+    final source = lines.join('\n');
+
+    final result = applyRemoval(source, [
+      // Ranges start at the declaration's keyword (`class`/`void`), not at
+      // the name — matching how the analysis server reports whole-node
+      // kinds (only `field`/`variable`/`constant` exclude their prefix).
+      decl(
+        startLine: 3,
+        startColumn: 0,
+        endLine: 6,
+        endColumn: 1,
+        kind: .class$,
+      ),
+      decl(
+        startLine: 5,
+        startColumn: 2,
+        endLine: 5,
+        endColumn: 2 + 'void orphanMethod() {}'.length,
+        kind: .method,
+      ),
+    ]);
+    expect(result, isNot(contains('UnusedClass')));
+    expect(result, isNot(contains('orphanMethod')));
+    expect(result, contains('class Kept {}'));
+    expect(result, contains('class AlsoKept {}'));
+    _expectBalanced(result);
+  });
+
+  test('removing nothing leaves the file untouched', () {
+    const source = 'void kept() {}\n';
+    expect(applyRemoval(source, const []), source);
+  });
+}
+
+/// A cheap brace-balance check so a regression that mangles a removal shows
+/// up in these fast unit tests, without needing the full analyzer.
+void _expectBalanced(String source) {
+  var depth = 0;
+  for (final ch in source.split('')) {
+    if (ch == '{') {
+      depth++;
+    }
+    if (ch == '}') {
+      depth--;
+    }
+    expect(depth, greaterThanOrEqualTo(0), reason: 'unbalanced braces');
+  }
+  expect(depth, 0, reason: 'unbalanced braces');
+}

--- a/test/reporter_test.dart
+++ b/test/reporter_test.dart
@@ -8,13 +8,19 @@
  *     - mark-ai-provenance
  */
 
+import 'dart:convert';
+
 import 'package:ciach/ciach.dart';
 import 'package:ciach/src/reporter.dart';
 import 'package:test/test.dart';
 
 void main() {
-  FinderResult resultWith(List<UnusedDeclaration> unused) => .new(
+  FinderResult resultWith(
+    List<UnusedDeclaration> unused, {
+    List<UnusedDeclaration> docOnly = const [],
+  }) => .new(
     unused: unused,
+    docOnly: docOnly,
     filesScanned: 3,
     declarationsChecked: 10,
     elapsed: const .new(seconds: 1),
@@ -83,6 +89,67 @@ void main() {
 
     test('produces no output when nothing is unused', () {
       expect(Reporter.github(resultWith(const [])), isEmpty);
+    });
+
+    test('emits a lower-severity ::notice for doc-only findings', () {
+      final out = Reporter.github(
+        resultWith(const [], docOnly: [decl(name: 'docOnlyThing')]),
+      );
+      expect(out, startsWith('::notice '));
+      expect(out, contains("docOnlyThing' has no code references"));
+    });
+  });
+
+  group('Reporter.text', () {
+    test('lists doc-only findings in a separate, labeled section', () {
+      final out = Reporter.text(
+        resultWith(
+          [decl(name: 'trulyDead')],
+          docOnly: [decl(name: 'onlyLinkedFromDocs')],
+        ),
+      );
+      expect(out, contains('trulyDead'));
+      expect(out, contains('onlyLinkedFromDocs'));
+      expect(out, contains('not counted as unused, never removed'));
+      // The doc-only entry appears after the "not counted..." label, not
+      // mixed into the unused listing above it.
+      expect(
+        out.indexOf('not counted as unused'),
+        greaterThan(out.indexOf('trulyDead')),
+      );
+    });
+
+    test(
+      'omits the doc-only section entirely when there is nothing to show',
+      () {
+        final out = Reporter.text(resultWith([decl()]));
+        expect(out, isNot(contains('doc comment')));
+      },
+    );
+  });
+
+  group('Reporter.json', () {
+    test('reports unused and docOnly as separate arrays', () {
+      final json =
+          jsonDecode(
+                Reporter.json(
+                  resultWith(
+                    [decl(name: 'trulyDead')],
+                    docOnly: [decl(name: 'onlyLinkedFromDocs')],
+                  ),
+                ),
+              )
+              as Map<String, Object?>;
+      final summary = json['summary']! as Map<String, Object?>;
+      expect(summary['unusedCount'], 1);
+      expect(summary['docOnlyCount'], 1);
+      final unused = json['unused']! as List<Object?>;
+      final docOnly = json['docOnly']! as List<Object?>;
+      expect((unused.single! as Map<String, Object?>)['name'], 'trulyDead');
+      expect(
+        (docOnly.single! as Map<String, Object?>)['name'],
+        'onlyLinkedFromDocs',
+      );
     });
   });
 }

--- a/test/reporter_test.dart
+++ b/test/reporter_test.dart
@@ -36,6 +36,12 @@ void main() {
     column: column,
     isPrivate: isPrivate,
     container: container,
+    range: (
+      startLine: line - 1,
+      startColumn: column - 1,
+      endLine: line - 1,
+      endColumn: column - 1 + name.length,
+    ),
   );
 
   group('Reporter.github', () {


### PR DESCRIPTION
## Summary

This PR adds the ability to automatically remove unused declarations from source files, along with improved classification of declarations referenced only from documentation comments.

## Key Changes

- **New `remover.dart` module**: Implements precise deletion of unused declarations from source files, handling complex cases like:
  - Multi-declarator statements (e.g., `int a = 1, b = 2, c = 3;`) where only some declarators are unused
  - Enum values with proper comma handling
  - Declarations with doc comments and annotations
  - Nested declarations (e.g., unused methods in unused classes)

- **Doc-only reference classification**: Declarations referenced only from dartdoc `[Xxx]` comment links are now reported separately as "doc-only" findings:
  - Never counted toward `--set-exit-if-changed`
  - Never removed by `--remove`
  - Reported as `::notice` (not `::warning`) in GitHub Actions format
  - Displayed in a separate section in text output

- **CLI enhancements**:
  - Added `--remove` flag to delete unused declarations after confirmation
  - Added `--force` flag to skip confirmation prompt (requires `--remove`)
  - Added `--operators` flag to include operator overloads (skipped by default since the analysis server can't resolve infix syntax back to declarations)
  - Removed `operator` from the `--kinds` list since operators are now handled separately

- **Updated models and reporting**:
  - Added `DeclarationRange` typedef to track full declaration spans for removal
  - Added `isEnumValue` field to `UnusedDeclaration`
  - Extended `FinderResult` with `docOnly` list separate from `unused`
  - Updated all reporters (text, JSON, GitHub) to handle doc-only findings

- **Documentation**: Updated README with installation instructions, removal workflow, and explanation of doc-only findings

## Notable Implementation Details

- The remover uses character-offset spans and handles UTF-16 column positions from LSP
- Multi-declarator removal is conservative: if the statement shape can't be confidently resolved, the declarator is left in place rather than risk producing invalid syntax
- Doc references are identified by checking if a reference location's line starts with `///`
- Metadata (doc comments, annotations) is automatically removed along with declarations by extending upward over contiguous comment/annotation lines

https://claude.ai/code/session_01CLMKZ9QfBPriuYWvNxb1c9