### PR TITLE
Add pub.dev topics and issue_tracker metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.0+1
+
+- Add pub.dev `topics` and `issue_tracker` metadata for discoverability. No
+  code changes.
+
 ## 0.2.0
 
 - Add `--remove` to delete unused declarations from source after reporting

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: ciach
 description: >-
   Finds unused (never-referenced) declarations in a Dart/Flutter package by
   driving the Dart analysis server over LSP and querying textDocument/references.
-version: 0.2.0
+version: 0.2.0+1
 repository: https://github.com/leancodepl/ciach
 homepage: https://github.com/leancodepl/ciach
 issue_tracker: https://github.com/leancodepl/ciach/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,13 @@ description: >-
 version: 0.2.0
 repository: https://github.com/leancodepl/ciach
 homepage: https://github.com/leancodepl/ciach
+issue_tracker: https://github.com/leancodepl/ciach/issues
+topics:
+  - static-analysis
+  - dead-code
+  - linter
+  - cli
+  - developer-tools
 
 environment:
   sdk: ^3.12.2


### PR DESCRIPTION
## Summary
- Add `topics` (`static-analysis`, `dead-code`, `linter`, `cli`, `developer-tools`) so the package surfaces on pub.dev's topic pages and topic-filtered search.
- Add explicit `issue_tracker` pointing to GitHub issues.
- Bump version to `0.2.0+1` (build-number only, since this is a metadata-only change with no code changes) and add a matching CHANGELOG entry.

## Test plan
- [x] Validated `pubspec.yaml` parses correctly (YAML syntax check).
- [ ] Publish `0.2.0+1` to pub.dev to confirm topics/issue_tracker render as expected (requires pushing a `v0.2.0+1` tag, not done as part of this PR).


---
_Generated by [Claude Code](https://claude.ai/code/session_01UudfwFt3AMKyd5bNbRZjwh)_