### PR TITLE
Lower minimum SDK constraint to ^3.10.0

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: ^3.12.0
+  sdk: ^3.10.0
 
 dev_dependencies:
   leancode_lint: ^24.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ topics:
   - developer-tools
 
 environment:
-  sdk: ^3.12.2
+  sdk: ^3.10.0
 
 dependencies:
   args: ^2.7.0


### PR DESCRIPTION
## Summary

Lowers `environment.sdk` from `^3.12.2` to `^3.10.0` (root package and the `example/` fixture). This lets ciach be activated on projects still pinned to Flutter 3.38–3.41 (Dart 3.10–3.11), which currently fail version solving:

```
Because pub global activate depends on ciach any which requires SDK version >=3.12.2 <4.0.0, version solving failed.
```

## Why 3.10 is a safe floor

- The only language feature in the codebase that gates the floor is **dot shorthands** (`.class$`, `.new(...)`, etc.), which shipped stable in **Dart 3.10**. Null-aware elements (`'container': ?container`) only need 3.8.
- `pro_lsp` declares `sdk: ^3.10.0` itself, so nothing in the dependency tree requires 3.12.

## Verification (on Dart 3.11.4 / Flutter 3.41.6)

- `dart analyze` — no issues
- `dart test` — all 30 tests pass
- `dart format --set-exit-if-changed .` — unchanged
- `dart run bin/ciach.dart example` — runs end-to-end, reports the expected fixture declarations
- Confirmed `// @dart=3.10` accepts the shorthand syntax while `// @dart=3.9` rejects it, so `^3.10.0` is the true floor

## Notes

Deliberately not bumping the version or touching the CHANGELOG so you can fold this into your next release however you prefer — happy to add an entry if you'd like. You may also want a second CI job on SDK `3.10` to keep the floor honest; also happy to add that here if wanted.