### PR TITLE
Reorganize source into cohesive modules and modernize the code

### DIFF
--- a/bin/ciach.dart
+++ b/bin/ciach.dart
@@ -12,27 +12,9 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:ciach/ciach.dart';
+import 'package:ciach/src/cli/args.dart';
 import 'package:ciach/src/reporter.dart';
 import 'package:path/path.dart' as p;
-
-/// Friendly `--kinds` names mapped to LSP symbol kinds.
-const _kindAliases = <String, SymbolKind>{
-  'class': .class$,
-  'mixin': .interface$,
-  'interface': .interface$,
-  'enum': .enum$,
-  'extension': .struct,
-  'function': .function,
-  'method': .method,
-  'constructor': .constructor,
-  'field': .field,
-  'property': .property,
-  'getter': .property,
-  'setter': .property,
-  'variable': .variable,
-  'constant': .constant,
-  'enum-value': .enumMember,
-};
 
 Future<void> main(List<String> arguments) async {
   // Returning an int from `main` does not set the process exit code in Dart,
@@ -41,7 +23,7 @@ Future<void> main(List<String> arguments) async {
 }
 
 Future<int> _run(List<String> arguments) async {
-  final parser = _buildParser();
+  final parser = buildParser();
 
   final ArgResults args;
   try {
@@ -50,12 +32,12 @@ Future<int> _run(List<String> arguments) async {
     stderr
       ..writeln(e.message)
       ..writeln()
-      ..writeln(_usage(parser));
+      ..writeln(usage(parser));
     return 2;
   }
 
   if (args.flag('help')) {
-    stdout.writeln(_usage(parser));
+    stdout.writeln(usage(parser));
     return 0;
   }
 
@@ -80,7 +62,7 @@ Future<int> _run(List<String> arguments) async {
 
   final Set<SymbolKind> kinds;
   try {
-    kinds = _parseKinds(args.multiOption('kinds'));
+    kinds = parseKinds(args.multiOption('kinds'));
   } on FormatException catch (e) {
     stderr.writeln(e.message);
     return 2;
@@ -207,8 +189,7 @@ Future<void> _removeUnused(
   final filesChanged = removeDeclarations(result.unused, rootPath);
   stdout.writeln(
     'Removed $count unused declaration$plural from $filesChanged '
-    'file${filesChanged == 1 ? '' : 's'}. '
-    "Run 'dart format' to tidy up spacing.",
+    "file${filesChanged == 1 ? '' : 's'}. Run 'dart format' to tidy up spacing.",
   );
   // Surface any advisory hints (e.g. a removed prevent-instantiation
   // constructor) once more, since removing the declaration also removes the
@@ -221,196 +202,6 @@ Future<void> _removeUnused(
     stdout.writeln('Note: $note');
   }
 }
-
-Set<SymbolKind> _parseKinds(List<String> raw) {
-  if (raw.isEmpty) {
-    return FinderOptions.defaultKinds;
-  }
-  final kinds = <SymbolKind>{};
-  for (final entry in raw) {
-    for (final name in entry.split(',')) {
-      final trimmed = name.trim().toLowerCase();
-      if (trimmed.isEmpty) {
-        continue;
-      }
-      final kind = _kindAliases[trimmed];
-      if (kind == null) {
-        throw FormatException(
-          "Unknown kind '$trimmed'. Valid kinds: "
-          '${(_kindAliases.keys.toList()..sort()).join(', ')}.',
-        );
-      }
-      kinds.add(kind);
-    }
-  }
-  return kinds;
-}
-
-ArgParser _buildParser() {
-  return .new()
-    ..addFlag(
-      'help',
-      abbr: 'h',
-      negatable: false,
-      help: 'Print this usage information.',
-    )
-    ..addFlag(
-      'public',
-      defaultsTo: true,
-      help:
-          'Report unused public declarations too. Disable to report only\n'
-          'private (underscore-prefixed) declarations, which are the\n'
-          'highest-confidence dead code.',
-    )
-    ..addFlag(
-      'generated',
-      help:
-          'Scan generated files (*.g.dart, *.freezed.dart, …). Off by default.',
-    )
-    ..addFlag(
-      'overrides',
-      help:
-          'Report members annotated with @override too. Off by default,\n'
-          'since overrides are often reached polymorphically and a plain\n'
-          'reference search can miss those uses.',
-    )
-    ..addFlag(
-      'operators',
-      help:
-          'Report operator overloads (operator +, operator ==, …) too. Off\n'
-          'by default: the analysis server never resolves infix operator\n'
-          "syntax (a + b) back to the operator's declaration, so a used\n"
-          'operator is reported as unused every time.',
-    )
-    ..addFlag(
-      'unused-union-members',
-      help:
-          'Also flag a class whose only references are type patterns over its\n'
-          '(sealed) supertype — matched but never constructed. Off by default:\n'
-          'a `case Foo():` arm otherwise counts as a use. Report-only: these\n'
-          'findings are surfaced but --remove never deletes them or their\n'
-          'pattern arms (removing a sealed member and rewriting its switches\n'
-          'is left to a human). Conservative: any reference that is not clearly\n'
-          'a type pattern keeps the class alive.',
-    )
-    ..addFlag(
-      'report-tojson',
-      help:
-          'Report a `toJson()` serialization hook as unused too. Off by\n'
-          'default: `jsonEncode(obj)` calls `obj.toJson()` by dynamic dispatch\n'
-          'with no source-level `.toJson()` reference for the search to see, so\n'
-          'a live serializer would be flagged. Enable to audit dead `toJson`s.',
-    )
-    ..addFlag(
-      'set-exit-if-changed',
-      help:
-          'Exit with a non-zero status when any unused declaration is found\n'
-          '(useful in CI).',
-    )
-    ..addFlag(
-      'remove',
-      help:
-          'Remove unused declarations from source after reporting them.\n'
-          'Prompts for confirmation first, unless --force is also given.',
-    )
-    ..addFlag(
-      'force',
-      help: 'Skip the confirmation prompt for --remove. Requires --remove.',
-    )
-    ..addMultiOption(
-      'exclude',
-      abbr: 'e',
-      help: 'Glob(s), relative to the root, of files to skip. Repeatable.',
-      valueHelp: 'glob',
-    )
-    ..addMultiOption(
-      'include',
-      abbr: 'i',
-      help: 'If given, only scan files matching these glob(s). Repeatable.',
-      valueHelp: 'glob',
-    )
-    ..addMultiOption(
-      'generated-suffix',
-      help:
-          'Additional filename suffix to treat as generated (and so\n'
-          'exclude from the scan), on top of the built-in set (*.g.dart,\n'
-          '*.freezed.dart, …). Use for custom code generators, e.g.\n'
-          '--generated-suffix .gc.dart. Include the leading dot. Repeatable.\n'
-          'Ignored when --generated is set.',
-      valueHelp: 'suffix',
-    )
-    ..addMultiOption(
-      'kinds',
-      abbr: 'k',
-      help:
-          'Restrict to these declaration kinds (comma-separated).\n'
-          'Valid: ${(_kindAliases.keys.toList()..sort()).join(', ')}.',
-      valueHelp: 'kind,kind',
-    )
-    ..addOption(
-      'format',
-      abbr: 'f',
-      allowed: ['text', 'json', 'github'],
-      defaultsTo: 'text',
-      help: 'Output format.',
-      allowedHelp: {
-        'text': 'Human-readable, grouped by file.',
-        'json': 'Machine-readable JSON.',
-        'github': 'GitHub Actions `::warning` annotations.',
-      },
-    )
-    ..addFlag(
-      'color',
-      help: 'Colorize text output. Defaults to auto-detecting the terminal.',
-    )
-    ..addFlag(
-      'progress',
-      help: 'Show scan progress on stderr. Defaults to on for a terminal.',
-    )
-    ..addOption(
-      'concurrency',
-      abbr: 'j',
-      defaultsTo: '16',
-      help:
-          'How many reference queries to run against the analysis server at\n'
-          'once. Higher can be faster on large projects, up to the limit of\n'
-          'the analysis server parallelism.',
-      valueHelp: 'n',
-    )
-    ..addOption(
-      'dart',
-      help:
-          'Path to the dart executable used to launch the analysis server.\n'
-          'Defaults to the SDK running this tool.',
-      valueHelp: 'path',
-    );
-}
-
-String _usage(ArgParser parser) =>
-    '''
-Find unused (never-referenced) declarations in a Dart/Flutter package.
-
-Usage: ciach [options] [path]
-
-  path   Package root to analyze (defaults to the current directory).
-
-${parser.usage}
-
-Examples:
-  # Scan the current package
-  ciach
-
-  # Only private declarations, excluding tests, as JSON
-  ciach --no-public -e 'test/**' -f json lib/
-
-  # GitHub Actions annotations, fail the job if anything is found
-  ciach -f github --set-exit-if-changed
-
-  # Remove what's found, after confirming
-  ciach --remove
-
-  # Remove without asking (e.g. in a script)
-  ciach --remove --force''';
 
 /// Prints single-line, overwriting progress to stderr.
 class _ProgressPrinter {

--- a/bin/ciach.dart
+++ b/bin/ciach.dart
@@ -177,8 +177,10 @@ Future<void> _removeUnused(
       return;
     }
     stdout.write('Remove $count unused declaration$plural? [y/N] ');
-    final answer = stdin.readLineSync()?.trim().toLowerCase();
-    proceed = answer == 'y' || answer == 'yes';
+    proceed = switch (stdin.readLineSync()?.trim().toLowerCase()) {
+      'y' || 'yes' => true,
+      _ => false,
+    };
   }
 
   if (!proceed) {

--- a/lib/src/candidates.dart
+++ b/lib/src/candidates.dart
@@ -1,0 +1,53 @@
+/*
+ * AI-Provenance:
+ *   model: claude-opus-4-8
+ *   harness: Claude Code
+ *   plugins:
+ *     - lean-ai-provenance
+ *   skills:
+ *     - mark-ai-provenance
+ */
+
+import 'package:pro_lsp/pro_lsp.dart' show DocumentSymbol;
+
+/// A declaration to check: the symbol plus enough context to query references
+/// for it and to report it later.
+typedef Candidate = ({
+  Uri uri,
+  String path,
+  DocumentSymbol symbol,
+  String? container,
+  bool isEnumValue,
+  bool isPreventInstantiationCtor,
+});
+
+/// A file path paired with a declaration name, used as a map key to look up
+/// per-declaration facts gathered by the remove-safety pre-pass.
+typedef DeclKey = ({String path, String name});
+
+/// How a candidate's references classify it.
+enum RefStatus {
+  /// At least one real (non-doc-comment) reference.
+  used,
+
+  /// No real references, but at least one dartdoc `[Xxx]` comment link.
+  docOnly,
+
+  /// No references of any kind.
+  unused,
+}
+
+/// The map key pairing a file [path] with a declaration [name].
+DeclKey declKey(String path, String name) => (path: path, name: name);
+
+extension CandidateKeys on Candidate {
+  /// This candidate's own `(path, name)` key.
+  DeclKey get key => (path: path, name: symbol.name);
+
+  /// The `(path, container)` key of this candidate's enclosing declaration,
+  /// or `null` when it has no container.
+  DeclKey? get containerKey => switch (container) {
+    final c? => (path: path, name: c),
+    null => null,
+  };
+}

--- a/lib/src/candidates.dart
+++ b/lib/src/candidates.dart
@@ -10,20 +10,21 @@
 
 import 'package:pro_lsp/pro_lsp.dart' show DocumentSymbol;
 
-/// A declaration to check: the symbol plus enough context to query references
-/// for it and to report it later.
-typedef Candidate = ({
-  Uri uri,
-  String path,
-  DocumentSymbol symbol,
-  String? container,
-  bool isEnumValue,
-  bool isPreventInstantiationCtor,
-});
-
 /// A file path paired with a declaration name, used as a map key to look up
 /// per-declaration facts gathered by the remove-safety pre-pass.
-typedef DeclKey = ({String path, String name});
+final class DeclKey {
+  const DeclKey(this.path, this.name);
+
+  final String path;
+  final String name;
+
+  @override
+  bool operator ==(Object other) =>
+      other is DeclKey && other.path == path && other.name == name;
+
+  @override
+  int get hashCode => Object.hash(path, name);
+}
 
 /// How a candidate's references classify it.
 enum RefStatus {
@@ -37,17 +38,32 @@ enum RefStatus {
   unused,
 }
 
-/// The map key pairing a file [path] with a declaration [name].
-DeclKey declKey(String path, String name) => (path: path, name: name);
+/// A declaration to check: the symbol plus enough context to query references
+/// for it and to report it later.
+final class Candidate {
+  const Candidate({
+    required this.uri,
+    required this.path,
+    required this.symbol,
+    required this.container,
+    required this.isEnumValue,
+    required this.isPreventInstantiationCtor,
+  });
 
-extension CandidateKeys on Candidate {
+  final Uri uri;
+  final String path;
+  final DocumentSymbol symbol;
+  final String? container;
+  final bool isEnumValue;
+  final bool isPreventInstantiationCtor;
+
   /// This candidate's own `(path, name)` key.
-  DeclKey get key => (path: path, name: symbol.name);
+  DeclKey get key => DeclKey(path, symbol.name);
 
   /// The `(path, container)` key of this candidate's enclosing declaration,
   /// or `null` when it has no container.
   DeclKey? get containerKey => switch (container) {
-    final c? => (path: path, name: c),
+    final c? => DeclKey(path, c),
     null => null,
   };
 }

--- a/lib/src/cli/args.dart
+++ b/lib/src/cli/args.dart
@@ -10,6 +10,7 @@
 
 import 'package:args/args.dart';
 import 'package:ciach/ciach.dart';
+import 'package:collection/collection.dart';
 
 /// Friendly `--kinds` names mapped to LSP symbol kinds.
 const kindAliases = <String, SymbolKind>{
@@ -31,7 +32,7 @@ const kindAliases = <String, SymbolKind>{
 };
 
 /// The `--kinds` alias names, sorted, for help text and error messages.
-String get kindNames => (kindAliases.keys.toList()..sort()).join(', ');
+String get kindNames => kindAliases.keys.sorted().join(', ');
 
 /// Parses the `--kinds` values (comma-separated, repeatable) into symbol kinds,
 /// falling back to [FinderOptions.defaultKinds] when none are given.

--- a/lib/src/cli/args.dart
+++ b/lib/src/cli/args.dart
@@ -56,145 +56,142 @@ Set<SymbolKind> parseKinds(List<String> raw) {
 
 /// Builds the CLI argument parser. Every flag and option ciach accepts is
 /// declared here, so adding one is a single-file change.
-ArgParser buildParser() {
-  return .new()
-    ..addFlag(
-      'help',
-      abbr: 'h',
-      negatable: false,
-      help: 'Print this usage information.',
-    )
-    ..addFlag(
-      'public',
-      defaultsTo: true,
-      help:
-          'Report unused public declarations too. Disable to report only\n'
-          'private (underscore-prefixed) declarations, which are the\n'
-          'highest-confidence dead code.',
-    )
-    ..addFlag(
-      'generated',
-      help:
-          'Scan generated files (*.g.dart, *.freezed.dart, …). Off by default.',
-    )
-    ..addFlag(
-      'overrides',
-      help:
-          'Report members annotated with @override too. Off by default,\n'
-          'since overrides are often reached polymorphically and a plain\n'
-          'reference search can miss those uses.',
-    )
-    ..addFlag(
-      'operators',
-      help:
-          'Report operator overloads (operator +, operator ==, …) too. Off\n'
-          'by default: the analysis server never resolves infix operator\n'
-          "syntax (a + b) back to the operator's declaration, so a used\n"
-          'operator is reported as unused every time.',
-    )
-    ..addFlag(
-      'unused-union-members',
-      help:
-          'Also flag a class whose only references are type patterns over its\n'
-          '(sealed) supertype — matched but never constructed. Off by default:\n'
-          'a `case Foo():` arm otherwise counts as a use. Report-only: these\n'
-          'findings are surfaced but --remove never deletes them or their\n'
-          'pattern arms (removing a sealed member and rewriting its switches\n'
-          'is left to a human). Conservative: any reference that is not clearly\n'
-          'a type pattern keeps the class alive.',
-    )
-    ..addFlag(
-      'report-tojson',
-      help:
-          'Report a `toJson()` serialization hook as unused too. Off by\n'
-          'default: `jsonEncode(obj)` calls `obj.toJson()` by dynamic dispatch\n'
-          'with no source-level `.toJson()` reference for the search to see, so\n'
-          'a live serializer would be flagged. Enable to audit dead `toJson`s.',
-    )
-    ..addFlag(
-      'set-exit-if-changed',
-      help:
-          'Exit with a non-zero status when any unused declaration is found\n'
-          '(useful in CI).',
-    )
-    ..addFlag(
-      'remove',
-      help:
-          'Remove unused declarations from source after reporting them.\n'
-          'Prompts for confirmation first, unless --force is also given.',
-    )
-    ..addFlag(
-      'force',
-      help: 'Skip the confirmation prompt for --remove. Requires --remove.',
-    )
-    ..addMultiOption(
-      'exclude',
-      abbr: 'e',
-      help: 'Glob(s), relative to the root, of files to skip. Repeatable.',
-      valueHelp: 'glob',
-    )
-    ..addMultiOption(
-      'include',
-      abbr: 'i',
-      help: 'If given, only scan files matching these glob(s). Repeatable.',
-      valueHelp: 'glob',
-    )
-    ..addMultiOption(
-      'generated-suffix',
-      help:
-          'Additional filename suffix to treat as generated (and so\n'
-          'exclude from the scan), on top of the built-in set (*.g.dart,\n'
-          '*.freezed.dart, …). Use for custom code generators, e.g.\n'
-          '--generated-suffix .gc.dart. Include the leading dot. Repeatable.\n'
-          'Ignored when --generated is set.',
-      valueHelp: 'suffix',
-    )
-    ..addMultiOption(
-      'kinds',
-      abbr: 'k',
-      help:
-          'Restrict to these declaration kinds (comma-separated).\n'
-          'Valid: $kindNames.',
-      valueHelp: 'kind,kind',
-    )
-    ..addOption(
-      'format',
-      abbr: 'f',
-      allowed: ['text', 'json', 'github'],
-      defaultsTo: 'text',
-      help: 'Output format.',
-      allowedHelp: {
-        'text': 'Human-readable, grouped by file.',
-        'json': 'Machine-readable JSON.',
-        'github': 'GitHub Actions `::warning` annotations.',
-      },
-    )
-    ..addFlag(
-      'color',
-      help: 'Colorize text output. Defaults to auto-detecting the terminal.',
-    )
-    ..addFlag(
-      'progress',
-      help: 'Show scan progress on stderr. Defaults to on for a terminal.',
-    )
-    ..addOption(
-      'concurrency',
-      abbr: 'j',
-      defaultsTo: '16',
-      help:
-          'How many reference queries to run against the analysis server at\n'
-          'once. Higher can be faster on large projects, up to the limit of\n'
-          'the analysis server parallelism.',
-      valueHelp: 'n',
-    )
-    ..addOption(
-      'dart',
-      help:
-          'Path to the dart executable used to launch the analysis server.\n'
-          'Defaults to the SDK running this tool.',
-      valueHelp: 'path',
-    );
-}
+ArgParser buildParser() => .new()
+  ..addFlag(
+    'help',
+    abbr: 'h',
+    negatable: false,
+    help: 'Print this usage information.',
+  )
+  ..addFlag(
+    'public',
+    defaultsTo: true,
+    help:
+        'Report unused public declarations too. Disable to report only\n'
+        'private (underscore-prefixed) declarations, which are the\n'
+        'highest-confidence dead code.',
+  )
+  ..addFlag(
+    'generated',
+    help: 'Scan generated files (*.g.dart, *.freezed.dart, …). Off by default.',
+  )
+  ..addFlag(
+    'overrides',
+    help:
+        'Report members annotated with @override too. Off by default,\n'
+        'since overrides are often reached polymorphically and a plain\n'
+        'reference search can miss those uses.',
+  )
+  ..addFlag(
+    'operators',
+    help:
+        'Report operator overloads (operator +, operator ==, …) too. Off\n'
+        'by default: the analysis server never resolves infix operator\n'
+        "syntax (a + b) back to the operator's declaration, so a used\n"
+        'operator is reported as unused every time.',
+  )
+  ..addFlag(
+    'unused-union-members',
+    help:
+        'Also flag a class whose only references are type patterns over its\n'
+        '(sealed) supertype — matched but never constructed. Off by default:\n'
+        'a `case Foo():` arm otherwise counts as a use. Report-only: these\n'
+        'findings are surfaced but --remove never deletes them or their\n'
+        'pattern arms (removing a sealed member and rewriting its switches\n'
+        'is left to a human). Conservative: any reference that is not clearly\n'
+        'a type pattern keeps the class alive.',
+  )
+  ..addFlag(
+    'report-tojson',
+    help:
+        'Report a `toJson()` serialization hook as unused too. Off by\n'
+        'default: `jsonEncode(obj)` calls `obj.toJson()` by dynamic dispatch\n'
+        'with no source-level `.toJson()` reference for the search to see, so\n'
+        'a live serializer would be flagged. Enable to audit dead `toJson`s.',
+  )
+  ..addFlag(
+    'set-exit-if-changed',
+    help:
+        'Exit with a non-zero status when any unused declaration is found\n'
+        '(useful in CI).',
+  )
+  ..addFlag(
+    'remove',
+    help:
+        'Remove unused declarations from source after reporting them.\n'
+        'Prompts for confirmation first, unless --force is also given.',
+  )
+  ..addFlag(
+    'force',
+    help: 'Skip the confirmation prompt for --remove. Requires --remove.',
+  )
+  ..addMultiOption(
+    'exclude',
+    abbr: 'e',
+    help: 'Glob(s), relative to the root, of files to skip. Repeatable.',
+    valueHelp: 'glob',
+  )
+  ..addMultiOption(
+    'include',
+    abbr: 'i',
+    help: 'If given, only scan files matching these glob(s). Repeatable.',
+    valueHelp: 'glob',
+  )
+  ..addMultiOption(
+    'generated-suffix',
+    help:
+        'Additional filename suffix to treat as generated (and so\n'
+        'exclude from the scan), on top of the built-in set (*.g.dart,\n'
+        '*.freezed.dart, …). Use for custom code generators, e.g.\n'
+        '--generated-suffix .gc.dart. Include the leading dot. Repeatable.\n'
+        'Ignored when --generated is set.',
+    valueHelp: 'suffix',
+  )
+  ..addMultiOption(
+    'kinds',
+    abbr: 'k',
+    help:
+        'Restrict to these declaration kinds (comma-separated).\n'
+        'Valid: $kindNames.',
+    valueHelp: 'kind,kind',
+  )
+  ..addOption(
+    'format',
+    abbr: 'f',
+    allowed: ['text', 'json', 'github'],
+    defaultsTo: 'text',
+    help: 'Output format.',
+    allowedHelp: {
+      'text': 'Human-readable, grouped by file.',
+      'json': 'Machine-readable JSON.',
+      'github': 'GitHub Actions `::warning` annotations.',
+    },
+  )
+  ..addFlag(
+    'color',
+    help: 'Colorize text output. Defaults to auto-detecting the terminal.',
+  )
+  ..addFlag(
+    'progress',
+    help: 'Show scan progress on stderr. Defaults to on for a terminal.',
+  )
+  ..addOption(
+    'concurrency',
+    abbr: 'j',
+    defaultsTo: '16',
+    help:
+        'How many reference queries to run against the analysis server at\n'
+        'once. Higher can be faster on large projects, up to the limit of\n'
+        'the analysis server parallelism.',
+    valueHelp: 'n',
+  )
+  ..addOption(
+    'dart',
+    help:
+        'Path to the dart executable used to launch the analysis server.\n'
+        'Defaults to the SDK running this tool.',
+    valueHelp: 'path',
+  );
 
 /// The full `--help` text, wrapping [parser]'s generated option list.
 String usage(ArgParser parser) =>

--- a/lib/src/cli/args.dart
+++ b/lib/src/cli/args.dart
@@ -1,0 +1,223 @@
+/*
+ * AI-Provenance:
+ *   model: claude-opus-4-8
+ *   harness: Claude Code
+ *   plugins:
+ *     - lean-ai-provenance
+ *   skills:
+ *     - mark-ai-provenance
+ */
+
+import 'package:args/args.dart';
+import 'package:ciach/ciach.dart';
+
+/// Friendly `--kinds` names mapped to LSP symbol kinds.
+const kindAliases = <String, SymbolKind>{
+  'class': .class$,
+  'mixin': .interface$,
+  'interface': .interface$,
+  'enum': .enum$,
+  'extension': .struct,
+  'function': .function,
+  'method': .method,
+  'constructor': .constructor,
+  'field': .field,
+  'property': .property,
+  'getter': .property,
+  'setter': .property,
+  'variable': .variable,
+  'constant': .constant,
+  'enum-value': .enumMember,
+};
+
+/// The `--kinds` alias names, sorted, for help text and error messages.
+String get kindNames => (kindAliases.keys.toList()..sort()).join(', ');
+
+/// Parses the `--kinds` values (comma-separated, repeatable) into symbol kinds,
+/// falling back to [FinderOptions.defaultKinds] when none are given.
+///
+/// Throws a [FormatException] naming the offending value on an unknown kind.
+Set<SymbolKind> parseKinds(List<String> raw) {
+  if (raw.isEmpty) {
+    return FinderOptions.defaultKinds;
+  }
+  return {
+    for (final entry in raw)
+      for (final name in entry.split(','))
+        if (name.trim().toLowerCase() case final trimmed
+            when trimmed.isNotEmpty)
+          kindAliases[trimmed] ??
+              (throw FormatException(
+                "Unknown kind '$trimmed'. Valid kinds: $kindNames.",
+              )),
+  };
+}
+
+/// Builds the CLI argument parser. Every flag and option ciach accepts is
+/// declared here, so adding one is a single-file change.
+ArgParser buildParser() {
+  return .new()
+    ..addFlag(
+      'help',
+      abbr: 'h',
+      negatable: false,
+      help: 'Print this usage information.',
+    )
+    ..addFlag(
+      'public',
+      defaultsTo: true,
+      help:
+          'Report unused public declarations too. Disable to report only\n'
+          'private (underscore-prefixed) declarations, which are the\n'
+          'highest-confidence dead code.',
+    )
+    ..addFlag(
+      'generated',
+      help:
+          'Scan generated files (*.g.dart, *.freezed.dart, …). Off by default.',
+    )
+    ..addFlag(
+      'overrides',
+      help:
+          'Report members annotated with @override too. Off by default,\n'
+          'since overrides are often reached polymorphically and a plain\n'
+          'reference search can miss those uses.',
+    )
+    ..addFlag(
+      'operators',
+      help:
+          'Report operator overloads (operator +, operator ==, …) too. Off\n'
+          'by default: the analysis server never resolves infix operator\n'
+          "syntax (a + b) back to the operator's declaration, so a used\n"
+          'operator is reported as unused every time.',
+    )
+    ..addFlag(
+      'unused-union-members',
+      help:
+          'Also flag a class whose only references are type patterns over its\n'
+          '(sealed) supertype — matched but never constructed. Off by default:\n'
+          'a `case Foo():` arm otherwise counts as a use. Report-only: these\n'
+          'findings are surfaced but --remove never deletes them or their\n'
+          'pattern arms (removing a sealed member and rewriting its switches\n'
+          'is left to a human). Conservative: any reference that is not clearly\n'
+          'a type pattern keeps the class alive.',
+    )
+    ..addFlag(
+      'report-tojson',
+      help:
+          'Report a `toJson()` serialization hook as unused too. Off by\n'
+          'default: `jsonEncode(obj)` calls `obj.toJson()` by dynamic dispatch\n'
+          'with no source-level `.toJson()` reference for the search to see, so\n'
+          'a live serializer would be flagged. Enable to audit dead `toJson`s.',
+    )
+    ..addFlag(
+      'set-exit-if-changed',
+      help:
+          'Exit with a non-zero status when any unused declaration is found\n'
+          '(useful in CI).',
+    )
+    ..addFlag(
+      'remove',
+      help:
+          'Remove unused declarations from source after reporting them.\n'
+          'Prompts for confirmation first, unless --force is also given.',
+    )
+    ..addFlag(
+      'force',
+      help: 'Skip the confirmation prompt for --remove. Requires --remove.',
+    )
+    ..addMultiOption(
+      'exclude',
+      abbr: 'e',
+      help: 'Glob(s), relative to the root, of files to skip. Repeatable.',
+      valueHelp: 'glob',
+    )
+    ..addMultiOption(
+      'include',
+      abbr: 'i',
+      help: 'If given, only scan files matching these glob(s). Repeatable.',
+      valueHelp: 'glob',
+    )
+    ..addMultiOption(
+      'generated-suffix',
+      help:
+          'Additional filename suffix to treat as generated (and so\n'
+          'exclude from the scan), on top of the built-in set (*.g.dart,\n'
+          '*.freezed.dart, …). Use for custom code generators, e.g.\n'
+          '--generated-suffix .gc.dart. Include the leading dot. Repeatable.\n'
+          'Ignored when --generated is set.',
+      valueHelp: 'suffix',
+    )
+    ..addMultiOption(
+      'kinds',
+      abbr: 'k',
+      help:
+          'Restrict to these declaration kinds (comma-separated).\n'
+          'Valid: $kindNames.',
+      valueHelp: 'kind,kind',
+    )
+    ..addOption(
+      'format',
+      abbr: 'f',
+      allowed: ['text', 'json', 'github'],
+      defaultsTo: 'text',
+      help: 'Output format.',
+      allowedHelp: {
+        'text': 'Human-readable, grouped by file.',
+        'json': 'Machine-readable JSON.',
+        'github': 'GitHub Actions `::warning` annotations.',
+      },
+    )
+    ..addFlag(
+      'color',
+      help: 'Colorize text output. Defaults to auto-detecting the terminal.',
+    )
+    ..addFlag(
+      'progress',
+      help: 'Show scan progress on stderr. Defaults to on for a terminal.',
+    )
+    ..addOption(
+      'concurrency',
+      abbr: 'j',
+      defaultsTo: '16',
+      help:
+          'How many reference queries to run against the analysis server at\n'
+          'once. Higher can be faster on large projects, up to the limit of\n'
+          'the analysis server parallelism.',
+      valueHelp: 'n',
+    )
+    ..addOption(
+      'dart',
+      help:
+          'Path to the dart executable used to launch the analysis server.\n'
+          'Defaults to the SDK running this tool.',
+      valueHelp: 'path',
+    );
+}
+
+/// The full `--help` text, wrapping [parser]'s generated option list.
+String usage(ArgParser parser) =>
+    '''
+Find unused (never-referenced) declarations in a Dart/Flutter package.
+
+Usage: ciach [options] [path]
+
+  path   Package root to analyze (defaults to the current directory).
+
+${parser.usage}
+
+Examples:
+  # Scan the current package
+  ciach
+
+  # Only private declarations, excluding tests, as JSON
+  ciach --no-public -e 'test/**' -f json lib/
+
+  # GitHub Actions annotations, fail the job if anything is found
+  ciach -f github --set-exit-if-changed
+
+  # Remove what's found, after confirming
+  ciach --remove
+
+  # Remove without asking (e.g. in a script)
+  ciach --remove --force''';

--- a/lib/src/concurrency.dart
+++ b/lib/src/concurrency.dart
@@ -31,6 +31,6 @@ Future<List<R>> mapPooled<T, R>(
   }
 
   final workerCount = concurrency < items.length ? concurrency : items.length;
-  await Future.wait([for (var i = 0; i < workerCount; i++) worker()]);
+  await List.generate(workerCount, (_) => worker()).wait;
   return results.cast<R>();
 }

--- a/lib/src/concurrency.dart
+++ b/lib/src/concurrency.dart
@@ -1,0 +1,36 @@
+/*
+ * AI-Provenance:
+ *   model: claude-opus-4-8
+ *   harness: Claude Code
+ *   plugins:
+ *     - lean-ai-provenance
+ *   skills:
+ *     - mark-ai-provenance
+ */
+
+import 'dart:async';
+
+/// Runs [fn] over [items] with at most [concurrency] futures in flight,
+/// preserving input order in the returned list.
+Future<List<R>> mapPooled<T, R>(
+  List<T> items,
+  int concurrency,
+  Future<R> Function(T) fn,
+) async {
+  final results = List<R?>.filled(items.length, null);
+  var next = 0;
+
+  Future<void> worker() async {
+    while (true) {
+      final index = next++;
+      if (index >= items.length) {
+        return;
+      }
+      results[index] = await fn(items[index]);
+    }
+  }
+
+  final workerCount = concurrency < items.length ? concurrency : items.length;
+  await Future.wait([for (var i = 0; i < workerCount; i++) worker()]);
+  return results.cast<R>();
+}

--- a/lib/src/conventions/flutter_widgets.dart
+++ b/lib/src/conventions/flutter_widgets.dart
@@ -1,0 +1,124 @@
+/*
+ * AI-Provenance:
+ *   model: claude-opus-4-8
+ *   harness: Claude Code
+ *   plugins:
+ *     - lean-ai-provenance
+ *   skills:
+ *     - mark-ai-provenance
+ */
+
+import 'package:ciach/src/candidates.dart';
+import 'package:ciach/src/models.dart';
+import 'package:ciach/src/paths.dart';
+import 'package:ciach/src/reference_kinds.dart';
+import 'package:ciach/src/source_index.dart';
+import 'package:ciach/src/symbols.dart';
+import 'package:pro_lsp/pro_lsp.dart' show DocumentSymbol, Location;
+
+/// The `State<` immediately preceding a type argument, with a token boundary
+/// before `State` so `MyState<…>`/`FooState<…>` don't match.
+final _statePrefix = RegExp(r'(?:^|[^A-Za-z0-9_$])State<\s*$');
+
+/// The `>` that closes a single `State<…>` type argument.
+final _stateSuffix = RegExp(r'^\s*>');
+
+/// Flutter `StatefulWidget`/`State` conventions: recognizing the `State<Widget>`
+/// pairing (so it isn't mistaken for an external use of the widget), and
+/// coupling a dead widget's private `State` subclass to the widget's removal.
+extension FlutterWidgets on SourceIndex {
+  /// Whether [loc] is the class name [className] appearing as the sole type
+  /// argument of `State<…>`, e.g. `class _FooState extends State<Foo>`.
+  ///
+  /// `State<Foo>` can only ever denote the state object of the `Foo` widget, so
+  /// it never means `Foo` itself is used elsewhere.
+  bool isStatePairingReference(String className, Location loc) {
+    final start = loc.range.start;
+    final end = loc.range.end;
+    if (start.line != end.line) {
+      return false;
+    }
+    final fileLines = lines(SourceIndex.pathOf(loc.uri));
+    if (start.line < 0 || start.line >= fileLines.length) {
+      return false;
+    }
+    final line = fileLines[start.line];
+    if (start.character < 0 ||
+        end.character > line.length ||
+        start.character > end.character) {
+      return false;
+    }
+    if (line.substring(start.character, end.character) != className) {
+      return false;
+    }
+    return _statePrefix.hasMatch(line.substring(0, start.character)) &&
+        _stateSuffix.hasMatch(line.substring(end.character));
+  }
+
+  /// The extra spans to remove alongside a dead [widget] class: the paired
+  /// private `State<Widget>` subclass, when there is exactly one and it is used
+  /// only from within the widget (via `createState`). Returns an empty list for
+  /// a plain class, or a StatefulWidget whose State is referenced elsewhere.
+  ///
+  /// Removing the widget on its own would leave
+  /// `class _S extends State<Widget>` referring to a now-deleted type — a build
+  /// break — so the State is coupled to the widget's removal, but it is not
+  /// itself reported.
+  List<CoupledRemoval> pairedStateRemovals(
+    Candidate widget,
+    List<Location> widgetRefs,
+    List<Candidate> candidates,
+    List<List<Location>> refsByCandidate,
+    String rootPath,
+  ) {
+    final out = <CoupledRemoval>[];
+    for (final loc in widgetRefs) {
+      if (!isStatePairingReference(widget.symbol.name, loc) ||
+          SourceIndex.pathOf(loc.uri) != widget.path) {
+        continue;
+      }
+      // The widget's own `createState` return type is inside the widget and
+      // removed with it; only a pairing reference outside the widget points at
+      // the separate State subclass.
+      if (loc.range.start.within(widget.symbol)) {
+        continue;
+      }
+      for (var j = 0; j < candidates.length; j++) {
+        final state = candidates[j];
+        if (state.symbol.kind != .class$ ||
+            state.path != widget.path ||
+            identical(state, widget) ||
+            !loc.range.start.within(state.symbol)) {
+          continue;
+        }
+        if (_referencedOnlyWithin(
+          refsByCandidate[j],
+          widget.symbol,
+          widget.path,
+        )) {
+          out.add((
+            filePath: relativePosix(state.path, rootPath),
+            range: state.symbol.declarationRange,
+          ));
+        }
+        break;
+      }
+    }
+    return out;
+  }
+
+  /// Whether every *code* reference in [refs] lies within [enclosing] in [path]
+  /// — used to confirm a paired State subclass is reachable only from its
+  /// widget. Doc-comment links are ignored: documentation never keeps code
+  /// alive, so it must not block coupling.
+  bool _referencedOnlyWithin(
+    List<Location> refs,
+    DocumentSymbol enclosing,
+    String path,
+  ) => refs.every(
+    (loc) =>
+        isDocReference(loc) ||
+        (SourceIndex.pathOf(loc.uri) == path &&
+            loc.range.start.within(enclosing)),
+  );
+}

--- a/lib/src/conventions/freezed.dart
+++ b/lib/src/conventions/freezed.dart
@@ -1,0 +1,79 @@
+/*
+ * AI-Provenance:
+ *   model: claude-opus-4-8
+ *   harness: Claude Code
+ *   plugins:
+ *     - lean-ai-provenance
+ *   skills:
+ *     - mark-ai-provenance
+ */
+
+import 'package:ciach/src/candidates.dart';
+import 'package:ciach/src/source_index.dart';
+import 'package:ciach/src/symbols.dart';
+import 'package:ciach/src/syntax_rules.dart';
+import 'package:pro_lsp/pro_lsp.dart' show DocumentSymbol;
+
+/// `freezed` union conventions.
+///
+/// A `@freezed`/`@Freezed` union's redirecting-factory arms are constructed
+/// only by the generated `fromJson`, never hand-called, so a reference search
+/// sees them as unused. This tracks which classes carry the annotation (fed in
+/// during candidate collection) and, given a union whose `fromJson` is used,
+/// treats those arms as live rather than dead.
+class FreezedUnions {
+  /// Keys `(path, class name)` of classes annotated `@freezed`/`@Freezed`.
+  final _annotatedClasses = <DeclKey>{};
+
+  static final _annotation = RegExp(r'@(?:freezed|Freezed)\b');
+
+  /// Records [symbol] as freezed-annotated when it is a type whose leading
+  /// metadata carries `@freezed`/`@Freezed`. Called for every symbol during
+  /// candidate collection.
+  void noteIfAnnotated(String path, DocumentSymbol symbol, List<String> lines) {
+    if (typeLikeKinds.contains(symbol.kind) &&
+        _annotation.hasMatch(symbol.leadingMetadata(lines))) {
+      _annotatedClasses.add(DeclKey(path, symbol.name));
+    }
+  }
+
+  /// Indices into [candidates] of redirecting-factory arms of a `@freezed`/
+  /// `@Freezed` union with a referenced `fromJson` — live serialization members
+  /// that read as unused. Conservative: never-dispatched arms are kept too,
+  /// being statically indistinguishable from live ones.
+  Set<int> deserializationOnlyArms(
+    List<Candidate> candidates,
+    List<RefStatus> statuses,
+    SourceIndex sources,
+  ) {
+    final unionsWithUsedFromJson = <DeclKey>{};
+    for (var i = 0; i < candidates.length; i++) {
+      final c = candidates[i];
+      if (c.symbol.kind == .constructor &&
+          statuses[i] == .used &&
+          c.symbol.declarationName(c.container) == 'fromJson') {
+        if (c.containerKey case final key?) {
+          unionsWithUsedFromJson.add(key);
+        }
+      }
+    }
+
+    final arms = <int>{};
+    for (var i = 0; i < candidates.length; i++) {
+      if (statuses[i] != .unused) {
+        continue;
+      }
+      final c = candidates[i];
+      if (c.symbol.kind != .constructor) {
+        continue;
+      }
+      if (c.containerKey case final key?
+          when _annotatedClasses.contains(key) &&
+              unionsWithUsedFromJson.contains(key) &&
+              sources.isRedirectingFactory(c)) {
+        arms.add(i);
+      }
+    }
+    return arms;
+  }
+}

--- a/lib/src/conventions/serialization.dart
+++ b/lib/src/conventions/serialization.dart
@@ -1,0 +1,45 @@
+/*
+ * AI-Provenance:
+ *   model: claude-opus-4-8
+ *   harness: Claude Code
+ *   plugins:
+ *     - lean-ai-provenance
+ *   skills:
+ *     - mark-ai-provenance
+ */
+
+import 'package:ciach/src/candidates.dart';
+import 'package:ciach/src/source_index.dart';
+import 'package:ciach/src/symbols.dart';
+
+/// A JSON-value return type on a `toJson`'s declaration line, before the name.
+final _toJsonJsonReturn = RegExp(
+  r'\b(?:Map|List|String|int|double|num|bool|Object|dynamic)\b\s*(?:<[^;{]*>)?\s*\??\s*$',
+);
+
+/// `json_serializable`/hand-rolled JSON serialization conventions.
+extension SerializationHooks on SourceIndex {
+  /// Whether [candidate] is a `toJson()` serialization hook — a
+  /// zero-required-arg method named `toJson` returning any JSON value
+  /// (`Map`/`List`/`String`/`num`/`int`/`double`/`bool`, or `Object`/`dynamic`).
+  /// `jsonEncode(obj)` dispatches to it dynamically with no source-level
+  /// `.toJson()` token, so the reference search can't see that use; exempt it
+  /// for any class, annotated or not.
+  bool isToJsonHook(Candidate candidate) {
+    final symbol = candidate.symbol;
+    if (symbol.kind != .method ||
+        symbol.name != 'toJson' ||
+        !symbol.hasNoParameters) {
+      return false;
+    }
+    final fileLines = lines(candidate.path);
+    final line = symbol.selectionRange.start.line;
+    if (line < 0 || line >= fileLines.length) {
+      return false;
+    }
+    final col = symbol.selectionRange.start.character;
+    final text = fileLines[line];
+    final beforeName = col <= text.length ? text.substring(0, col) : text;
+    return _toJsonJsonReturn.hasMatch(beforeName);
+  }
+}

--- a/lib/src/finder.dart
+++ b/lib/src/finder.dart
@@ -13,12 +13,17 @@ import 'dart:io';
 
 import 'package:ciach/src/candidates.dart';
 import 'package:ciach/src/concurrency.dart';
+import 'package:ciach/src/conventions/flutter_widgets.dart';
+import 'package:ciach/src/conventions/freezed.dart';
+import 'package:ciach/src/conventions/serialization.dart';
 import 'package:ciach/src/file_discovery.dart';
 import 'package:ciach/src/lsp/lsp_client.dart';
 import 'package:ciach/src/models.dart';
+import 'package:ciach/src/paths.dart';
+import 'package:ciach/src/reference_classifier.dart';
+import 'package:ciach/src/remove_safety.dart';
 import 'package:ciach/src/source_index.dart';
 import 'package:ciach/src/symbols.dart';
-import 'package:ciach/src/syntax_rules.dart';
 import 'package:path/path.dart' as p;
 import 'package:pro_lsp/pro_lsp.dart' show DocumentSymbol, Location;
 
@@ -28,6 +33,12 @@ import 'package:pro_lsp/pro_lsp.dart' show DocumentSymbol, Location;
 /// For every declaration reported by `textDocument/documentSymbol`, a
 /// `textDocument/references` query is issued at the declaration's name, with
 /// `includeDeclaration: false`. An empty result means the declaration is unused.
+///
+/// `Ciach` owns the pipeline (discover → collect → check references → report);
+/// the semantic pieces live in collaborators: [ReferenceClassifier] decides
+/// used/unused, [RemoveSafety] flags findings that can't be auto-removed, and
+/// the `conventions/` rules ([FreezedUnions], serialization and Flutter
+/// widgets) keep framework-driven declarations alive.
 class Ciach {
   /// Creates a finder that runs with the given [options].
   Ciach(this.options);
@@ -39,22 +50,13 @@ class Ciach {
   /// shared by the classification and the structural detectors.
   final _sources = SourceIndex();
 
-  /// Keys `(path, class name)` of classes annotated `@freezed`/`@Freezed`.
-  final _freezedAnnotatedClasses = <DeclKey>{};
+  /// Freezed-union tracking, fed as candidates are collected.
+  final _freezed = FreezedUnions();
 
-  static final _freezedAnnotation = RegExp(r'@(?:freezed|Freezed)\b');
-
-  /// A JSON-value return type on a `toJson`'s declaration line, before the name.
-  static final _toJsonJsonReturn = RegExp(
-    r'\b(?:Map|List|String|int|double|num|bool|Object|dynamic)\b\s*(?:<[^;{]*>)?\s*\??\s*$',
+  late final _classifier = ReferenceClassifier(
+    _sources,
+    unusedUnionMembers: options.unusedUnionMembers,
   );
-
-  /// The `State<` immediately preceding a type argument, with a token boundary
-  /// before `State` so `MyState<…>`/`FooState<…>` don't match.
-  static final _statePrefix = RegExp(r'(?:^|[^A-Za-z0-9_$])State<\s*$');
-
-  /// The `>` that closes a single `State<…>` type argument.
-  static final _stateSuffix = RegExp(r'^\s*>');
 
   /// Advisory note attached to a sole, zero-parameter private constructor
   /// (`Foo._();`) — the classic prevent-instantiation marker. Such a
@@ -130,43 +132,24 @@ class Ciach {
       // and a line is emitted as soon as its last declaration is checked. Files
       // with no candidates are already counted as done.
       _report('Checking references for $declarationsChecked declaration(s)…');
-      final remainingPerFile = <String, int>{};
-      for (final candidate in candidates) {
-        remainingPerFile.update(
-          candidate.path,
-          (n) => n + 1,
-          ifAbsent: () => 1,
-        );
-      }
-      final totalFiles = files.length;
-      var filesDone = totalFiles - remainingPerFile.length;
-
-      final refsByCandidate = await mapPooled(candidates, options.concurrency, (
-        candidate,
-      ) async {
-        final refs = await client.references(
-          candidate.uri,
-          candidate.symbol.selectionRange.start,
-        );
-        if (remainingPerFile.update(candidate.path, (n) => n - 1) == 0) {
-          filesDone++;
-          _report(
-            '[$filesDone/$totalFiles] '
-            '${p.relative(candidate.path, from: rootPath)}',
-          );
-        }
-        return refs;
-      });
+      final refsByCandidate = await _checkReferences(
+        client,
+        candidates,
+        files.length,
+        rootPath,
+      );
 
       final statuses = [
         for (var i = 0; i < candidates.length; i++)
-          _classify(candidates[i], refsByCandidate[i]),
+          _classifier.classify(candidates[i], refsByCandidate[i]),
       ];
 
-      // A deser-only union arm reads zero references but is a live serialization member.
-      final freezedUnionArms = _freezedDeserializedUnionArms(
+      // A deser-only union arm reads zero references but is a live serialization
+      // member.
+      final freezedUnionArms = _freezed.deserializationOnlyArms(
         candidates,
         statuses,
+        _sources,
       );
 
       // Names of classes flagged unused, per file. A whole dead class is
@@ -182,8 +165,8 @@ class Ciach {
         }
       }
 
-      final safety = _RemoveSafety.analyze(
-        this,
+      final safety = RemoveSafety.analyze(
+        _sources,
         candidates,
         statuses,
         refsByCandidate,
@@ -195,63 +178,30 @@ class Ciach {
         final refs = refsByCandidate[i];
         switch (statuses[i]) {
           case .unused:
-            if (freezedUnionArms.contains(i)) {
-              break;
-            }
-            if (!options.reportToJson && _isToJsonHook(candidate)) {
-              break;
-            }
-            if (_isConstructorOfDeadClass(candidate, deadClassNames)) {
-              break;
-            }
-            final containerKey = candidate.containerKey;
-            // An enum value reached only through `.values` iteration is used,
-            // not dead: suppress it entirely (never reported) rather than
-            // flagging it for the empty-enum guard.
-            if (candidate.isEnumValue &&
-                containerKey != null &&
-                safety.enumValuesIterated.contains(containerKey)) {
+            if (_isSuppressed(
+              candidate,
+              i,
+              freezedUnionArms,
+              deadClassNames,
+              safety,
+            )) {
               break;
             }
             final isClass = candidate.symbol.kind == .class$;
-            final paired = isClass
-                ? _pairedStateRemovals(
-                    candidate,
-                    refs,
-                    candidates,
-                    refsByCandidate,
-                    rootPath,
-                  )
-                : const <CoupledRemoval>[];
-            // A finding is report-only (removalBlocked) when auto-removing it
-            // would break the build:
-            //
-            // * a class kept dead only by type patterns under
-            //   --unused-union-members (never constructed, only matched):
-            //   deleting a sealed member and its scattered `case`s is a source
-            //   rewrite this tool won't attempt;
-            // * an enum value whose removal would empty a still-referenced enum;
-            // * the last constructor of a live class with `final` fields or
-            //   super-constructor forwarding.
-            //
-            // Each is surfaced so a human can act on it, but the remover leaves
-            // it — and anything coupled to it — entirely alone.
-            final removalBlocked =
-                (isClass &&
-                    options.unusedUnionMembers &&
-                    _isPatternMatchedClass(candidate, refs)) ||
-                (candidate.isEnumValue &&
-                    containerKey != null &&
-                    safety.emptiedEnums.contains(containerKey)) ||
-                (candidate.symbol.kind == .constructor &&
-                    containerKey != null &&
-                    safety.blockedCtorClasses.contains(containerKey));
             unused.add(
               _toUnused(
                 candidate,
                 rootPath,
-                coupledRemovals: paired,
-                removalBlocked: removalBlocked,
+                coupledRemovals: isClass
+                    ? _sources.pairedStateRemovals(
+                        candidate,
+                        refs,
+                        candidates,
+                        refsByCandidate,
+                        rootPath,
+                      )
+                    : const [],
+                removalBlocked: _isRemovalBlocked(candidate, refs, safety),
                 // A sole, zero-parameter private constructor is dead code like
                 // any other, but nudge toward `abstract final class`.
                 hint: candidate.isPreventInstantiationCtor
@@ -279,6 +229,91 @@ class Ciach {
       declarationsChecked: declarationsChecked,
       elapsed: stopwatch.elapsed,
     );
+  }
+
+  /// Queries `textDocument/references` for every candidate through one global
+  /// pool, reporting `[done/total]` progress as each file's last query lands.
+  Future<List<List<Location>>> _checkReferences(
+    LspClient client,
+    List<Candidate> candidates,
+    int totalFiles,
+    String rootPath,
+  ) {
+    final remainingPerFile = <String, int>{};
+    for (final candidate in candidates) {
+      remainingPerFile.update(candidate.path, (n) => n + 1, ifAbsent: () => 1);
+    }
+    var filesDone = totalFiles - remainingPerFile.length;
+
+    return mapPooled(candidates, options.concurrency, (candidate) async {
+      final refs = await client.references(
+        candidate.uri,
+        candidate.symbol.selectionRange.start,
+      );
+      if (remainingPerFile.update(candidate.path, (n) => n - 1) == 0) {
+        filesDone++;
+        _report(
+          '[$filesDone/$totalFiles] '
+          '${p.relative(candidate.path, from: rootPath)}',
+        );
+      }
+      return refs;
+    });
+  }
+
+  /// Whether an unused [candidate] should be silently suppressed (never
+  /// reported): a live freezed-union arm, an exempt `toJson` hook, a
+  /// constructor removed with its already-dead class, or an enum value reached
+  /// only through `.values` iteration.
+  bool _isSuppressed(
+    Candidate candidate,
+    int index,
+    Set<int> freezedUnionArms,
+    Map<String, Set<String>> deadClassNames,
+    RemoveSafety safety,
+  ) {
+    if (freezedUnionArms.contains(index)) {
+      return true;
+    }
+    if (!options.reportToJson && _sources.isToJsonHook(candidate)) {
+      return true;
+    }
+    if (_isConstructorOfDeadClass(candidate, deadClassNames)) {
+      return true;
+    }
+    final containerKey = candidate.containerKey;
+    return candidate.isEnumValue &&
+        containerKey != null &&
+        safety.enumValuesIterated.contains(containerKey);
+  }
+
+  /// Whether a dead [candidate] is real but must *not* be auto-removed, because
+  /// doing so would break the build:
+  ///
+  /// * a class kept dead only by type patterns under `--unused-union-members`
+  ///   (never constructed, only matched): deleting a sealed member and its
+  ///   scattered `case`s is a source rewrite this tool won't attempt;
+  /// * an enum value whose removal would empty a still-referenced enum;
+  /// * the last constructor of a live class with `final` fields or
+  ///   super-constructor forwarding.
+  ///
+  /// Each is surfaced so a human can act on it, but the remover leaves it — and
+  /// anything coupled to it — entirely alone.
+  bool _isRemovalBlocked(
+    Candidate candidate,
+    List<Location> refs,
+    RemoveSafety safety,
+  ) {
+    final containerKey = candidate.containerKey;
+    return (candidate.symbol.kind == .class$ &&
+            options.unusedUnionMembers &&
+            _classifier.isPatternMatchedClass(candidate, refs)) ||
+        (candidate.isEnumValue &&
+            containerKey != null &&
+            safety.emptiedEnums.contains(containerKey)) ||
+        (candidate.symbol.kind == .constructor &&
+            containerKey != null &&
+            safety.blockedCtorClasses.contains(containerKey));
   }
 
   /// Opens [path] in the analysis server without collecting candidates from
@@ -335,10 +370,7 @@ class Ciach {
     List<Candidate> out,
   ) {
     for (final symbol in symbols) {
-      if (typeLikeKinds.contains(symbol.kind) &&
-          _freezedAnnotation.hasMatch(symbol.leadingMetadata(lines))) {
-        _freezedAnnotatedClasses.add(DeclKey(path, symbol.name));
-      }
+      _freezed.noteIfAnnotated(path, symbol, lines);
       if (_shouldConsider(symbol, parentIsEnum, lines)) {
         out.add(
           Candidate(
@@ -421,7 +453,7 @@ class Ciach {
     return .new(
       name: name,
       kind: symbol.reportedKind(parentIsEnum: candidate.isEnumValue),
-      filePath: _relPath(candidate.path, rootPath),
+      filePath: relativePosix(candidate.path, rootPath),
       // LSP positions are zero-based; report them one-based for humans.
       line: start.line + 1,
       column: start.character + 1,
@@ -435,277 +467,12 @@ class Ciach {
     );
   }
 
-  /// Classifies a candidate from the references reported for it.
-  ///
-  /// Non-class candidates keep the simple rule: any real (non-doc) reference
-  /// means used, only doc-comment links means doc-only, none means unused.
-  ///
-  /// Classes get [_classifyClass], which discounts *self-references* — the
-  /// class's own body, and the `State<Self>` StatefulWidget pairing — so a
-  /// class kept alive only by its own unnamed constructor's declaration (whose
-  /// name coincides with the class) is correctly seen as dead.
-  RefStatus _classify(Candidate candidate, List<Location> refs) {
-    if (candidate.symbol.kind == .class$) {
-      return _classifyClass(candidate, refs);
-    }
-    if (refs.isEmpty) {
-      return .unused;
-    }
-    return refs.any((loc) => !_isDocReference(loc)) ? .used : .docOnly;
-  }
-
-  /// Classifies a class by its references, ignoring self-references.
-  ///
-  /// A class is used only if some reference is a real (non-doc) reference from
-  /// *outside* the class itself; if the only outside references are doc-comment
-  /// links it is doc-only, and otherwise (only self-references, or none at all)
-  /// it is unused. This is deliberately conservative: any single unexplained
-  /// outside reference keeps the class alive, so the failure mode is missing a
-  /// dead class, never deleting a live one.
-  RefStatus _classifyClass(Candidate candidate, List<Location> refs) {
-    var hasExternalDoc = false;
-    var hasPatternMatch = false;
-    for (final loc in refs) {
-      if (_isSelfClassReference(candidate, loc)) {
-        continue;
-      }
-      if (_isDocReference(loc)) {
-        hasExternalDoc = true;
-        continue;
-      }
-      // With --unused-union-members, a reference that is confidently a *type
-      // pattern* (a `case`/if-case/while-case pattern, or a switch-expression
-      // arm) is a *match*, not a construction: if the type is never
-      // constructed, no such match can ever fire, so it is discounted like a
-      // self-reference. Any reference that is not confidently a type pattern
-      // keeps the class alive — the conservative choice (nested sub-patterns
-      // and pattern-variable declarations are intentionally not recognized).
-      if (options.unusedUnionMembers && _sources.isPatternRef(loc)) {
-        hasPatternMatch = true;
-        continue;
-      }
-      // A real, non-pattern reference from outside: the class is used.
-      return .used;
-    }
-    // Matched-only-by-a-pattern (never constructed) is dead code, not a softer
-    // doc-only report.
-    if (hasPatternMatch) {
-      return .unused;
-    }
-    return hasExternalDoc ? .docOnly : .unused;
-  }
-
-  /// Whether [location] points at a dartdoc `[Xxx]`-style reference rather than
-  /// real code — i.e. its line, in the file it points into, starts with `///`.
-  /// Block (`/** */`) doc comments aren't recognized; `///` is the standard and
-  /// lint-enforced style.
-  bool _isDocReference(Location location) {
-    final lines = _sources.lines(SourceIndex.pathOf(location.uri));
-    final line = location.range.start.line;
-    if (line < 0 || line >= lines.length) {
-      return false;
-    }
-    return lines[line].trim().startsWith('///');
-  }
-
-  /// Whether [loc] is a reference to [candidate] that does not count as a use.
-  ///
-  /// Two shapes qualify:
-  ///
-  /// 1. A reference inside the class's own source span — its body, signature,
-  ///    or leading doc/annotation lines. This covers the unnamed constructor's
-  ///    declaration, a `State<Foo>` return type on the widget's own
-  ///    `createState`, and any purely-internal self-use.
-  /// 2. A `State<Foo>` type-argument reference anywhere — the StatefulWidget
-  ///    pairing. `State<Foo>` can only ever denote the state object of the
-  ///    `Foo` widget, so it never means `Foo` itself is used elsewhere.
-  bool _isSelfClassReference(Candidate candidate, Location loc) {
-    if (SourceIndex.pathOf(loc.uri) == candidate.path) {
-      final top = candidate.symbol.metadataTopLine(
-        _sources.lines(candidate.path),
-      );
-      final pos = loc.range.start;
-      if (pos.line >= top && pos.atOrBefore(candidate.symbol.range.end)) {
-        return true;
-      }
-    }
-    return _isStatePairingReference(candidate.symbol.name, loc);
-  }
-
-  /// Whether [loc] is the class name [className] appearing as the sole type
-  /// argument of `State<…>`, e.g. `class _FooState extends State<Foo>`.
-  bool _isStatePairingReference(String className, Location loc) {
-    final start = loc.range.start;
-    final end = loc.range.end;
-    if (start.line != end.line) {
-      return false;
-    }
-    final lines = _sources.lines(SourceIndex.pathOf(loc.uri));
-    if (start.line < 0 || start.line >= lines.length) {
-      return false;
-    }
-    final line = lines[start.line];
-    if (start.character < 0 ||
-        end.character > line.length ||
-        start.character > end.character) {
-      return false;
-    }
-    if (line.substring(start.character, end.character) != className) {
-      return false;
-    }
-    return _statePrefix.hasMatch(line.substring(0, start.character)) &&
-        _stateSuffix.hasMatch(line.substring(end.character));
-  }
-
   bool _isConstructorOfDeadClass(
     Candidate candidate,
     Map<String, Set<String>> deadClassNames,
   ) =>
       candidate.symbol.kind == .constructor &&
       (deadClassNames[candidate.path]?.contains(candidate.container) ?? false);
-
-  /// Whether [candidate] is a `toJson()` serialization hook — a zero-required-arg
-  /// method named `toJson` returning any JSON value (`Map`/`List`/`String`/`num`/
-  /// `int`/`double`/`bool`, or `Object`/`dynamic`). `jsonEncode(obj)` dispatches to
-  /// it dynamically with no source-level `.toJson()` token, so the reference search
-  /// can't see that use; exempt it for any class, annotated or not.
-  bool _isToJsonHook(Candidate candidate) {
-    final symbol = candidate.symbol;
-    if (symbol.kind != .method ||
-        symbol.name != 'toJson' ||
-        !symbol.hasNoParameters) {
-      return false;
-    }
-    final lines = _sources.lines(candidate.path);
-    final line = symbol.selectionRange.start.line;
-    if (line < 0 || line >= lines.length) {
-      return false;
-    }
-    final col = symbol.selectionRange.start.character;
-    final text = lines[line];
-    final beforeName = col <= text.length ? text.substring(0, col) : text;
-    return _toJsonJsonReturn.hasMatch(beforeName);
-  }
-
-  /// Redirecting-factory arms of a `@freezed`/`@Freezed` union with a referenced
-  /// `fromJson`; conservative — never-dispatched arms are kept too, being
-  /// statically indistinguishable.
-  Set<int> _freezedDeserializedUnionArms(
-    List<Candidate> candidates,
-    List<RefStatus> statuses,
-  ) {
-    final unionsWithUsedFromJson = <DeclKey>{};
-    for (var i = 0; i < candidates.length; i++) {
-      final c = candidates[i];
-      if (c.symbol.kind == .constructor &&
-          statuses[i] == .used &&
-          c.symbol.declarationName(c.container) == 'fromJson') {
-        if (c.containerKey case final key?) {
-          unionsWithUsedFromJson.add(key);
-        }
-      }
-    }
-
-    final arms = <int>{};
-    for (var i = 0; i < candidates.length; i++) {
-      if (statuses[i] != .unused) {
-        continue;
-      }
-      final c = candidates[i];
-      if (c.symbol.kind != .constructor) {
-        continue;
-      }
-      if (c.containerKey case final key?
-          when _freezedAnnotatedClasses.contains(key) &&
-              unionsWithUsedFromJson.contains(key) &&
-              _sources.isRedirectingFactory(c)) {
-        arms.add(i);
-      }
-    }
-    return arms;
-  }
-
-  /// The extra spans to remove alongside a dead [widget] class: the paired
-  /// private `State<Widget>` subclass, when there is exactly one and it is used
-  /// only from within the widget (via `createState`). Returns an empty list for
-  /// a plain class, or a StatefulWidget whose State is referenced elsewhere.
-  ///
-  /// Removing the widget on its own would leave
-  /// `class _S extends State<Widget>` referring to a now-deleted type — a build
-  /// break — so the State is coupled to the widget's removal, but it is not
-  /// itself reported.
-  List<CoupledRemoval> _pairedStateRemovals(
-    Candidate widget,
-    List<Location> widgetRefs,
-    List<Candidate> candidates,
-    List<List<Location>> refsByCandidate,
-    String rootPath,
-  ) {
-    final out = <CoupledRemoval>[];
-    for (final loc in widgetRefs) {
-      if (!_isStatePairingReference(widget.symbol.name, loc) ||
-          SourceIndex.pathOf(loc.uri) != widget.path) {
-        continue;
-      }
-      // The widget's own `createState` return type is inside the widget and
-      // removed with it; only a pairing reference outside the widget points at
-      // the separate State subclass.
-      if (loc.range.start.within(widget.symbol)) {
-        continue;
-      }
-      for (var j = 0; j < candidates.length; j++) {
-        final state = candidates[j];
-        if (state.symbol.kind != .class$ ||
-            state.path != widget.path ||
-            identical(state, widget) ||
-            !loc.range.start.within(state.symbol)) {
-          continue;
-        }
-        if (_referencedOnlyWithin(
-          refsByCandidate[j],
-          widget.symbol,
-          widget.path,
-        )) {
-          out.add((
-            filePath: _relPath(state.path, rootPath),
-            range: state.symbol.declarationRange,
-          ));
-        }
-        break;
-      }
-    }
-    return out;
-  }
-
-  /// Whether every *code* reference in [refs] lies within [enclosing] in
-  /// [path] — used to confirm a paired State subclass is reachable only from
-  /// its widget. Doc-comment links are ignored: documentation never keeps code
-  /// alive, so it must not block coupling.
-  bool _referencedOnlyWithin(
-    List<Location> refs,
-    DocumentSymbol enclosing,
-    String path,
-  ) => refs.every(
-    (loc) =>
-        _isDocReference(loc) ||
-        (SourceIndex.pathOf(loc.uri) == path &&
-            loc.range.start.within(enclosing)),
-  );
-
-  /// Whether [candidate] — already classified as unused under
-  /// `--unused-union-members` — is kept dead by *type patterns*: at least one
-  /// of its non-self, non-doc references is a `case`/switch-expression pattern
-  /// match rather than a construction.
-  bool _isPatternMatchedClass(Candidate candidate, List<Location> refs) =>
-      refs.any(
-        (loc) =>
-            !_isSelfClassReference(candidate, loc) &&
-            !_isDocReference(loc) &&
-            _sources.isPatternRef(loc),
-      );
-
-  String _relPath(String absPath, String rootPath) =>
-      p.split(p.relative(absPath, from: rootPath)).join('/');
 
   static int _byLocation(UnusedDeclaration a, UnusedDeclaration b) {
     final byFile = a.filePath.compareTo(b.filePath);
@@ -715,117 +482,4 @@ class Ciach {
     final byLine = a.line.compareTo(b.line);
     return byLine != 0 ? byLine : a.column.compareTo(b.column);
   }
-}
-
-/// The remove-safety pre-pass: facts gathered up front so the reporting loop
-/// stays a set of cheap lookups when deciding which findings are report-only
-/// (`removalBlocked`) because auto-removing them would break the build.
-///
-/// * [emptiedEnums] — enums every one of whose values would be removed while
-///   the enum type is still referenced, leaving `enum E {}` (a compile error).
-/// * [blockedCtorClasses] — live classes all of whose constructors are dead:
-///   removing them synthesizes an implicit default constructor that strands
-///   `final` fields or breaks super-constructor forwarding.
-/// * [enumValuesIterated] — enums whose values are all reachable through
-///   `.values` iteration, so a value reached only that way is used, not dead,
-///   and is suppressed entirely rather than reported.
-class _RemoveSafety {
-  const _RemoveSafety({
-    required this.emptiedEnums,
-    required this.blockedCtorClasses,
-    required this.enumValuesIterated,
-  });
-
-  factory _RemoveSafety.analyze(
-    Ciach finder,
-    List<Candidate> candidates,
-    List<RefStatus> statuses,
-    List<List<Location>> refsByCandidate,
-    Map<String, Set<String>> deadClassNames,
-  ) {
-    final sources = finder._sources;
-    final enumTypeHasRef = <DeclKey, bool>{};
-    final enumValueTotal = <DeclKey, int>{};
-    final enumValueDead = <DeclKey, int>{};
-    final enumValuesIterated = <DeclKey>{};
-    final ctorTotal = <DeclKey, int>{};
-    final ctorDead = <DeclKey, int>{};
-    final ctorForwardsSuper = <DeclKey, bool>{};
-    final classByKey = <DeclKey, Candidate>{};
-
-    for (var i = 0; i < candidates.length; i++) {
-      final candidate = candidates[i];
-      final symbol = candidate.symbol;
-      final unused = statuses[i] == .unused;
-      if (symbol.kind == .enum$ && !candidate.isEnumValue) {
-        enumTypeHasRef[candidate.key] = refsByCandidate[i].isNotEmpty;
-        if (refsByCandidate[i].any(sources.isDotValuesRef) ||
-            sources.enumIteratesOwnValues(candidate)) {
-          enumValuesIterated.add(candidate.key);
-        }
-      } else if (candidate.isEnumValue) {
-        if (candidate.containerKey case final key?) {
-          enumValueTotal.update(key, (n) => n + 1, ifAbsent: () => 1);
-          if (unused) {
-            enumValueDead.update(key, (n) => n + 1, ifAbsent: () => 1);
-          }
-        }
-      } else if (symbol.kind == .class$) {
-        classByKey[candidate.key] = candidate;
-      } else if (symbol.kind == .constructor) {
-        if (candidate.containerKey case final key?) {
-          ctorTotal.update(key, (n) => n + 1, ifAbsent: () => 1);
-          if (unused) {
-            ctorDead.update(key, (n) => n + 1, ifAbsent: () => 1);
-            if (sources.ctorForwardsSuper(candidate)) {
-              ctorForwardsSuper[key] = true;
-            }
-          }
-        }
-      }
-    }
-
-    final emptiedEnums = <DeclKey>{};
-    for (final MapEntry(:key, value: total) in enumValueTotal.entries) {
-      final dead = enumValueDead[key] ?? 0;
-      if (dead == 0 || dead != total) {
-        continue;
-      }
-      // Conservative: if the enum-type candidate is missing we cannot prove the
-      // enum is itself being removed, so assume it stays and block.
-      if (enumTypeHasRef[key] ?? true) {
-        emptiedEnums.add(key);
-      }
-    }
-
-    final blockedCtorClasses = <DeclKey>{};
-    for (final MapEntry(:key, value: total) in ctorTotal.entries) {
-      final dead = ctorDead[key] ?? 0;
-      if (dead == 0 || dead != total) {
-        continue;
-      }
-      // A dead class is removed whole (its constructors go with it), so its
-      // constructors are never reported on their own — nothing to guard.
-      if (deadClassNames[key.path]?.contains(key.name) ?? false) {
-        continue;
-      }
-      final classCandidate = classByKey[key];
-      final hasFinalField =
-          classCandidate != null &&
-          sources.classHasFinalInstanceField(classCandidate);
-      if (hasFinalField || (ctorForwardsSuper[key] ?? false)) {
-        blockedCtorClasses.add(key);
-      }
-    }
-
-    return _RemoveSafety(
-      emptiedEnums: emptiedEnums,
-      blockedCtorClasses: blockedCtorClasses,
-      enumValuesIterated: enumValuesIterated,
-    );
-  }
-
-  final Set<DeclKey> emptiedEnums;
-  final Set<DeclKey> blockedCtorClasses;
-  final Set<DeclKey> enumValuesIterated;
 }

--- a/lib/src/finder.dart
+++ b/lib/src/finder.dart
@@ -11,46 +11,16 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:ciach/src/candidates.dart';
+import 'package:ciach/src/concurrency.dart';
 import 'package:ciach/src/file_discovery.dart';
 import 'package:ciach/src/lsp/lsp_client.dart';
 import 'package:ciach/src/models.dart';
+import 'package:ciach/src/source_index.dart';
+import 'package:ciach/src/symbols.dart';
+import 'package:ciach/src/syntax_rules.dart';
 import 'package:path/path.dart' as p;
-import 'package:pro_lsp/pro_lsp.dart'
-    show DocumentSymbol, Location, Position, SymbolKind;
-
-/// A declaration to check: the symbol plus enough context to query references
-/// for it and to report it later.
-typedef _Candidate = ({
-  Uri uri,
-  String path,
-  DocumentSymbol symbol,
-  String? container,
-  bool isEnumValue,
-  bool isPreventInstantiationCtor,
-});
-
-/// How a candidate's references classify it.
-enum _RefStatus {
-  /// At least one real (non-doc-comment) reference.
-  used,
-
-  /// No real references, but at least one dartdoc `[Xxx]` comment link.
-  docOnly,
-
-  /// No references of any kind.
-  unused,
-}
-
-/// A minimal lexical token: a source span plus whether it is an identifier /
-/// keyword (`isWord`) or a single punctuation character. Whitespace, comments,
-/// and string literals are dropped during tokenization, so `case`/`default`
-/// keywords and brackets can be matched without tripping over a `case` that
-/// only appears inside a comment or string.
-typedef _Token = ({int start, int end, bool isWord, String value});
-
-/// A file path paired with a declaration name, used as a map key to look up
-/// per-declaration facts gathered by the remove-safety pre-pass.
-typedef _DeclKey = ({String path, String name});
+import 'package:pro_lsp/pro_lsp.dart' show DocumentSymbol, Location;
 
 /// Finds declarations that are never referenced by driving the Dart analysis
 /// server over LSP.
@@ -65,118 +35,12 @@ class Ciach {
   /// The configuration for this run.
   final FinderOptions options;
 
-  /// Symbol kinds that introduce a lexical scope; their name becomes the
-  /// container for nested members.
-  static const _typeLikeKinds = <SymbolKind>{
-    .class$,
-    .interface$,
-    .enum$,
-    .struct,
-  };
-
-  /// Names of Dart's overloadable operators. The analysis server reports an
-  /// `operator +`/`operator ==`/… declaration as a plain [SymbolKind.method]
-  /// named exactly one of these — there is no distinct operator symbol kind —
-  /// so this is the only reliable way to recognize one.
-  static const _operatorNames = <String>{
-    '+',
-    '-',
-    '*',
-    '/',
-    '%',
-    '~/',
-    '&',
-    '|',
-    '^',
-    '~',
-    '<<',
-    '>>',
-    '>>>',
-    '<',
-    '<=',
-    '>',
-    '>=',
-    '==',
-    '[]',
-    '[]=',
-  };
-
-  bool _isOperator(DocumentSymbol symbol) =>
-      symbol.kind == .method && _operatorNames.contains(symbol.name);
-
-  /// Whether [symbol] is a `call` method (callable via implicit-call syntax
-  /// `obj(...)`). The reference search can't resolve that syntax back to the
-  /// declaration — like infix operators (see [_isOperator]) — so a used `call`
-  /// is always reported as unused.
-  bool _isCallMethod(DocumentSymbol symbol) =>
-      symbol.kind == .method && symbol.name == 'call';
-
-  /// Advisory note attached to a sole, zero-parameter private constructor
-  /// (`Foo._();`) — the classic prevent-instantiation marker. Such a
-  /// constructor is still reported (and removable) like any other dead code,
-  /// but the note points at the idiomatic alternative.
-  static const _preventInstantiationHint =
-      'looks like a prevent-instantiation constructor — for a '
-      'non-instantiable static-only class, prefer `abstract final class`';
-
-  /// Whether [symbol] is a private constructor (`Foo._`, `Foo._named`). The
-  /// server names constructors with the class included (`Foo`, `Foo.named`),
-  /// so the private marker is a segment after the last `.` starting with `_`;
-  /// the unnamed constructor (no `.`) is never private here.
-  bool _isPrivateConstructor(DocumentSymbol symbol) {
-    if (symbol.kind != .constructor) {
-      return false;
-    }
-    final name = symbol.name;
-    final dot = name.lastIndexOf('.');
-    return dot >= 0 && dot + 1 < name.length && name[dot + 1] == '_';
-  }
-
-  /// Whether [symbol]'s parameter list is empty. The server reports the
-  /// signature in [DocumentSymbol.detail] as the parenthesized parameter list
-  /// (`()`, `(int a)`, …); if the detail is missing we can't tell the arity, so
-  /// treat it as empty to avoid missing the zero-parameter marker.
-  bool _hasNoParameters(DocumentSymbol symbol) {
-    final detail = symbol.detail?.trim();
-    if (detail == null || detail.isEmpty) {
-      return true;
-    }
-    final inner = detail.startsWith('(') && detail.endsWith(')')
-        ? detail.substring(1, detail.length - 1).trim()
-        : detail;
-    return inner.isEmpty;
-  }
-
-  /// Whether [symbol] is the classic prevent-instantiation marker: a class's
-  /// sole, zero-parameter private constructor (`Foo._();`). It is no longer
-  /// special-cased away — it's reported (and removable) like any other dead
-  /// declaration — but findings that match this shape carry
-  /// [_preventInstantiationHint] so the report can nudge toward
-  /// `abstract final class`. [siblings] are the constructor's fellow class
-  /// members, used to confirm it is the class's only constructor.
-  bool _isPreventInstantiationMarker(
-    DocumentSymbol symbol,
-    List<DocumentSymbol> siblings,
-  ) {
-    if (!_isPrivateConstructor(symbol)) {
-      return false;
-    }
-    final constructorCount = siblings
-        .where((s) => s.kind == .constructor)
-        .length;
-    if (constructorCount != 1) {
-      return false;
-    }
-    return _hasNoParameters(symbol);
-  }
-
-  /// Lines of every scanned file, keyed by absolute path, populated as each
-  /// file is opened in [_collectCandidatesFor]. Reused to classify reference
-  /// locations as doc comments without re-reading files from disk.
-  final _fileLines = <String, List<String>>{};
+  /// Lazily-cached source text and tokens for every file touched this run,
+  /// shared by the classification and the structural detectors.
+  final _sources = SourceIndex();
 
   /// Keys `(path, class name)` of classes annotated `@freezed`/`@Freezed`.
-  final _freezedAnnotatedClasses = <_DeclKey>{};
+  final _freezedAnnotatedClasses = <DeclKey>{};
 
   static final _freezedAnnotation = RegExp(r'@(?:freezed|Freezed)\b');
 
@@ -185,25 +49,20 @@ class Ciach {
     r'\b(?:Map|List|String|int|double|num|bool|Object|dynamic)\b\s*(?:<[^;{]*>)?\s*\??\s*$',
   );
 
-  /// Whether [location] points at a dartdoc `[Xxx]`-style reference rather
-  /// than real code — i.e. its line, in the file it points into, starts with
-  /// `///`. Block (`/** */`) doc comments aren't recognized; `///` is the
-  /// standard and lint-enforced style.
-  bool _isDocReference(Location location) {
-    final lines = _linesFor(_pathOf(location.uri));
-    final line = location.range.start.line;
-    if (line < 0 || line >= lines.length) {
-      return false;
-    }
-    return lines[line].trim().startsWith('///');
-  }
+  /// The `State<` immediately preceding a type argument, with a token boundary
+  /// before `State` so `MyState<…>`/`FooState<…>` don't match.
+  static final _statePrefix = RegExp(r'(?:^|[^A-Za-z0-9_$])State<\s*$');
 
-  /// The absolute file path a reference [uri] points at.
-  String _pathOf(String uri) => Uri.parse(uri).toFilePath();
+  /// The `>` that closes a single `State<…>` type argument.
+  static final _stateSuffix = RegExp(r'^\s*>');
 
-  /// The lines of the file at [path], read (and cached) on demand.
-  List<String> _linesFor(String path) =>
-      _fileLines[path] ??= _readFile(path)?.split('\n') ?? const [];
+  /// Advisory note attached to a sole, zero-parameter private constructor
+  /// (`Foo._();`) — the classic prevent-instantiation marker. Such a
+  /// constructor is still reported (and removable) like any other dead code,
+  /// but the note points at the idiomatic alternative.
+  static const _preventInstantiationHint =
+      'looks like a prevent-instantiation constructor — for a '
+      'non-instantiable static-only class, prefer `abstract final class`';
 
   void _report(String message) => options.onProgress?.call(message);
 
@@ -245,7 +104,7 @@ class Ciach {
       // generated code — e.g. a `toJson` called from a `.g.dart` — resolves.
       if (discovered.warmOnly.isNotEmpty) {
         _report('Warming ${discovered.warmOnly.length} generated file(s)…');
-        await _mapPooled<String, bool>(
+        await mapPooled(
           discovered.warmOnly,
           options.concurrency,
           (path) => _warmFile(client, path),
@@ -257,7 +116,7 @@ class Ciach {
       // server's cache; without it, reference queries against files the server
       // has evicted come back empty and produce false "unused" reports.
       _report('Collecting declarations from ${files.length} file(s)…');
-      final perFile = await _mapPooled<String, List<_Candidate>>(
+      final perFile = await mapPooled(
         files,
         options.concurrency,
         (path) => _collectCandidatesFor(client, path),
@@ -282,26 +141,22 @@ class Ciach {
       final totalFiles = files.length;
       var filesDone = totalFiles - remainingPerFile.length;
 
-      final refsByCandidate = await _mapPooled<_Candidate, List<Location>>(
-        candidates,
-        options.concurrency,
-        (candidate) async {
-          final refs = await client.references(
-            candidate.uri,
-            candidate.symbol.selectionRange.start,
+      final refsByCandidate = await mapPooled(candidates, options.concurrency, (
+        candidate,
+      ) async {
+        final refs = await client.references(
+          candidate.uri,
+          candidate.symbol.selectionRange.start,
+        );
+        if (remainingPerFile.update(candidate.path, (n) => n - 1) == 0) {
+          filesDone++;
+          _report(
+            '[$filesDone/$totalFiles] '
+            '${p.relative(candidate.path, from: rootPath)}',
           );
-          final remaining = remainingPerFile[candidate.path]! - 1;
-          remainingPerFile[candidate.path] = remaining;
-          if (remaining == 0) {
-            filesDone++;
-            _report(
-              '[$filesDone/$totalFiles] '
-              '${p.relative(candidate.path, from: rootPath)}',
-            );
-          }
-          return refs;
-        },
-      );
+        }
+        return refs;
+      });
 
       final statuses = [
         for (var i = 0; i < candidates.length; i++)
@@ -320,7 +175,7 @@ class Ciach {
       final deadClassNames = <String, Set<String>>{};
       for (var i = 0; i < candidates.length; i++) {
         final candidate = candidates[i];
-        if (statuses[i] == _RefStatus.unused &&
+        if (statuses[i] == RefStatus.unused &&
             candidate.symbol.kind == .class$) {
           deadClassNames
               .putIfAbsent(candidate.path, () => <String>{})
@@ -328,119 +183,19 @@ class Ciach {
         }
       }
 
-      // ---- Remove-safety pre-pass ----
-      //
-      // Some findings are genuinely dead but cannot be auto-removed without
-      // breaking the build, so they are reported with `removalBlocked` set and
-      // left for a human — reusing the same mechanism as pattern-matched sealed
-      // members. Everything the reporting loop below needs to decide is
-      // gathered here, up front, so that loop stays a set of cheap lookups.
-      //
-      // * `emptiedEnums`        — enums every one of whose values would be
-      //   removed while the enum TYPE is still referenced, leaving `enum E {}`
-      //   (a compile error). Those value removals are blocked (guard 2).
-      // * `blockedCtorClasses`  — live classes all of whose constructors are
-      //   dead: removing them synthesizes an implicit default constructor that
-      //   strands `final` fields (guard 3) or breaks super-constructor
-      //   forwarding (guard 4). Those constructor removals are blocked.
-      final enumTypeHasRef = <_DeclKey, bool>{};
-      final enumValueTotal = <_DeclKey, int>{};
-      final ctorTotal = <_DeclKey, int>{};
-      final ctorDead = <_DeclKey, int>{};
-      final ctorForwardsSuper = <_DeclKey, bool>{};
-      final classByKey = <_DeclKey, _Candidate>{};
-      // Enums whose values are all reachable through `.values` iteration —
-      // either the qualified `EnumType.values` ([_isDotValuesRef]) or the bare
-      // `values` getter inside the enum's own body ([_enumIteratesOwnValues]).
-      // A value reached only that way is *used*, not dead, so it is suppressed
-      // entirely below rather than reported (and so never reaches the
-      // empty-enum guard). The guard still fires for an all-dead enum whose
-      // values are neither named individually nor iterated.
-      final enumValuesIterated = <_DeclKey>{};
+      final safety = _RemoveSafety.analyze(
+        this,
+        candidates,
+        statuses,
+        refsByCandidate,
+        deadClassNames,
+      );
 
       for (var i = 0; i < candidates.length; i++) {
         final candidate = candidates[i];
-        final symbol = candidate.symbol;
         final refs = refsByCandidate[i];
-        if (symbol.kind == .enum$ && !candidate.isEnumValue) {
-          enumTypeHasRef[_key(candidate.path, symbol.name)] = refs.isNotEmpty;
-          if (refs.any(_isDotValuesRef) || _enumIteratesOwnValues(candidate)) {
-            enumValuesIterated.add(_key(candidate.path, symbol.name));
-          }
-        } else if (candidate.isEnumValue && candidate.container != null) {
-          enumValueTotal.update(
-            _key(candidate.path, candidate.container!),
-            (n) => n + 1,
-            ifAbsent: () => 1,
-          );
-        } else if (symbol.kind == .class$) {
-          classByKey[_key(candidate.path, symbol.name)] = candidate;
-        } else if (symbol.kind == .constructor && candidate.container != null) {
-          final key = _key(candidate.path, candidate.container!);
-          ctorTotal.update(key, (n) => n + 1, ifAbsent: () => 1);
-          if (statuses[i] == _RefStatus.unused) {
-            ctorDead.update(key, (n) => n + 1, ifAbsent: () => 1);
-            if (_ctorForwardsSuper(candidate)) {
-              ctorForwardsSuper[key] = true;
-            }
-          }
-        }
-      }
-
-      // Enum values that are dead, keyed by enum, so guard 2 can tell when
-      // *every* value of an enum would go.
-      final enumValueDead = <_DeclKey, int>{};
-      for (var i = 0; i < candidates.length; i++) {
-        final candidate = candidates[i];
-        if (!candidate.isEnumValue ||
-            candidate.container == null ||
-            statuses[i] != _RefStatus.unused) {
-          continue;
-        }
-        final key = _key(candidate.path, candidate.container!);
-        enumValueDead.update(key, (n) => n + 1, ifAbsent: () => 1);
-      }
-
-      final emptiedEnums = <_DeclKey>{};
-      for (final entry in enumValueTotal.entries) {
-        final key = entry.key;
-        final dead = enumValueDead[key] ?? 0;
-        if (dead == 0 || dead != entry.value) {
-          continue;
-        }
-        // Conservative: if the enum-type candidate is missing we cannot prove
-        // the enum is itself being removed, so assume it stays and block.
-        if (enumTypeHasRef[key] ?? true) {
-          emptiedEnums.add(key);
-        }
-      }
-
-      final blockedCtorClasses = <_DeclKey>{};
-      for (final entry in ctorTotal.entries) {
-        final key = entry.key;
-        final dead = ctorDead[key] ?? 0;
-        if (dead == 0 || dead != entry.value) {
-          continue;
-        }
-        // A dead class is removed whole (its constructors go with it), so its
-        // constructors are never reported on their own — nothing to guard.
-        if (deadClassNames[key.path]?.contains(key.name) ?? false) {
-          continue;
-        }
-        final classCandidate = classByKey[key];
-        final hasFinalField =
-            classCandidate != null &&
-            _classHasFinalInstanceField(classCandidate);
-        final forwardsSuper = ctorForwardsSuper[key] ?? false;
-        if (hasFinalField || forwardsSuper) {
-          blockedCtorClasses.add(key);
-        }
-      }
-
-      for (var i = 0; i < candidates.length; i++) {
-        final candidate = candidates[i];
         switch (statuses[i]) {
-          case _RefStatus.unused:
+          case RefStatus.unused:
             if (freezedUnionArms.contains(i)) {
               break;
             }
@@ -450,21 +205,20 @@ class Ciach {
             if (_isConstructorOfDeadClass(candidate, deadClassNames)) {
               break;
             }
+            final containerKey = candidate.containerKey;
             // An enum value reached only through `.values` iteration is used,
             // not dead: suppress it entirely (never reported) rather than
             // flagging it for the empty-enum guard.
             if (candidate.isEnumValue &&
-                candidate.container != null &&
-                enumValuesIterated.contains(
-                  _key(candidate.path, candidate.container!),
-                )) {
+                containerKey != null &&
+                safety.enumValuesIterated.contains(containerKey)) {
               break;
             }
             final isClass = candidate.symbol.kind == .class$;
             final paired = isClass
                 ? _pairedStateRemovals(
                     candidate,
-                    refsByCandidate[i],
+                    refs,
                     candidates,
                     refsByCandidate,
                     rootPath,
@@ -477,27 +231,22 @@ class Ciach {
             //   --unused-union-members (never constructed, only matched):
             //   deleting a sealed member and its scattered `case`s is a source
             //   rewrite this tool won't attempt;
-            // * an enum value whose removal would empty a still-referenced enum
-            //   (guard 2);
-            // * the last constructor of a live class with `final` fields
-            //   (guard 3) or super-constructor forwarding (guard 4).
+            // * an enum value whose removal would empty a still-referenced enum;
+            // * the last constructor of a live class with `final` fields or
+            //   super-constructor forwarding.
             //
             // Each is surfaced so a human can act on it, but the remover leaves
             // it — and anything coupled to it — entirely alone.
             final removalBlocked =
                 (isClass &&
                     options.unusedUnionMembers &&
-                    _isPatternMatchedClass(candidate, refsByCandidate[i])) ||
+                    _isPatternMatchedClass(candidate, refs)) ||
                 (candidate.isEnumValue &&
-                    candidate.container != null &&
-                    emptiedEnums.contains(
-                      _key(candidate.path, candidate.container!),
-                    )) ||
+                    containerKey != null &&
+                    safety.emptiedEnums.contains(containerKey)) ||
                 (candidate.symbol.kind == .constructor &&
-                    candidate.container != null &&
-                    blockedCtorClasses.contains(
-                      _key(candidate.path, candidate.container!),
-                    ));
+                    containerKey != null &&
+                    safety.blockedCtorClasses.contains(containerKey));
             unused.add(
               _toUnused(
                 candidate,
@@ -511,9 +260,9 @@ class Ciach {
                     : null,
               ),
             );
-          case _RefStatus.docOnly:
+          case RefStatus.docOnly:
             docOnly.add(_toUnused(candidate, rootPath));
-          case _RefStatus.used:
+          case RefStatus.used:
             break;
         }
       }
@@ -537,40 +286,46 @@ class Ciach {
   /// it, so references *into* still-scanned code from this file resolve.
   /// Returns whether the file could be read and opened.
   Future<bool> _warmFile(LspClient client, String path) async {
-    final content = _readFile(path);
+    final content = SourceIndex.readFile(path);
     if (content == null) {
       return false;
     }
-    final uri = File(path).uri;
-    client.didOpen(uri, content);
-    _fileLines[path] = content.split('\n');
+    client.didOpen(File(path).uri, content);
+    _sources.cacheLines(path, content.split('\n'));
     return true;
   }
 
   /// Fetches the symbols for [path] and returns the declarations worth checking.
-  Future<List<_Candidate>> _collectCandidatesFor(
+  Future<List<Candidate>> _collectCandidatesFor(
     LspClient client,
     String path,
   ) async {
-    final content = _readFile(path);
+    final content = SourceIndex.readFile(path);
     if (content == null) {
       return const [];
     }
     final uri = File(path).uri;
     client.didOpen(uri, content);
     final symbols = await client.documentSymbol(uri);
-    final lines = content.split('\n');
-    _fileLines[path] = lines;
-    final out = <_Candidate>[];
-    _collectCandidates(uri, path, symbols, null, false, lines, out);
+    _sources.cacheLines(path, content.split('\n'));
+    final out = <Candidate>[];
+    _collectCandidates(
+      uri,
+      path,
+      symbols,
+      null,
+      false,
+      _sources.lines(path),
+      out,
+    );
     return out;
   }
 
   /// Recursively walks the symbol tree, keeping only symbols worth checking,
   /// and records the enclosing type name as their container.
   ///
-  /// [parentIsEnum] marks children of an enum declaration so [_reportedKind]
-  /// can remap its enum values to the `enum-value` kind.
+  /// [parentIsEnum] marks children of an enum declaration so their enum values
+  /// are remapped to the `enum-value` kind.
   void _collectCandidates(
     Uri uri,
     String path,
@@ -578,12 +333,12 @@ class Ciach {
     String? container,
     bool parentIsEnum,
     List<String> lines,
-    List<_Candidate> out,
+    List<Candidate> out,
   ) {
     for (final symbol in symbols) {
-      if (_typeLikeKinds.contains(symbol.kind) &&
-          _freezedAnnotation.hasMatch(_leadingMetadata(symbol, lines))) {
-        _freezedAnnotatedClasses.add(_key(path, symbol.name));
+      if (typeLikeKinds.contains(symbol.kind) &&
+          _freezedAnnotation.hasMatch(symbol.leadingMetadata(lines))) {
+        _freezedAnnotatedClasses.add(declKey(path, symbol.name));
       }
       if (_shouldConsider(symbol, parentIsEnum, lines)) {
         out.add((
@@ -595,13 +350,12 @@ class Ciach {
           // `symbols` are this symbol's siblings (its class's members when
           // `symbol` is a constructor), so this confirms the sole-constructor
           // shape without threading the list any further.
-          isPreventInstantiationCtor: _isPreventInstantiationMarker(
-            symbol,
+          isPreventInstantiationCtor: symbol.isPreventInstantiationMarker(
             symbols,
           ),
         ));
       }
-      final childContainer = _typeLikeKinds.contains(symbol.kind)
+      final childContainer = typeLikeKinds.contains(symbol.kind)
           ? symbol.name
           : container;
       _collectCandidates(
@@ -621,27 +375,28 @@ class Ciach {
     bool parentIsEnum,
     List<String> lines,
   ) {
-    if (!options.kinds.contains(_reportedKind(symbol, parentIsEnum))) {
+    if (!options.kinds.contains(
+      symbol.reportedKind(parentIsEnum: parentIsEnum),
+    )) {
       return false;
     }
     // The program entry point is never "unused".
     if (symbol.kind == .function && symbol.name == 'main') {
       return false;
     }
-    final private = _isPrivateName(symbol.name);
-    if (!private && !options.includePublic) {
+    if (!isPrivateName(symbol.name) && !options.includePublic) {
       return false;
     }
-    if (options.skipOperators && _isOperator(symbol)) {
+    if (options.skipOperators && symbol.isOperator) {
       return false;
     }
     // Always skipped (no flag): implicit-call syntax is unresolvable, like
-    // operators. See [_isCallMethod].
-    if (_isCallMethod(symbol)) {
+    // operators.
+    if (symbol.isCallMethod) {
       return false;
     }
 
-    final leading = _leadingMetadata(symbol, lines);
+    final leading = symbol.leadingMetadata(lines);
     if (options.skipOverrides && leading.contains('@override')) {
       return false;
     }
@@ -652,14 +407,8 @@ class Ciach {
     return true;
   }
 
-  /// The kind ciach reports for [symbol]. The analysis server tags enum values
-  /// with [SymbolKind.enum$] (same as the enum type), so remap them to
-  /// [SymbolKind.enumMember] under an enum to match the `enum-value` CLI kind.
-  static SymbolKind _reportedKind(DocumentSymbol symbol, bool parentIsEnum) =>
-      parentIsEnum && symbol.kind == .enum$ ? .enumMember : symbol.kind;
-
   UnusedDeclaration _toUnused(
-    _Candidate candidate,
+    Candidate candidate,
     String rootPath, {
     List<CoupledRemoval> coupledRemovals = const [],
     bool removalBlocked = false,
@@ -667,18 +416,18 @@ class Ciach {
   }) {
     final symbol = candidate.symbol;
     final start = symbol.selectionRange.start;
-    final name = _declarationName(symbol, candidate.container);
+    final name = symbol.declarationName(candidate.container);
     return .new(
       name: name,
-      kind: _reportedKind(symbol, candidate.isEnumValue),
+      kind: symbol.reportedKind(parentIsEnum: candidate.isEnumValue),
       filePath: _relPath(candidate.path, rootPath),
       // LSP positions are zero-based; report them one-based for humans.
       line: start.line + 1,
       column: start.character + 1,
-      isPrivate: _isPrivateName(name),
+      isPrivate: isPrivateName(name),
       container: candidate.container,
       isEnumValue: candidate.isEnumValue,
-      range: _rangeOf(symbol),
+      range: symbol.declarationRange,
       coupledRemovals: coupledRemovals,
       removalBlocked: removalBlocked,
       hint: hint,
@@ -694,15 +443,16 @@ class Ciach {
   /// class's own body, and the `State<Self>` StatefulWidget pairing — so a
   /// class kept alive only by its own unnamed constructor's declaration (whose
   /// name coincides with the class) is correctly seen as dead.
-  _RefStatus _classify(_Candidate candidate, List<Location> refs) {
+  RefStatus _classify(Candidate candidate, List<Location> refs) {
     if (candidate.symbol.kind == .class$) {
       return _classifyClass(candidate, refs);
     }
     if (refs.isEmpty) {
-      return _RefStatus.unused;
+      return RefStatus.unused;
     }
-    final hasRealRef = refs.any((loc) => !_isDocReference(loc));
-    return hasRealRef ? _RefStatus.used : _RefStatus.docOnly;
+    return refs.any((loc) => !_isDocReference(loc))
+        ? RefStatus.used
+        : RefStatus.docOnly;
   }
 
   /// Classifies a class by its references, ignoring self-references.
@@ -713,8 +463,7 @@ class Ciach {
   /// it is unused. This is deliberately conservative: any single unexplained
   /// outside reference keeps the class alive, so the failure mode is missing a
   /// dead class, never deleting a live one.
-  _RefStatus _classifyClass(_Candidate candidate, List<Location> refs) {
-    var hasExternalCode = false;
+  RefStatus _classifyClass(Candidate candidate, List<Location> refs) {
     var hasExternalDoc = false;
     var hasPatternMatch = false;
     for (final loc in refs) {
@@ -730,24 +479,34 @@ class Ciach {
       // arm) is a *match*, not a construction: if the type is never
       // constructed, no such match can ever fire, so it is discounted like a
       // self-reference. Any reference that is not confidently a type pattern
-      // falls through to `hasExternalCode` and keeps the class alive — the
-      // conservative choice (nested sub-patterns and pattern-variable
-      // declarations are intentionally not recognized, so they keep it alive).
-      if (options.unusedUnionMembers && _isPatternRef(loc)) {
+      // keeps the class alive — the conservative choice (nested sub-patterns
+      // and pattern-variable declarations are intentionally not recognized).
+      if (options.unusedUnionMembers && _sources.isPatternRef(loc)) {
         hasPatternMatch = true;
         continue;
       }
-      hasExternalCode = true;
-    }
-    if (hasExternalCode) {
-      return _RefStatus.used;
+      // A real, non-pattern reference from outside: the class is used.
+      return RefStatus.used;
     }
     // Matched-only-by-a-pattern (never constructed) is dead code, not a softer
     // doc-only report.
     if (hasPatternMatch) {
-      return _RefStatus.unused;
+      return RefStatus.unused;
     }
-    return hasExternalDoc ? _RefStatus.docOnly : _RefStatus.unused;
+    return hasExternalDoc ? RefStatus.docOnly : RefStatus.unused;
+  }
+
+  /// Whether [location] points at a dartdoc `[Xxx]`-style reference rather than
+  /// real code — i.e. its line, in the file it points into, starts with `///`.
+  /// Block (`/** */`) doc comments aren't recognized; `///` is the standard and
+  /// lint-enforced style.
+  bool _isDocReference(Location location) {
+    final lines = _sources.lines(SourceIndex.pathOf(location.uri));
+    final line = location.range.start.line;
+    if (line < 0 || line >= lines.length) {
+      return false;
+    }
+    return lines[line].trim().startsWith('///');
   }
 
   /// Whether [loc] is a reference to [candidate] that does not count as a use.
@@ -756,19 +515,18 @@ class Ciach {
   ///
   /// 1. A reference inside the class's own source span — its body, signature,
   ///    or leading doc/annotation lines. This covers the unnamed constructor's
-  ///    declaration (`Foo` in `Foo();`, reported by the server as a reference
-  ///    to the class), a `State<Foo>` return type on the widget's own
+  ///    declaration, a `State<Foo>` return type on the widget's own
   ///    `createState`, and any purely-internal self-use.
   /// 2. A `State<Foo>` type-argument reference anywhere — the StatefulWidget
   ///    pairing. `State<Foo>` can only ever denote the state object of the
   ///    `Foo` widget, so it never means `Foo` itself is used elsewhere.
-  bool _isSelfClassReference(_Candidate candidate, Location loc) {
-    if (_pathOf(loc.uri) == candidate.path) {
-      final lines = _linesFor(candidate.path);
-      final top = _metadataTopLine(candidate.symbol, lines);
+  bool _isSelfClassReference(Candidate candidate, Location loc) {
+    if (SourceIndex.pathOf(loc.uri) == candidate.path) {
+      final top = candidate.symbol.metadataTopLine(
+        _sources.lines(candidate.path),
+      );
       final pos = loc.range.start;
-      final afterTop = pos.line >= top;
-      if (afterTop && _atOrBeforeEnd(pos, candidate.symbol.range.end)) {
+      if (pos.line >= top && pos.atOrBefore(candidate.symbol.range.end)) {
         return true;
       }
     }
@@ -783,7 +541,7 @@ class Ciach {
     if (start.line != end.line) {
       return false;
     }
-    final lines = _linesFor(_pathOf(loc.uri));
+    final lines = _sources.lines(SourceIndex.pathOf(loc.uri));
     if (start.line < 0 || start.line >= lines.length) {
       return false;
     }
@@ -800,19 +558,11 @@ class Ciach {
         _stateSuffix.hasMatch(line.substring(end.character));
   }
 
-  /// The `State<` immediately preceding a type argument, with a token boundary
-  /// before `State` so `MyState<…>`/`FooState<…>` don't match.
-  static final _statePrefix = RegExp(r'(?:^|[^A-Za-z0-9_$])State<\s*$');
-
-  /// The `>` that closes a single `State<…>` type argument.
-  static final _stateSuffix = RegExp(r'^\s*>');
-
   bool _isConstructorOfDeadClass(
-    _Candidate candidate,
+    Candidate candidate,
     Map<String, Set<String>> deadClassNames,
   ) =>
       candidate.symbol.kind == .constructor &&
-      candidate.container != null &&
       (deadClassNames[candidate.path]?.contains(candidate.container) ?? false);
 
   /// Whether [candidate] is a `toJson()` serialization hook — a zero-required-arg
@@ -820,14 +570,14 @@ class Ciach {
   /// `int`/`double`/`bool`, or `Object`/`dynamic`). `jsonEncode(obj)` dispatches to
   /// it dynamically with no source-level `.toJson()` token, so the reference search
   /// can't see that use; exempt it for any class, annotated or not.
-  bool _isToJsonHook(_Candidate candidate) {
+  bool _isToJsonHook(Candidate candidate) {
     final symbol = candidate.symbol;
     if (symbol.kind != .method ||
         symbol.name != 'toJson' ||
-        !_hasNoParameters(symbol)) {
+        !symbol.hasNoParameters) {
       return false;
     }
-    final lines = _linesFor(candidate.path);
+    final lines = _sources.lines(candidate.path);
     final line = symbol.selectionRange.start.line;
     if (line < 0 || line >= lines.length) {
       return false;
@@ -838,227 +588,42 @@ class Ciach {
     return _toJsonJsonReturn.hasMatch(beforeName);
   }
 
-  /// Builds the map key pairing a file [path] with a declaration [name].
-  static _DeclKey _key(String path, String name) => (path: path, name: name);
-
-  /// Redirecting-factory arms of a `@freezed`/`@Freezed` union with a referenced `fromJson`; conservative — never-dispatched arms are kept too, being statically indistinguishable.
+  /// Redirecting-factory arms of a `@freezed`/`@Freezed` union with a referenced
+  /// `fromJson`; conservative — never-dispatched arms are kept too, being
+  /// statically indistinguishable.
   Set<int> _freezedDeserializedUnionArms(
-    List<_Candidate> candidates,
-    List<_RefStatus> statuses,
+    List<Candidate> candidates,
+    List<RefStatus> statuses,
   ) {
-    final unionsWithUsedFromJson = <_DeclKey>{};
+    final unionsWithUsedFromJson = <DeclKey>{};
     for (var i = 0; i < candidates.length; i++) {
       final c = candidates[i];
       if (c.symbol.kind == .constructor &&
-          c.container != null &&
-          statuses[i] == _RefStatus.used &&
-          _declarationName(c.symbol, c.container) == 'fromJson') {
-        unionsWithUsedFromJson.add(_key(c.path, c.container!));
+          statuses[i] == RefStatus.used &&
+          c.symbol.declarationName(c.container) == 'fromJson') {
+        if (c.containerKey case final key?) {
+          unionsWithUsedFromJson.add(key);
+        }
       }
     }
 
     final arms = <int>{};
     for (var i = 0; i < candidates.length; i++) {
-      if (statuses[i] != _RefStatus.unused) {
+      if (statuses[i] != RefStatus.unused) {
         continue;
       }
       final c = candidates[i];
-      if (c.symbol.kind != .constructor || c.container == null) {
+      if (c.symbol.kind != .constructor) {
         continue;
       }
-      final key = _key(c.path, c.container!);
-      if (_freezedAnnotatedClasses.contains(key) &&
-          unionsWithUsedFromJson.contains(key) &&
-          _isRedirectingFactory(c)) {
+      if (c.containerKey case final key?
+          when _freezedAnnotatedClasses.contains(key) &&
+              unionsWithUsedFromJson.contains(key) &&
+              _sources.isRedirectingFactory(c)) {
         arms.add(i);
       }
     }
     return arms;
-  }
-
-  /// Whether [ctor] is a redirecting factory (`factory X(..) = Target;`) — a `=` at depth 0 after `factory` whose next token is a word (not a `=>` body).
-  bool _isRedirectingFactory(_Candidate ctor) {
-    final content = _contentFor(ctor.path);
-    if (content.isEmpty) {
-      return false;
-    }
-    final lineStarts = _lineStartsFor(ctor.path);
-    final startOff = _offsetOfPosition(
-      lineStarts,
-      content,
-      ctor.symbol.range.start,
-    );
-    final endOff = _offsetOfPosition(
-      lineStarts,
-      content,
-      ctor.symbol.range.end,
-    );
-    if (startOff == null || endOff == null) {
-      return false;
-    }
-    final tokens = _tokensFor(ctor.path);
-    var sawFactory = false;
-    var depth = 0;
-    for (var i = 0; i < tokens.length; i++) {
-      final t = tokens[i];
-      if (t.start < startOff) {
-        continue;
-      }
-      if (t.start >= endOff) {
-        break;
-      }
-      if (t.isWord) {
-        if (t.value == 'factory') {
-          sawFactory = true;
-        }
-        continue;
-      }
-      switch (t.value) {
-        case '(' || '[' || '{':
-          depth++;
-        case ')' || ']' || '}':
-          depth--;
-        case '=':
-          if (depth == 0 &&
-              sawFactory &&
-              i + 1 < tokens.length &&
-              tokens[i + 1].isWord) {
-            return true;
-          }
-      }
-    }
-    return false;
-  }
-
-  /// Whether [ctor] forwards to a super constructor *with arguments* — a
-  /// `super.<field>` parameter or a non-empty `super(...)` call. Such a
-  /// constructor exists to satisfy a superclass whose unnamed constructor is
-  /// not zero-arg; removing it (leaving an implicit default constructor that
-  /// calls `super()`) would fail to compile (`no_default_super_constructor`).
-  /// A bare `super()` is not forwarding.
-  ///
-  /// Deliberately conservative: a `super.method()` call in the body is also
-  /// treated as forwarding, which can over-block a safe removal — the tool
-  /// reports the finding rather than risk a build break.
-  bool _ctorForwardsSuper(_Candidate ctor) {
-    final content = _contentFor(ctor.path);
-    if (content.isEmpty) {
-      return false;
-    }
-    final lineStarts = _lineStartsFor(ctor.path);
-    final startOff = _offsetOfPosition(
-      lineStarts,
-      content,
-      ctor.symbol.range.start,
-    );
-    final endOff = _offsetOfPosition(
-      lineStarts,
-      content,
-      ctor.symbol.range.end,
-    );
-    if (startOff == null || endOff == null) {
-      return false;
-    }
-    final tokens = _tokensFor(ctor.path);
-    for (var i = 0; i < tokens.length; i++) {
-      final t = tokens[i];
-      if (t.start < startOff) {
-        continue;
-      }
-      if (t.start >= endOff) {
-        break;
-      }
-      if (!t.isWord || t.value != 'super' || i + 1 >= tokens.length) {
-        continue;
-      }
-      final next = tokens[i + 1];
-      if (next.isWord) {
-        continue;
-      }
-      if (next.value == '.') {
-        return true;
-      }
-      if (next.value == '(') {
-        final after = i + 2 < tokens.length ? tokens[i + 2] : null;
-        final emptyCall = after != null && !after.isWord && after.value == ')';
-        if (!emptyCall) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  /// Whether [classCandidate] declares at least one `final` *instance* field
-  /// (not `static`/`const`). Such a field relies on a constructor to be
-  /// initialized, so removing the class's sole constructor would strand it
-  /// (`final_not_initialized`).
-  bool _classHasFinalInstanceField(_Candidate classCandidate) {
-    final children = classCandidate.symbol.children ?? const [];
-    for (final child in children) {
-      if (child.kind == .field &&
-          _isFinalInstanceField(classCandidate.path, child)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /// Whether [field] in [path] is declared `final` and is an *instance* field,
-  /// determined by scanning the declaration's modifier/type prefix — the
-  /// tokens between the field name and the enclosing class body `{` or the
-  /// previous member's terminating `;`. A `static` or `const` modifier
-  /// disqualifies it (those don't depend on a constructor).
-  bool _isFinalInstanceField(String path, DocumentSymbol field) {
-    final content = _contentFor(path);
-    if (content.isEmpty) {
-      return false;
-    }
-    final lineStarts = _lineStartsFor(path);
-    final off = _offsetOfPosition(
-      lineStarts,
-      content,
-      field.selectionRange.start,
-    );
-    if (off == null) {
-      return false;
-    }
-    final tokens = _tokensFor(path);
-    final ti = _tokenIndexAt(tokens, off);
-    if (ti == null) {
-      return false;
-    }
-    var isFinal = false;
-    var depth = 0;
-    for (var i = ti - 1; i >= 0; i--) {
-      final t = tokens[i];
-      if (t.isWord) {
-        if (t.value == 'static' || t.value == 'const') {
-          return false;
-        }
-        if (t.value == 'final') {
-          isFinal = true;
-        }
-        continue;
-      }
-      switch (t.value) {
-        case ')' || ']' || '}':
-          depth++;
-        case '(' || '[' || '{':
-          // A `{` at depth 0 is the class body's opening brace, and an
-          // unmatched `(`/`[` there means the prefix's start — either way, the
-          // field declaration begins here.
-          if (depth == 0) {
-            return isFinal;
-          }
-          depth--;
-        case ';':
-          if (depth == 0) {
-            return isFinal; // previous member/statement boundary
-          }
-      }
-    }
-    return isFinal;
   }
 
   /// The extra spans to remove alongside a dead [widget] class: the paired
@@ -1071,24 +636,22 @@ class Ciach {
   /// break — so the State is coupled to the widget's removal, but it is not
   /// itself reported.
   List<CoupledRemoval> _pairedStateRemovals(
-    _Candidate widget,
+    Candidate widget,
     List<Location> widgetRefs,
-    List<_Candidate> candidates,
+    List<Candidate> candidates,
     List<List<Location>> refsByCandidate,
     String rootPath,
   ) {
     final out = <CoupledRemoval>[];
     for (final loc in widgetRefs) {
-      if (!_isStatePairingReference(widget.symbol.name, loc)) {
-        continue;
-      }
-      if (_pathOf(loc.uri) != widget.path) {
+      if (!_isStatePairingReference(widget.symbol.name, loc) ||
+          SourceIndex.pathOf(loc.uri) != widget.path) {
         continue;
       }
       // The widget's own `createState` return type is inside the widget and
       // removed with it; only a pairing reference outside the widget points at
       // the separate State subclass.
-      if (_withinSymbol(loc.range.start, widget.symbol)) {
+      if (loc.range.start.within(widget.symbol)) {
         continue;
       }
       for (var j = 0; j < candidates.length; j++) {
@@ -1096,7 +659,7 @@ class Ciach {
         if (state.symbol.kind != .class$ ||
             state.path != widget.path ||
             identical(state, widget) ||
-            !_withinSymbol(loc.range.start, state.symbol)) {
+            !loc.range.start.within(state.symbol)) {
           continue;
         }
         if (_referencedOnlyWithin(
@@ -1106,7 +669,7 @@ class Ciach {
         )) {
           out.add((
             filePath: _relPath(state.path, rootPath),
-            range: _rangeOf(state.symbol),
+            range: state.symbol.declarationRange,
           ));
         }
         break;
@@ -1117,572 +680,33 @@ class Ciach {
 
   /// Whether every *code* reference in [refs] lies within [enclosing] in
   /// [path] — used to confirm a paired State subclass is reachable only from
-  /// its widget. Doc-comment links (e.g. a `[_FooState]` mention) are ignored:
-  /// documentation never keeps code alive, so it must not block coupling.
+  /// its widget. Doc-comment links are ignored: documentation never keeps code
+  /// alive, so it must not block coupling.
   bool _referencedOnlyWithin(
     List<Location> refs,
     DocumentSymbol enclosing,
     String path,
-  ) {
-    for (final loc in refs) {
-      if (_isDocReference(loc)) {
-        continue;
-      }
-      if (_pathOf(loc.uri) != path ||
-          !_withinSymbol(loc.range.start, enclosing)) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  /// Whether [pos] falls within [symbol]'s full source range.
-  bool _withinSymbol(Position pos, DocumentSymbol symbol) {
-    final start = symbol.range.start;
-    final afterStart =
-        pos.line > start.line ||
-        (pos.line == start.line && pos.character >= start.character);
-    return afterStart && _atOrBeforeEnd(pos, symbol.range.end);
-  }
-
-  bool _atOrBeforeEnd(Position pos, Position end) =>
-      pos.line < end.line ||
-      (pos.line == end.line && pos.character <= end.character);
-
-  DeclarationRange _rangeOf(DocumentSymbol symbol) => (
-    startLine: symbol.range.start.line,
-    startColumn: symbol.range.start.character,
-    endLine: symbol.range.end.line,
-    endColumn: symbol.range.end.character,
+  ) => refs.every(
+    (loc) =>
+        _isDocReference(loc) ||
+        (SourceIndex.pathOf(loc.uri) == path &&
+            loc.range.start.within(enclosing)),
   );
-
-  /// [absPath] expressed relative to [rootPath], with `/` separators, matching
-  /// [UnusedDeclaration.filePath].
-  String _relPath(String absPath, String rootPath) =>
-      p.split(p.relative(absPath, from: rootPath)).join('/');
 
   /// Whether [candidate] — already classified as unused under
   /// `--unused-union-members` — is kept dead by *type patterns*: at least one
   /// of its non-self, non-doc references is a `case`/switch-expression pattern
   /// match rather than a construction.
-  ///
-  /// Such a class is reported (a human should know the type is never
-  /// constructed, only matched) but its removal is *blocked*: deleting a member
-  /// of a sealed union and its scattered pattern arms is a source rewrite this
-  /// tool won't attempt, so `--remove` leaves it — and its arms — in place.
-  bool _isPatternMatchedClass(_Candidate candidate, List<Location> refs) {
-    for (final loc in refs) {
-      if (_isSelfClassReference(candidate, loc) || _isDocReference(loc)) {
-        continue;
-      }
-      if (_isPatternRef(loc)) {
-        return true;
-      }
-    }
-    return false;
-  }
+  bool _isPatternMatchedClass(Candidate candidate, List<Location> refs) =>
+      refs.any(
+        (loc) =>
+            !_isSelfClassReference(candidate, loc) &&
+            !_isDocReference(loc) &&
+            _sources.isPatternRef(loc),
+      );
 
-  /// Whether reference [loc] to a class is a *type pattern* — a match, not a
-  /// construction — for the opt-in dead-union-member detection.
-  ///
-  /// Recognized as patterns:
-  ///
-  /// * A `case <Type>` pattern — in a `switch` statement, or in an
-  ///   `if (x case …)` / `while (x case …)` header.
-  /// * A switch-*expression* arm `<Type>… => …,`.
-  ///
-  /// Everything else (construction, type annotations, `extends`/`implements`,
-  /// static access, nested sub-patterns, pattern-variable declarations) is not
-  /// a pattern — a real use that keeps the class alive.
-  /// Whether reference [loc] is a type name immediately followed by `.values`
-  /// — the qualified `<EnumName>.values` iteration, which reaches every value.
-  /// The implicit bare-`values` form is caught by [_enumIteratesOwnValues].
-  /// Precise on purpose: a `.value` access or a `.values` on another symbol
-  /// doesn't count.
-  bool _isDotValuesRef(Location loc) {
-    final located = _locateTypeToken(loc);
-    if (located == null) {
-      return false;
-    }
-    final (:tokens, :ti) = located;
-    if (ti + 2 >= tokens.length) {
-      return false;
-    }
-    final dot = tokens[ti + 1];
-    final values = tokens[ti + 2];
-    return !dot.isWord &&
-        dot.value == '.' &&
-        values.isWord &&
-        values.value == 'values';
-  }
-
-  /// Whether [enumCandidate] iterates its own values via the implicit `values`
-  /// getter from inside its body — a bare `values` (not `x.values`), as in a
-  /// `values.any(…)` helper. Having no `<EnumName>.` prefix, it's invisible to a
-  /// references query on the type ([_isDotValuesRef]), so it's found by a source
-  /// scan. Conservative: a local named `values` also matches, which only ever
-  /// retains code, never removes something live.
-  bool _enumIteratesOwnValues(_Candidate enumCandidate) {
-    final content = _contentFor(enumCandidate.path);
-    if (content.isEmpty) {
-      return false;
-    }
-    final lineStarts = _lineStartsFor(enumCandidate.path);
-    final startOff = _offsetOfPosition(
-      lineStarts,
-      content,
-      enumCandidate.symbol.range.start,
-    );
-    final endOff = _offsetOfPosition(
-      lineStarts,
-      content,
-      enumCandidate.symbol.range.end,
-    );
-    if (startOff == null || endOff == null) {
-      return false;
-    }
-    final tokens = _tokensFor(enumCandidate.path);
-    for (var i = 0; i < tokens.length; i++) {
-      final t = tokens[i];
-      if (t.start < startOff) {
-        continue;
-      }
-      if (t.start >= endOff) {
-        break;
-      }
-      if (!t.isWord || t.value != 'values') {
-        continue;
-      }
-      // `.values` here is member access on another receiver, not the enum's
-      // own getter; the qualified form is handled by [_isDotValuesRef].
-      final prev = i > 0 ? tokens[i - 1] : null;
-      if (prev != null && !prev.isWord && prev.value == '.') {
-        continue;
-      }
-      return true;
-    }
-    return false;
-  }
-
-  bool _isPatternRef(Location loc) {
-    final located = _locateTypeToken(loc);
-    if (located == null) {
-      return false;
-    }
-    final (:tokens, :ti) = located;
-
-    final prev = ti > 0 ? tokens[ti - 1] : null;
-    if (prev != null && prev.isWord && prev.value == 'case') {
-      // Any `case <Type>` — switch statement, if-case, or while-case — matches
-      // the type without constructing it.
-      return true;
-    }
-
-    return _isSwitchExprArm(tokens, ti);
-  }
-
-  /// Resolves [loc] to the lexer token index of the referenced type name,
-  /// returning it with the file's cached tokens, or `null` if the reference
-  /// doesn't line up with a word token.
-  ({List<_Token> tokens, int ti})? _locateTypeToken(Location loc) {
-    final path = _pathOf(loc.uri);
-    final content = _contentFor(path);
-    if (content.isEmpty) {
-      return null;
-    }
-    final lineStarts = _lineStartsFor(path);
-    final startOff = _offsetOfPosition(lineStarts, content, loc.range.start);
-    if (startOff == null) {
-      return null;
-    }
-    final tokens = _tokensFor(path);
-    final ti = _tokenIndexAt(tokens, startOff);
-    if (ti == null || !tokens[ti].isWord) {
-      return null;
-    }
-    return (tokens: tokens, ti: ti);
-  }
-
-  /// Whether the type token at [ti] begins a switch-*expression* arm: preceded
-  /// by the `{`/`,` of a `switch (…) {` body and followed by a top-level `=>`.
-  bool _isSwitchExprArm(List<_Token> tokens, int ti) {
-    if (ti == 0) {
-      return false;
-    }
-    final prev = tokens[ti - 1];
-    if (prev.isWord || (prev.value != '{' && prev.value != ',')) {
-      return false;
-    }
-    // Find the enclosing `{` (walking back over a preceding arm if prev is `,`).
-    final braceIndex = _enclosingOpener(tokens, ti - 1);
-    if (braceIndex == null || tokens[braceIndex].value != '{') {
-      return false;
-    }
-    // `{` must close a `switch (…)` header: the token before it is `)` whose
-    // matching `(` is immediately preceded by `switch`.
-    final closeParen = braceIndex - 1;
-    if (closeParen < 0 ||
-        tokens[closeParen].isWord ||
-        tokens[closeParen].value != ')') {
-      return false;
-    }
-    final openParen = _matchingOpenParen(tokens, closeParen);
-    if (openParen == null || openParen == 0) {
-      return false;
-    }
-    final kw = tokens[openParen - 1];
-    if (!kw.isWord || kw.value != 'switch') {
-      return false;
-    }
-    // A top-level `=>` must follow the pattern (so this is an arm, not e.g. a
-    // set/map entry inside a collection literal).
-    var depth = 0;
-    for (var k = ti + 1; k < tokens.length; k++) {
-      final t = tokens[k];
-      if (t.isWord) {
-        continue;
-      }
-      switch (t.value) {
-        case '(' || '[' || '{':
-          depth++;
-        case ')' || ']' || '}':
-          if (depth == 0) {
-            return false;
-          }
-          depth--;
-        case ',' || ';':
-          if (depth == 0) {
-            return false;
-          }
-        case '=':
-          if (depth == 0 &&
-              k + 1 < tokens.length &&
-              !tokens[k + 1].isWord &&
-              tokens[k + 1].value == '>') {
-            return true;
-          }
-      }
-    }
-    return false;
-  }
-
-  /// Walking backward from [from], the index of the nearest enclosing (not yet
-  /// closed) opening bracket, or `null` if the scan runs off the start.
-  int? _enclosingOpener(List<_Token> tokens, int from) {
-    var depth = 0;
-    for (var k = from; k >= 0; k--) {
-      final t = tokens[k];
-      if (t.isWord) {
-        continue;
-      }
-      switch (t.value) {
-        case ')' || ']' || '}':
-          depth++;
-        case '(' || '[' || '{':
-          if (depth == 0) {
-            return k;
-          }
-          depth--;
-      }
-    }
-    return null;
-  }
-
-  /// The index of the `(` matching the `)` at [closeIndex], or `null`.
-  int? _matchingOpenParen(List<_Token> tokens, int closeIndex) {
-    var depth = 0;
-    for (var k = closeIndex; k >= 0; k--) {
-      final t = tokens[k];
-      if (t.isWord) {
-        continue;
-      }
-      switch (t.value) {
-        case ')' || ']' || '}':
-          depth++;
-        case '(' || '[' || '{':
-          depth--;
-          if (depth == 0) {
-            return t.value == '(' ? k : null;
-          }
-      }
-    }
-    return null;
-  }
-
-  /// Absolute offset of an LSP [position] in [content], or `null` if out of
-  /// range. LSP columns are UTF-16 code units, which is exactly how Dart
-  /// indexes a `String`, so the arithmetic needs no conversion.
-  int? _offsetOfPosition(
-    List<int> lineStarts,
-    String content,
-    Position position,
-  ) {
-    if (position.line < 0 || position.line >= lineStarts.length) {
-      return null;
-    }
-    final offset = lineStarts[position.line] + position.character;
-    if (offset < 0 || offset > content.length) {
-      return null;
-    }
-    return offset;
-  }
-
-  /// The index of the token whose span starts exactly at [offset], or `null`
-  /// if none does. Tokens are ordered by start, so this is a binary search.
-  int? _tokenIndexAt(List<_Token> tokens, int offset) {
-    var lo = 0;
-    var hi = tokens.length - 1;
-    while (lo <= hi) {
-      final mid = (lo + hi) >> 1;
-      final start = tokens[mid].start;
-      if (start == offset) {
-        return mid;
-      }
-      if (start < offset) {
-        lo = mid + 1;
-      } else {
-        hi = mid - 1;
-      }
-    }
-    return null;
-  }
-
-  final _contentCache = <String, String>{};
-  final _lineStartsCache = <String, List<int>>{};
-  final _tokensCache = <String, List<_Token>>{};
-
-  /// The full text of [path], reconstructed from the cached lines so it matches
-  /// the document content the analysis server resolved positions against.
-  String _contentFor(String path) =>
-      _contentCache[path] ??= _linesFor(path).join('\n');
-
-  List<int> _lineStartsFor(String path) =>
-      _lineStartsCache[path] ??= _computeLineStarts(_contentFor(path));
-
-  List<_Token> _tokensFor(String path) =>
-      _tokensCache[path] ??= _tokenize(_contentFor(path));
-
-  static List<int> _computeLineStarts(String content) {
-    final starts = <int>[0];
-    for (var i = 0; i < content.length; i++) {
-      if (content[i] == '\n') {
-        starts.add(i + 1);
-      }
-    }
-    return starts;
-  }
-
-  static bool _isIdentStart(String ch) =>
-      (ch.compareTo('a') >= 0 && ch.compareTo('z') <= 0) ||
-      (ch.compareTo('A') >= 0 && ch.compareTo('Z') <= 0) ||
-      ch == '_' ||
-      ch == r'$';
-
-  static bool _isIdentPart(String ch) =>
-      _isIdentStart(ch) || (ch.compareTo('0') >= 0 && ch.compareTo('9') <= 0);
-
-  /// Splits [content] into [_Token]s, skipping whitespace, `//` and (nesting)
-  /// `/* */` comments, and every string-literal form (single/double,
-  /// triple-quoted, raw, and `${…}`/`$id` interpolation). Everything else is
-  /// emitted as either a word token or a single-character punctuation token.
-  static List<_Token> _tokenize(String content) {
-    final tokens = <_Token>[];
-    final n = content.length;
-    var i = 0;
-    while (i < n) {
-      final ch = content[i];
-      if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r') {
-        i++;
-        continue;
-      }
-      if (ch == '/' && i + 1 < n && content[i + 1] == '/') {
-        i += 2;
-        while (i < n && content[i] != '\n') {
-          i++;
-        }
-        continue;
-      }
-      if (ch == '/' && i + 1 < n && content[i + 1] == '*') {
-        i = _skipBlockComment(content, i);
-        continue;
-      }
-      if ((ch == 'r' || ch == 'R') &&
-          i + 1 < n &&
-          (content[i + 1] == "'" || content[i + 1] == '"')) {
-        i = _skipString(content, i + 1, raw: true);
-        continue;
-      }
-      if (ch == "'" || ch == '"') {
-        i = _skipString(content, i, raw: false);
-        continue;
-      }
-      if (_isIdentStart(ch)) {
-        final start = i;
-        i++;
-        while (i < n && _isIdentPart(content[i])) {
-          i++;
-        }
-        tokens.add((
-          start: start,
-          end: i,
-          isWord: true,
-          value: content.substring(start, i),
-        ));
-        continue;
-      }
-      tokens.add((start: i, end: i + 1, isWord: false, value: ch));
-      i++;
-    }
-    return tokens;
-  }
-
-  /// Skips a (possibly nested) `/* … */` block comment starting at [from],
-  /// returning the index just past it.
-  static int _skipBlockComment(String content, int from) {
-    final n = content.length;
-    var i = from + 2;
-    var depth = 1;
-    while (i < n && depth > 0) {
-      if (content[i] == '/' && i + 1 < n && content[i + 1] == '*') {
-        depth++;
-        i += 2;
-      } else if (content[i] == '*' && i + 1 < n && content[i + 1] == '/') {
-        depth--;
-        i += 2;
-      } else {
-        i++;
-      }
-    }
-    return i;
-  }
-
-  /// Skips a string literal whose opening quote is at [from], returning the
-  /// index just past the closing quote. Handles triple quotes, escapes, and —
-  /// unless [raw] — `${…}`/`$id` interpolation (whose braces and nested
-  /// strings are matched so a `}` or quote inside them doesn't end the string).
-  static int _skipString(String content, int from, {required bool raw}) {
-    final n = content.length;
-    final quote = content[from];
-    final triple =
-        from + 2 < n &&
-        content[from + 1] == quote &&
-        content[from + 2] == quote;
-    var i = from + (triple ? 3 : 1);
-    while (i < n) {
-      final c = content[i];
-      if (!raw && c == r'\') {
-        i += 2;
-        continue;
-      }
-      if (!raw && c == r'$') {
-        i = _skipInterpolation(content, i);
-        continue;
-      }
-      if (c == quote) {
-        if (!triple) {
-          return i + 1;
-        }
-        if (i + 2 < n && content[i + 1] == quote && content[i + 2] == quote) {
-          return i + 3;
-        }
-      }
-      if (!triple && c == '\n') {
-        // Unterminated single-line string; stop at the newline rather than run on.
-        return i;
-      }
-      i++;
-    }
-    return n;
-  }
-
-  /// Skips a `$`-interpolation starting at [from] (the `$`), returning the
-  /// index just past it. Handles both `$identifier` and brace-matched `${…}`.
-  static int _skipInterpolation(String content, int from) {
-    final n = content.length;
-    if (from + 1 < n && content[from + 1] == '{') {
-      var i = from + 2;
-      var depth = 1;
-      while (i < n && depth > 0) {
-        final c = content[i];
-        if (c == '{') {
-          depth++;
-          i++;
-        } else if (c == '}') {
-          depth--;
-          i++;
-        } else if (c == "'" || c == '"') {
-          i = _skipString(content, i, raw: false);
-        } else {
-          i++;
-        }
-      }
-      return i;
-    }
-    var i = from + 1;
-    while (i < n && _isIdentPart(content[i])) {
-      i++;
-    }
-    return i;
-  }
-
-  /// The first line of [symbol] including its contiguous leading
-  /// doc-comment/annotation block (mirrors the removal-side extension), so a
-  /// self-referencing dartdoc link in the class's own doc counts as a
-  /// self-reference.
-  int _metadataTopLine(DocumentSymbol symbol, List<String> lines) {
-    final nameLine = symbol.selectionRange.start.line;
-    var top = symbol.range.start.line <= nameLine
-        ? symbol.range.start.line
-        : nameLine;
-    while (top - 1 >= 0) {
-      final trimmed = lines[top - 1].trim();
-      final isMetaLine =
-          trimmed.isEmpty ||
-          trimmed.startsWith('@') ||
-          trimmed.startsWith('//') ||
-          trimmed.startsWith('/*') ||
-          trimmed.startsWith('*') ||
-          trimmed.endsWith('*/');
-      if (isMetaLine) {
-        top--;
-      } else {
-        break;
-      }
-    }
-    return top;
-  }
-
-  /// The name to report for [symbol].
-  ///
-  /// The analysis server names constructor symbols with the class included
-  /// (`Foo` for the unnamed constructor, `Foo.named` for a named one). The
-  /// container already carries the class, so strip that prefix here and report
-  /// the unnamed constructor as `new` — yielding `Foo.named` / `Foo.new` once
-  /// combined with the container, rather than `Foo.Foo.named` / `Foo.Foo`.
-  String _declarationName(DocumentSymbol symbol, String? container) {
-    if (symbol.kind != .constructor) {
-      return symbol.name;
-    }
-    final raw = symbol.name;
-    if (container != null && raw.startsWith('$container.')) {
-      return raw.substring(container.length + 1);
-    }
-    return raw.isEmpty || raw == container ? 'new' : raw;
-  }
-
-  bool _isPrivateName(String name) {
-    final simple = name.contains('.') ? name.split('.').last : name;
-    return simple.startsWith('_');
-  }
-
-  /// Returns the annotations, modifiers and doc comments immediately preceding
-  /// [symbol], as a single string, for cheap annotation detection.
-  String _leadingMetadata(DocumentSymbol symbol, List<String> lines) {
-    final nameLine = symbol.selectionRange.start.line;
-    final top = _metadataTopLine(symbol, lines);
-    final end = nameLine < lines.length ? nameLine : lines.length - 1;
-    return lines.sublist(top, end + 1).join('\n');
-  }
+  String _relPath(String absPath, String rootPath) =>
+      p.split(p.relative(absPath, from: rootPath)).join('/');
 
   static int _byLocation(UnusedDeclaration a, UnusedDeclaration b) {
     final byFile = a.filePath.compareTo(b.filePath);
@@ -1692,37 +716,117 @@ class Ciach {
     final byLine = a.line.compareTo(b.line);
     return byLine != 0 ? byLine : a.column.compareTo(b.column);
   }
+}
 
-  String? _readFile(String path) {
-    try {
-      return File(path).readAsStringSync();
-    } on Object {
-      return null;
-    }
-  }
+/// The remove-safety pre-pass: facts gathered up front so the reporting loop
+/// stays a set of cheap lookups when deciding which findings are report-only
+/// (`removalBlocked`) because auto-removing them would break the build.
+///
+/// * [emptiedEnums] — enums every one of whose values would be removed while
+///   the enum type is still referenced, leaving `enum E {}` (a compile error).
+/// * [blockedCtorClasses] — live classes all of whose constructors are dead:
+///   removing them synthesizes an implicit default constructor that strands
+///   `final` fields or breaks super-constructor forwarding.
+/// * [enumValuesIterated] — enums whose values are all reachable through
+///   `.values` iteration, so a value reached only that way is used, not dead,
+///   and is suppressed entirely rather than reported.
+class _RemoveSafety {
+  const _RemoveSafety({
+    required this.emptiedEnums,
+    required this.blockedCtorClasses,
+    required this.enumValuesIterated,
+  });
 
-  /// Runs [fn] over [items] with at most [concurrency] futures in flight,
-  /// preserving input order in the returned list.
-  Future<List<R>> _mapPooled<T, R>(
-    List<T> items,
-    int concurrency,
-    Future<R> Function(T) fn,
-  ) async {
-    final results = List<R?>.filled(items.length, null);
-    var next = 0;
+  factory _RemoveSafety.analyze(
+    Ciach finder,
+    List<Candidate> candidates,
+    List<RefStatus> statuses,
+    List<List<Location>> refsByCandidate,
+    Map<String, Set<String>> deadClassNames,
+  ) {
+    final sources = finder._sources;
+    final enumTypeHasRef = <DeclKey, bool>{};
+    final enumValueTotal = <DeclKey, int>{};
+    final enumValueDead = <DeclKey, int>{};
+    final enumValuesIterated = <DeclKey>{};
+    final ctorTotal = <DeclKey, int>{};
+    final ctorDead = <DeclKey, int>{};
+    final ctorForwardsSuper = <DeclKey, bool>{};
+    final classByKey = <DeclKey, Candidate>{};
 
-    Future<void> worker() async {
-      while (true) {
-        final index = next++;
-        if (index >= items.length) {
-          return;
+    for (var i = 0; i < candidates.length; i++) {
+      final candidate = candidates[i];
+      final symbol = candidate.symbol;
+      final unused = statuses[i] == RefStatus.unused;
+      if (symbol.kind == .enum$ && !candidate.isEnumValue) {
+        enumTypeHasRef[candidate.key] = refsByCandidate[i].isNotEmpty;
+        if (refsByCandidate[i].any(sources.isDotValuesRef) ||
+            sources.enumIteratesOwnValues(candidate)) {
+          enumValuesIterated.add(candidate.key);
         }
-        results[index] = await fn(items[index]);
+      } else if (candidate.isEnumValue) {
+        if (candidate.containerKey case final key?) {
+          enumValueTotal.update(key, (n) => n + 1, ifAbsent: () => 1);
+          if (unused) {
+            enumValueDead.update(key, (n) => n + 1, ifAbsent: () => 1);
+          }
+        }
+      } else if (symbol.kind == .class$) {
+        classByKey[candidate.key] = candidate;
+      } else if (symbol.kind == .constructor) {
+        if (candidate.containerKey case final key?) {
+          ctorTotal.update(key, (n) => n + 1, ifAbsent: () => 1);
+          if (unused) {
+            ctorDead.update(key, (n) => n + 1, ifAbsent: () => 1);
+            if (sources.ctorForwardsSuper(candidate)) {
+              ctorForwardsSuper[key] = true;
+            }
+          }
+        }
       }
     }
 
-    final workerCount = concurrency < items.length ? concurrency : items.length;
-    await Future.wait([for (var i = 0; i < workerCount; i++) worker()]);
-    return results.cast<R>();
+    final emptiedEnums = <DeclKey>{};
+    for (final MapEntry(:key, value: total) in enumValueTotal.entries) {
+      final dead = enumValueDead[key] ?? 0;
+      if (dead == 0 || dead != total) {
+        continue;
+      }
+      // Conservative: if the enum-type candidate is missing we cannot prove the
+      // enum is itself being removed, so assume it stays and block.
+      if (enumTypeHasRef[key] ?? true) {
+        emptiedEnums.add(key);
+      }
+    }
+
+    final blockedCtorClasses = <DeclKey>{};
+    for (final MapEntry(:key, value: total) in ctorTotal.entries) {
+      final dead = ctorDead[key] ?? 0;
+      if (dead == 0 || dead != total) {
+        continue;
+      }
+      // A dead class is removed whole (its constructors go with it), so its
+      // constructors are never reported on their own — nothing to guard.
+      if (deadClassNames[key.path]?.contains(key.name) ?? false) {
+        continue;
+      }
+      final classCandidate = classByKey[key];
+      final hasFinalField =
+          classCandidate != null &&
+          sources.classHasFinalInstanceField(classCandidate);
+      if (hasFinalField || (ctorForwardsSuper[key] ?? false)) {
+        blockedCtorClasses.add(key);
+      }
+    }
+
+    return _RemoveSafety(
+      emptiedEnums: emptiedEnums,
+      blockedCtorClasses: blockedCtorClasses,
+      enumValuesIterated: enumValuesIterated,
+    );
   }
+
+  final Set<DeclKey> emptiedEnums;
+  final Set<DeclKey> blockedCtorClasses;
+  final Set<DeclKey> enumValuesIterated;
 }

--- a/lib/src/finder.dart
+++ b/lib/src/finder.dart
@@ -175,8 +175,7 @@ class Ciach {
       final deadClassNames = <String, Set<String>>{};
       for (var i = 0; i < candidates.length; i++) {
         final candidate = candidates[i];
-        if (statuses[i] == RefStatus.unused &&
-            candidate.symbol.kind == .class$) {
+        if (statuses[i] == .unused && candidate.symbol.kind == .class$) {
           deadClassNames
               .putIfAbsent(candidate.path, () => <String>{})
               .add(candidate.symbol.name);
@@ -195,7 +194,7 @@ class Ciach {
         final candidate = candidates[i];
         final refs = refsByCandidate[i];
         switch (statuses[i]) {
-          case RefStatus.unused:
+          case .unused:
             if (freezedUnionArms.contains(i)) {
               break;
             }
@@ -260,9 +259,9 @@ class Ciach {
                     : null,
               ),
             );
-          case RefStatus.docOnly:
+          case .docOnly:
             docOnly.add(_toUnused(candidate, rootPath));
-          case RefStatus.used:
+          case .used:
             break;
         }
       }
@@ -338,22 +337,24 @@ class Ciach {
     for (final symbol in symbols) {
       if (typeLikeKinds.contains(symbol.kind) &&
           _freezedAnnotation.hasMatch(symbol.leadingMetadata(lines))) {
-        _freezedAnnotatedClasses.add(declKey(path, symbol.name));
+        _freezedAnnotatedClasses.add(DeclKey(path, symbol.name));
       }
       if (_shouldConsider(symbol, parentIsEnum, lines)) {
-        out.add((
-          uri: uri,
-          path: path,
-          symbol: symbol,
-          container: container,
-          isEnumValue: parentIsEnum && symbol.kind == .enum$,
-          // `symbols` are this symbol's siblings (its class's members when
-          // `symbol` is a constructor), so this confirms the sole-constructor
-          // shape without threading the list any further.
-          isPreventInstantiationCtor: symbol.isPreventInstantiationMarker(
-            symbols,
+        out.add(
+          Candidate(
+            uri: uri,
+            path: path,
+            symbol: symbol,
+            container: container,
+            isEnumValue: parentIsEnum && symbol.kind == .enum$,
+            // `symbols` are this symbol's siblings (its class's members when
+            // `symbol` is a constructor), so this confirms the sole-constructor
+            // shape without threading the list any further.
+            isPreventInstantiationCtor: symbol.isPreventInstantiationMarker(
+              symbols,
+            ),
           ),
-        ));
+        );
       }
       final childContainer = typeLikeKinds.contains(symbol.kind)
           ? symbol.name
@@ -448,11 +449,9 @@ class Ciach {
       return _classifyClass(candidate, refs);
     }
     if (refs.isEmpty) {
-      return RefStatus.unused;
+      return .unused;
     }
-    return refs.any((loc) => !_isDocReference(loc))
-        ? RefStatus.used
-        : RefStatus.docOnly;
+    return refs.any((loc) => !_isDocReference(loc)) ? .used : .docOnly;
   }
 
   /// Classifies a class by its references, ignoring self-references.
@@ -486,14 +485,14 @@ class Ciach {
         continue;
       }
       // A real, non-pattern reference from outside: the class is used.
-      return RefStatus.used;
+      return .used;
     }
     // Matched-only-by-a-pattern (never constructed) is dead code, not a softer
     // doc-only report.
     if (hasPatternMatch) {
-      return RefStatus.unused;
+      return .unused;
     }
-    return hasExternalDoc ? RefStatus.docOnly : RefStatus.unused;
+    return hasExternalDoc ? .docOnly : .unused;
   }
 
   /// Whether [location] points at a dartdoc `[Xxx]`-style reference rather than
@@ -599,7 +598,7 @@ class Ciach {
     for (var i = 0; i < candidates.length; i++) {
       final c = candidates[i];
       if (c.symbol.kind == .constructor &&
-          statuses[i] == RefStatus.used &&
+          statuses[i] == .used &&
           c.symbol.declarationName(c.container) == 'fromJson') {
         if (c.containerKey case final key?) {
           unionsWithUsedFromJson.add(key);
@@ -609,7 +608,7 @@ class Ciach {
 
     final arms = <int>{};
     for (var i = 0; i < candidates.length; i++) {
-      if (statuses[i] != RefStatus.unused) {
+      if (statuses[i] != .unused) {
         continue;
       }
       final c = candidates[i];
@@ -757,7 +756,7 @@ class _RemoveSafety {
     for (var i = 0; i < candidates.length; i++) {
       final candidate = candidates[i];
       final symbol = candidate.symbol;
-      final unused = statuses[i] == RefStatus.unused;
+      final unused = statuses[i] == .unused;
       if (symbol.kind == .enum$ && !candidate.isEnumValue) {
         enumTypeHasRef[candidate.key] = refsByCandidate[i].isNotEmpty;
         if (refsByCandidate[i].any(sources.isDotValuesRef) ||

--- a/lib/src/lexing.dart
+++ b/lib/src/lexing.dart
@@ -1,0 +1,253 @@
+/*
+ * AI-Provenance:
+ *   model: claude-opus-4-8
+ *   harness: Claude Code
+ *   plugins:
+ *     - lean-ai-provenance
+ *   skills:
+ *     - mark-ai-provenance
+ */
+
+/// A minimal Dart lexer, just rich enough for the structural checks the finder
+/// needs (constructor shapes, pattern matches, enum-value iteration). It drops
+/// whitespace, comments, and string literals so keywords and brackets can be
+/// matched without tripping over a `case` that only appears inside a comment or
+/// string — but it is deliberately *not* a full parser.
+library;
+
+/// A single lexical token: a source span plus whether it is an identifier /
+/// keyword (`isWord`) or a single punctuation character. Whitespace, comments,
+/// and string literals are dropped during tokenization.
+typedef Token = ({int start, int end, bool isWord, String value});
+
+/// Opening bracket punctuation.
+const _openers = {'(', '[', '{'};
+
+/// Closing bracket punctuation, paired positionally with [_openers].
+const _closers = {')', ']', '}'};
+
+extension TokenBrackets on Token {
+  /// Whether this token is an opening bracket (`(`, `[`, `{`).
+  bool get isOpener => !isWord && _openers.contains(value);
+
+  /// Whether this token is a closing bracket (`)`, `]`, `}`).
+  bool get isCloser => !isWord && _closers.contains(value);
+}
+
+/// The byte offset of the start of each line in [content] (index 0 is offset
+/// 0). Used to translate LSP line/character positions into absolute offsets.
+List<int> computeLineStarts(String content) {
+  final starts = <int>[0];
+  for (var i = 0; i < content.length; i++) {
+    if (content[i] == '\n') {
+      starts.add(i + 1);
+    }
+  }
+  return starts;
+}
+
+/// Splits [content] into [Token]s, skipping whitespace, `//` and (nesting)
+/// `/* */` comments, and every string-literal form (single/double,
+/// triple-quoted, raw, and `${…}`/`$id` interpolation). Everything else is
+/// emitted as either a word token or a single-character punctuation token.
+List<Token> tokenize(String content) {
+  final tokens = <Token>[];
+  final n = content.length;
+  var i = 0;
+  while (i < n) {
+    final ch = content[i];
+    if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r') {
+      i++;
+      continue;
+    }
+    if (ch == '/' && i + 1 < n && content[i + 1] == '/') {
+      i += 2;
+      while (i < n && content[i] != '\n') {
+        i++;
+      }
+      continue;
+    }
+    if (ch == '/' && i + 1 < n && content[i + 1] == '*') {
+      i = _skipBlockComment(content, i);
+      continue;
+    }
+    if ((ch == 'r' || ch == 'R') &&
+        i + 1 < n &&
+        (content[i + 1] == "'" || content[i + 1] == '"')) {
+      i = _skipString(content, i + 1, raw: true);
+      continue;
+    }
+    if (ch == "'" || ch == '"') {
+      i = _skipString(content, i, raw: false);
+      continue;
+    }
+    if (_isIdentStart(ch)) {
+      final start = i;
+      i++;
+      while (i < n && _isIdentPart(content[i])) {
+        i++;
+      }
+      tokens.add((
+        start: start,
+        end: i,
+        isWord: true,
+        value: content.substring(start, i),
+      ));
+      continue;
+    }
+    tokens.add((start: i, end: i + 1, isWord: false, value: ch));
+    i++;
+  }
+  return tokens;
+}
+
+/// The index of the token whose span starts exactly at [offset], or `null`
+/// if none does. Tokens are ordered by start, so this is a binary search.
+int? tokenIndexAt(List<Token> tokens, int offset) {
+  var lo = 0;
+  var hi = tokens.length - 1;
+  while (lo <= hi) {
+    final mid = (lo + hi) >> 1;
+    final start = tokens[mid].start;
+    if (start == offset) {
+      return mid;
+    }
+    if (start < offset) {
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return null;
+}
+
+/// Walking backward from [from], the index of the nearest enclosing (not yet
+/// closed) opening bracket, or `null` if the scan runs off the start.
+int? enclosingOpener(List<Token> tokens, int from) {
+  var depth = 0;
+  for (var k = from; k >= 0; k--) {
+    final t = tokens[k];
+    if (t.isCloser) {
+      depth++;
+    } else if (t.isOpener) {
+      if (depth == 0) {
+        return k;
+      }
+      depth--;
+    }
+  }
+  return null;
+}
+
+/// The index of the `(` matching the `)` at [closeIndex], or `null`.
+int? matchingOpenParen(List<Token> tokens, int closeIndex) {
+  var depth = 0;
+  for (var k = closeIndex; k >= 0; k--) {
+    final t = tokens[k];
+    if (t.isCloser) {
+      depth++;
+    } else if (t.isOpener) {
+      depth--;
+      if (depth == 0) {
+        return t.value == '(' ? k : null;
+      }
+    }
+  }
+  return null;
+}
+
+bool _isIdentStart(String ch) =>
+    (ch.compareTo('a') >= 0 && ch.compareTo('z') <= 0) ||
+    (ch.compareTo('A') >= 0 && ch.compareTo('Z') <= 0) ||
+    ch == '_' ||
+    ch == r'$';
+
+bool _isIdentPart(String ch) =>
+    _isIdentStart(ch) || (ch.compareTo('0') >= 0 && ch.compareTo('9') <= 0);
+
+/// Skips a (possibly nested) `/* … */` block comment starting at [from],
+/// returning the index just past it.
+int _skipBlockComment(String content, int from) {
+  final n = content.length;
+  var i = from + 2;
+  var depth = 1;
+  while (i < n && depth > 0) {
+    if (content[i] == '/' && i + 1 < n && content[i + 1] == '*') {
+      depth++;
+      i += 2;
+    } else if (content[i] == '*' && i + 1 < n && content[i + 1] == '/') {
+      depth--;
+      i += 2;
+    } else {
+      i++;
+    }
+  }
+  return i;
+}
+
+/// Skips a string literal whose opening quote is at [from], returning the
+/// index just past the closing quote. Handles triple quotes, escapes, and —
+/// unless [raw] — `${…}`/`$id` interpolation (whose braces and nested
+/// strings are matched so a `}` or quote inside them doesn't end the string).
+int _skipString(String content, int from, {required bool raw}) {
+  final n = content.length;
+  final quote = content[from];
+  final triple =
+      from + 2 < n && content[from + 1] == quote && content[from + 2] == quote;
+  var i = from + (triple ? 3 : 1);
+  while (i < n) {
+    final c = content[i];
+    if (!raw && c == r'\') {
+      i += 2;
+      continue;
+    }
+    if (!raw && c == r'$') {
+      i = _skipInterpolation(content, i);
+      continue;
+    }
+    if (c == quote) {
+      if (!triple) {
+        return i + 1;
+      }
+      if (i + 2 < n && content[i + 1] == quote && content[i + 2] == quote) {
+        return i + 3;
+      }
+    }
+    if (!triple && c == '\n') {
+      // Unterminated single-line string; stop at the newline rather than run on.
+      return i;
+    }
+    i++;
+  }
+  return n;
+}
+
+/// Skips a `$`-interpolation starting at [from] (the `$`), returning the
+/// index just past it. Handles both `$identifier` and brace-matched `${…}`.
+int _skipInterpolation(String content, int from) {
+  final n = content.length;
+  if (from + 1 < n && content[from + 1] == '{') {
+    var i = from + 2;
+    var depth = 1;
+    while (i < n && depth > 0) {
+      final c = content[i];
+      if (c == '{') {
+        depth++;
+        i++;
+      } else if (c == '}') {
+        depth--;
+        i++;
+      } else if (c == "'" || c == '"') {
+        i = _skipString(content, i, raw: false);
+      } else {
+        i++;
+      }
+    }
+    return i;
+  }
+  var i = from + 1;
+  while (i < n && _isIdentPart(content[i])) {
+    i++;
+  }
+  return i;
+}

--- a/lib/src/lexing.dart
+++ b/lib/src/lexing.dart
@@ -15,18 +15,28 @@
 /// string — but it is deliberately *not* a full parser.
 library;
 
-/// A single lexical token: a source span plus whether it is an identifier /
-/// keyword (`isWord`) or a single punctuation character. Whitespace, comments,
-/// and string literals are dropped during tokenization.
-typedef Token = ({int start, int end, bool isWord, String value});
-
 /// Opening bracket punctuation.
 const _openers = {'(', '[', '{'};
 
 /// Closing bracket punctuation, paired positionally with [_openers].
 const _closers = {')', ']', '}'};
 
-extension TokenBrackets on Token {
+/// A single lexical token: a source span plus whether it is an identifier /
+/// keyword (`isWord`) or a single punctuation character. Whitespace, comments,
+/// and string literals are dropped during tokenization.
+final class Token {
+  const Token({
+    required this.start,
+    required this.end,
+    required this.isWord,
+    required this.value,
+  });
+
+  final int start;
+  final int end;
+  final bool isWord;
+  final String value;
+
   /// Whether this token is an opening bracket (`(`, `[`, `{`).
   bool get isOpener => !isWord && _openers.contains(value);
 
@@ -56,7 +66,7 @@ List<Token> tokenize(String content) {
   var i = 0;
   while (i < n) {
     final ch = content[i];
-    if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r') {
+    if (ch case ' ' || '\t' || '\n' || '\r') {
       i++;
       continue;
     }
@@ -87,15 +97,17 @@ List<Token> tokenize(String content) {
       while (i < n && _isIdentPart(content[i])) {
         i++;
       }
-      tokens.add((
-        start: start,
-        end: i,
-        isWord: true,
-        value: content.substring(start, i),
-      ));
+      tokens.add(
+        Token(
+          start: start,
+          end: i,
+          isWord: true,
+          value: content.substring(start, i),
+        ),
+      );
       continue;
     }
-    tokens.add((start: i, end: i + 1, isWord: false, value: ch));
+    tokens.add(Token(start: i, end: i + 1, isWord: false, value: ch));
     i++;
   }
   return tokens;

--- a/lib/src/paths.dart
+++ b/lib/src/paths.dart
@@ -1,0 +1,16 @@
+/*
+ * AI-Provenance:
+ *   model: claude-opus-4-8
+ *   harness: Claude Code
+ *   plugins:
+ *     - lean-ai-provenance
+ *   skills:
+ *     - mark-ai-provenance
+ */
+
+import 'package:path/path.dart' as p;
+
+/// [absPath] expressed relative to [rootPath], with `/` separators — the form
+/// used for a finding's and a coupled removal's `filePath`.
+String relativePosix(String absPath, String rootPath) =>
+    p.split(p.relative(absPath, from: rootPath)).join('/');

--- a/lib/src/reference_classifier.dart
+++ b/lib/src/reference_classifier.dart
@@ -47,7 +47,7 @@ class ReferenceClassifier {
     if (refs.isEmpty) {
       return .unused;
     }
-    return refs.any((loc) => !_sources.isDocReference(loc)) ? .used : .docOnly;
+    return refs.every(_sources.isDocReference) ? .docOnly : .used;
   }
 
   /// Classifies a class by its references, ignoring self-references.

--- a/lib/src/reference_classifier.dart
+++ b/lib/src/reference_classifier.dart
@@ -1,0 +1,128 @@
+/*
+ * AI-Provenance:
+ *   model: claude-opus-4-8
+ *   harness: Claude Code
+ *   plugins:
+ *     - lean-ai-provenance
+ *   skills:
+ *     - mark-ai-provenance
+ */
+
+import 'package:ciach/src/candidates.dart';
+import 'package:ciach/src/conventions/flutter_widgets.dart';
+import 'package:ciach/src/reference_kinds.dart';
+import 'package:ciach/src/source_index.dart';
+import 'package:ciach/src/symbols.dart';
+import 'package:ciach/src/syntax_rules.dart';
+import 'package:pro_lsp/pro_lsp.dart' show Location;
+
+/// Decides whether a declaration is used, unused, or referenced only from doc
+/// comments, from the references the analysis server reported for it.
+///
+/// This is the semantic heart of the tool: everything that discounts a
+/// reference (self-references, the `State<Self>` pairing, doc-comment links,
+/// type-pattern matches) lives here, kept apart from the run orchestration.
+class ReferenceClassifier {
+  ReferenceClassifier(this._sources, {required this.unusedUnionMembers});
+
+  final SourceIndex _sources;
+
+  /// Whether a class matched only by a type pattern (never constructed) counts
+  /// as dead — the opt-in `--unused-union-members` behaviour.
+  final bool unusedUnionMembers;
+
+  /// Classifies [candidate] from the [refs] reported for it.
+  ///
+  /// Non-class candidates keep the simple rule: any real (non-doc) reference
+  /// means used, only doc-comment links means doc-only, none means unused.
+  ///
+  /// Classes get [_classifyClass], which discounts *self-references* — the
+  /// class's own body, and the `State<Self>` StatefulWidget pairing — so a
+  /// class kept alive only by its own unnamed constructor's declaration (whose
+  /// name coincides with the class) is correctly seen as dead.
+  RefStatus classify(Candidate candidate, List<Location> refs) {
+    if (candidate.symbol.kind == .class$) {
+      return _classifyClass(candidate, refs);
+    }
+    if (refs.isEmpty) {
+      return .unused;
+    }
+    return refs.any((loc) => !_sources.isDocReference(loc)) ? .used : .docOnly;
+  }
+
+  /// Classifies a class by its references, ignoring self-references.
+  ///
+  /// A class is used only if some reference is a real (non-doc) reference from
+  /// *outside* the class itself; if the only outside references are doc-comment
+  /// links it is doc-only, and otherwise (only self-references, or none at all)
+  /// it is unused. This is deliberately conservative: any single unexplained
+  /// outside reference keeps the class alive, so the failure mode is missing a
+  /// dead class, never deleting a live one.
+  RefStatus _classifyClass(Candidate candidate, List<Location> refs) {
+    var hasExternalDoc = false;
+    var hasPatternMatch = false;
+    for (final loc in refs) {
+      if (isSelfClassReference(candidate, loc)) {
+        continue;
+      }
+      if (_sources.isDocReference(loc)) {
+        hasExternalDoc = true;
+        continue;
+      }
+      // With --unused-union-members, a reference that is confidently a *type
+      // pattern* (a `case`/if-case/while-case pattern, or a switch-expression
+      // arm) is a *match*, not a construction: if the type is never
+      // constructed, no such match can ever fire, so it is discounted like a
+      // self-reference. Any reference that is not confidently a type pattern
+      // keeps the class alive — the conservative choice (nested sub-patterns
+      // and pattern-variable declarations are intentionally not recognized).
+      if (unusedUnionMembers && _sources.isPatternRef(loc)) {
+        hasPatternMatch = true;
+        continue;
+      }
+      // A real, non-pattern reference from outside: the class is used.
+      return .used;
+    }
+    // Matched-only-by-a-pattern (never constructed) is dead code, not a softer
+    // doc-only report.
+    if (hasPatternMatch) {
+      return .unused;
+    }
+    return hasExternalDoc ? .docOnly : .unused;
+  }
+
+  /// Whether [loc] is a reference to [candidate] that does not count as a use.
+  ///
+  /// Two shapes qualify:
+  ///
+  /// 1. A reference inside the class's own source span — its body, signature,
+  ///    or leading doc/annotation lines. This covers the unnamed constructor's
+  ///    declaration, a `State<Foo>` return type on the widget's own
+  ///    `createState`, and any purely-internal self-use.
+  /// 2. A `State<Foo>` type-argument reference anywhere — the StatefulWidget
+  ///    pairing (see [FlutterWidgets.isStatePairingReference]).
+  bool isSelfClassReference(Candidate candidate, Location loc) {
+    if (SourceIndex.pathOf(loc.uri) == candidate.path) {
+      final top = candidate.symbol.metadataTopLine(
+        _sources.lines(candidate.path),
+      );
+      final pos = loc.range.start;
+      if (pos.line >= top && pos.atOrBefore(candidate.symbol.range.end)) {
+        return true;
+      }
+    }
+    return _sources.isStatePairingReference(candidate.symbol.name, loc);
+  }
+
+  /// Whether [candidate] — already classified as unused under
+  /// `--unused-union-members` — is kept dead by *type patterns*: at least one
+  /// of its non-self, non-doc references is a `case`/switch-expression pattern
+  /// match rather than a construction.
+  bool isPatternMatchedClass(Candidate candidate, List<Location> refs) =>
+      refs.any(
+        (loc) =>
+            !isSelfClassReference(candidate, loc) &&
+            !_sources.isDocReference(loc) &&
+            _sources.isPatternRef(loc),
+      );
+}

--- a/lib/src/reference_kinds.dart
+++ b/lib/src/reference_kinds.dart
@@ -1,0 +1,29 @@
+/*
+ * AI-Provenance:
+ *   model: claude-opus-4-8
+ *   harness: Claude Code
+ *   plugins:
+ *     - lean-ai-provenance
+ *   skills:
+ *     - mark-ai-provenance
+ */
+
+import 'package:ciach/src/source_index.dart';
+import 'package:pro_lsp/pro_lsp.dart' show Location;
+
+/// Recognizers for special *shapes* of reference — ones the classifier treats
+/// differently from an ordinary code use.
+extension ReferenceKinds on SourceIndex {
+  /// Whether [loc] points at a dartdoc `[Xxx]`-style reference rather than real
+  /// code — i.e. its line, in the file it points into, starts with `///`. Block
+  /// (`/** */`) doc comments aren't recognized; `///` is the standard and
+  /// lint-enforced style.
+  bool isDocReference(Location loc) {
+    final docLines = lines(SourceIndex.pathOf(loc.uri));
+    final line = loc.range.start.line;
+    if (line < 0 || line >= docLines.length) {
+      return false;
+    }
+    return docLines[line].trim().startsWith('///');
+  }
+}

--- a/lib/src/remove_safety.dart
+++ b/lib/src/remove_safety.dart
@@ -1,0 +1,126 @@
+/*
+ * AI-Provenance:
+ *   model: claude-opus-4-8
+ *   harness: Claude Code
+ *   plugins:
+ *     - lean-ai-provenance
+ *   skills:
+ *     - mark-ai-provenance
+ */
+
+import 'package:ciach/src/candidates.dart';
+import 'package:ciach/src/source_index.dart';
+import 'package:ciach/src/syntax_rules.dart';
+import 'package:pro_lsp/pro_lsp.dart' show Location;
+
+/// The remove-safety pre-pass: facts gathered up front so the reporting loop
+/// stays a set of cheap lookups when deciding which findings are report-only
+/// (`removalBlocked`) because auto-removing them would break the build.
+///
+/// * [emptiedEnums] — enums every one of whose values would be removed while
+///   the enum type is still referenced, leaving `enum E {}` (a compile error).
+/// * [blockedCtorClasses] — live classes all of whose constructors are dead:
+///   removing them synthesizes an implicit default constructor that strands
+///   `final` fields or breaks super-constructor forwarding.
+/// * [enumValuesIterated] — enums whose values are all reachable through
+///   `.values` iteration, so a value reached only that way is used, not dead,
+///   and is suppressed entirely rather than reported.
+class RemoveSafety {
+  const RemoveSafety({
+    required this.emptiedEnums,
+    required this.blockedCtorClasses,
+    required this.enumValuesIterated,
+  });
+
+  factory RemoveSafety.analyze(
+    SourceIndex sources,
+    List<Candidate> candidates,
+    List<RefStatus> statuses,
+    List<List<Location>> refsByCandidate,
+    Map<String, Set<String>> deadClassNames,
+  ) {
+    final enumTypeHasRef = <DeclKey, bool>{};
+    final enumValueTotal = <DeclKey, int>{};
+    final enumValueDead = <DeclKey, int>{};
+    final enumValuesIterated = <DeclKey>{};
+    final ctorTotal = <DeclKey, int>{};
+    final ctorDead = <DeclKey, int>{};
+    final ctorForwardsSuper = <DeclKey, bool>{};
+    final classByKey = <DeclKey, Candidate>{};
+
+    for (var i = 0; i < candidates.length; i++) {
+      final candidate = candidates[i];
+      final symbol = candidate.symbol;
+      final unused = statuses[i] == .unused;
+      if (symbol.kind == .enum$ && !candidate.isEnumValue) {
+        enumTypeHasRef[candidate.key] = refsByCandidate[i].isNotEmpty;
+        if (refsByCandidate[i].any(sources.isDotValuesRef) ||
+            sources.enumIteratesOwnValues(candidate)) {
+          enumValuesIterated.add(candidate.key);
+        }
+      } else if (candidate.isEnumValue) {
+        if (candidate.containerKey case final key?) {
+          enumValueTotal.update(key, (n) => n + 1, ifAbsent: () => 1);
+          if (unused) {
+            enumValueDead.update(key, (n) => n + 1, ifAbsent: () => 1);
+          }
+        }
+      } else if (symbol.kind == .class$) {
+        classByKey[candidate.key] = candidate;
+      } else if (symbol.kind == .constructor) {
+        if (candidate.containerKey case final key?) {
+          ctorTotal.update(key, (n) => n + 1, ifAbsent: () => 1);
+          if (unused) {
+            ctorDead.update(key, (n) => n + 1, ifAbsent: () => 1);
+            if (sources.ctorForwardsSuper(candidate)) {
+              ctorForwardsSuper[key] = true;
+            }
+          }
+        }
+      }
+    }
+
+    final emptiedEnums = <DeclKey>{};
+    for (final MapEntry(:key, value: total) in enumValueTotal.entries) {
+      final dead = enumValueDead[key] ?? 0;
+      if (dead == 0 || dead != total) {
+        continue;
+      }
+      // Conservative: if the enum-type candidate is missing we cannot prove the
+      // enum is itself being removed, so assume it stays and block.
+      if (enumTypeHasRef[key] ?? true) {
+        emptiedEnums.add(key);
+      }
+    }
+
+    final blockedCtorClasses = <DeclKey>{};
+    for (final MapEntry(:key, value: total) in ctorTotal.entries) {
+      final dead = ctorDead[key] ?? 0;
+      if (dead == 0 || dead != total) {
+        continue;
+      }
+      // A dead class is removed whole (its constructors go with it), so its
+      // constructors are never reported on their own — nothing to guard.
+      if (deadClassNames[key.path]?.contains(key.name) ?? false) {
+        continue;
+      }
+      final classCandidate = classByKey[key];
+      final hasFinalField =
+          classCandidate != null &&
+          sources.classHasFinalInstanceField(classCandidate);
+      if (hasFinalField || (ctorForwardsSuper[key] ?? false)) {
+        blockedCtorClasses.add(key);
+      }
+    }
+
+    return RemoveSafety(
+      emptiedEnums: emptiedEnums,
+      blockedCtorClasses: blockedCtorClasses,
+      enumValuesIterated: enumValuesIterated,
+    );
+  }
+
+  final Set<DeclKey> emptiedEnums;
+  final Set<DeclKey> blockedCtorClasses;
+  final Set<DeclKey> enumValuesIterated;
+}

--- a/lib/src/remover.dart
+++ b/lib/src/remover.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:ciach/src/models.dart';
+import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 import 'package:pro_lsp/pro_lsp.dart' show SymbolKind;
 
@@ -199,21 +200,20 @@ List<_Span> _declaratorSpans(
       offsetOf(d.range.startLine, d.range.startColumn);
 
   final spans = <_Span>[];
-  for (final entry in groups.entries) {
-    final members = entry.value
-      ..sort((a, b) => startOf(a).compareTo(startOf(b)));
+  for (final MapEntry(key: statementEnd, value: members) in groups.entries) {
+    final sorted = members.sortedBy<num>(startOf);
     final whole = _wholeStatementSpan(
       content,
       lines,
-      members,
-      entry.key,
+      sorted,
+      statementEnd,
       offsetOf,
     );
     if (whole != null) {
       spans.add(whole);
       continue;
     }
-    for (final decl in members) {
+    for (final decl in sorted) {
       final span = _partialDeclaratorSpan(decl, content, offsetOf);
       if (span != null) {
         spans.add(span);
@@ -287,25 +287,21 @@ _Span? _partialDeclaratorSpan(
 
   final beforeText = content.substring(lineStart, baseStart);
   final leadingComma = _lastTopLevelComma(beforeText);
-  final separator = _nextTopLevelSeparator(content, baseEnd);
-  if (separator == null) {
-    return null;
-  }
-
-  if (separator.$2 == ',') {
-    final start = leadingComma == null
-        ? baseStart
-        : lineStart + leadingComma + 1;
-    return (start: start, end: separator.$1 + 1);
-  }
-  if (leadingComma == null) {
-    // Unreachable in practice: a sole declarator is always caught by
-    // `_wholeStatementSpan` first. Handled anyway for robustness.
-    return (start: lineStart, end: separator.$1 + 1);
-  }
-  // The last of several declarators: drop the now-orphaned leading comma,
-  // but leave the `;` in place — it still terminates the statement.
-  return (start: lineStart + leadingComma, end: baseEnd);
+  return switch (_nextTopLevelSeparator(content, baseEnd)) {
+    null => null,
+    (final commaEnd, ',') => (
+      start: leadingComma == null ? baseStart : lineStart + leadingComma + 1,
+      end: commaEnd + 1,
+    ),
+    // Separator is the statement's `;`: drop the now-orphaned leading comma if
+    // there is one, leaving the `;` in place; otherwise (a sole declarator,
+    // unreachable in practice since `_wholeStatementSpan` catches it first)
+    // fall back to the line start.
+    (final semicolonEnd, _) => switch (leadingComma) {
+      final comma? => (start: lineStart + comma, end: baseEnd),
+      null => (start: lineStart, end: semicolonEnd + 1),
+    },
+  };
 }
 
 /// Extends [startLine] upward over contiguous doc-comment/annotation lines
@@ -394,14 +390,14 @@ _Span _absorbOrphanEnumComma(String content, _Span span) {
 int? _finalStatementEnd(String content, int from) {
   var pos = from;
   while (true) {
-    final separator = _nextTopLevelSeparator(content, pos);
-    if (separator == null) {
-      return null;
+    switch (_nextTopLevelSeparator(content, pos)) {
+      case null:
+        return null;
+      case (final index, ';'):
+        return index;
+      case (final index, _):
+        pos = index + 1;
     }
-    if (separator.$2 == ';') {
-      return separator.$1;
-    }
-    pos = separator.$1 + 1;
   }
 }
 
@@ -483,9 +479,8 @@ bool _isWhitespace(String ch) =>
     ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r';
 
 List<_Span> _mergeSpans(List<_Span> spans) {
-  final sorted = [...spans]..sort((a, b) => a.start.compareTo(b.start));
   final merged = <_Span>[];
-  for (final span in sorted) {
+  for (final span in spans.sortedBy<num>((s) => s.start)) {
     if (merged.isNotEmpty && span.start <= merged.last.end) {
       final last = merged.removeLast();
       merged.add((

--- a/lib/src/remover.dart
+++ b/lib/src/remover.dart
@@ -50,7 +50,7 @@ int removeDeclarations(List<UnusedDeclaration> declarations, String rootPath) {
           .add(
             UnusedDeclaration(
               name: '',
-              kind: SymbolKind.class$,
+              kind: .class$,
               filePath: coupled.filePath,
               line: range.startLine + 1,
               column: range.startColumn + 1,
@@ -354,11 +354,17 @@ bool _looksLikeMetadata(String trimmedLine) =>
 /// consume the gap after a removed enum value's comma.
 int _skipSameLineBlank(String content, int from) {
   var i = from;
-  while (i < content.length && (content[i] == ' ' || content[i] == '\t')) {
+  while (i < content.length && _isSpaceOrTab(content[i])) {
     i++;
   }
   return i;
 }
+
+/// Whether [ch] is a space or tab — a blank that stays on the same line.
+bool _isSpaceOrTab(String ch) => switch (ch) {
+  ' ' || '\t' => true,
+  _ => false,
+};
 
 /// Drops the separator comma left dangling when a compact single-line enum
 /// loses a trailing run of values — when the merged [span] is bracketed on its
@@ -367,15 +373,14 @@ int _skipSameLineBlank(String content, int from) {
 /// multi-line enums untouched.
 _Span _absorbOrphanEnumComma(String content, _Span span) {
   var after = span.end;
-  while (after < content.length &&
-      (content[after] == ' ' || content[after] == '\t')) {
+  while (after < content.length && _isSpaceOrTab(content[after])) {
     after++;
   }
   if (after >= content.length || content[after] != '}') {
     return span;
   }
   var before = span.start - 1;
-  while (before >= 0 && (content[before] == ' ' || content[before] == '\t')) {
+  while (before >= 0 && _isSpaceOrTab(content[before])) {
     before--;
   }
   if (before < 0 || content[before] != ',') {
@@ -407,15 +412,15 @@ int? _lastTopLevelComma(String text) {
   var depth = 0;
   int? last;
   for (var i = 0; i < text.length; i++) {
-    final ch = text[i];
-    if (ch == '(' || ch == '[' || ch == '{' || ch == '<') {
-      depth++;
-    } else if (ch == ')' || ch == ']' || ch == '}' || ch == '>') {
-      if (depth > 0) {
-        depth--;
-      }
-    } else if (depth == 0 && ch == ',') {
-      last = i;
+    switch (text[i]) {
+      case '(' || '[' || '{' || '<':
+        depth++;
+      case ')' || ']' || '}' || '>':
+        if (depth > 0) {
+          depth--;
+        }
+      case ',' when depth == 0:
+        last = i;
     }
   }
   return last;
@@ -429,15 +434,16 @@ int? _lastTopLevelComma(String text) {
   var depth = 0;
   for (var i = from; i < content.length; i++) {
     final ch = content[i];
-    if (ch == '(' || ch == '[' || ch == '{') {
-      depth++;
-    } else if (ch == ')' || ch == ']' || ch == '}') {
-      if (depth == 0) {
-        return null;
-      }
-      depth--;
-    } else if (depth == 0 && (ch == ',' || ch == ';')) {
-      return (i, ch);
+    switch (ch) {
+      case '(' || '[' || '{':
+        depth++;
+      case ')' || ']' || '}':
+        if (depth == 0) {
+          return null;
+        }
+        depth--;
+      case ',' || ';' when depth == 0:
+        return (i, ch);
     }
   }
   return null;
@@ -475,8 +481,10 @@ int? _previousNonWhitespace(String content, int before) {
   return null;
 }
 
-bool _isWhitespace(String ch) =>
-    ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r';
+bool _isWhitespace(String ch) => switch (ch) {
+  ' ' || '\t' || '\n' || '\r' => true,
+  _ => false,
+};
 
 List<_Span> _mergeSpans(List<_Span> spans) {
   final merged = <_Span>[];

--- a/lib/src/reporter.dart
+++ b/lib/src/reporter.dart
@@ -11,6 +11,7 @@
 import 'dart:convert';
 
 import 'package:ciach/src/models.dart';
+import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 
 /// Renders a [FinderResult] for humans or machines.
@@ -42,23 +43,15 @@ abstract final class Reporter {
     List<UnusedDeclaration> decls,
     bool useColor,
   ) {
-    final byFile = <String, List<UnusedDeclaration>>{};
-    for (final decl in decls) {
-      byFile.putIfAbsent(decl.filePath, () => []).add(decl);
-    }
+    for (final MapEntry(key: file, value: fileDecls)
+        in decls.groupListsBy((d) => d.filePath).entries) {
+      buffer.writeln(_style(file, _bold, useColor));
 
-    for (final entry in byFile.entries) {
-      buffer.writeln(_style(entry.key, _bold, useColor));
+      // Column widths for tidy alignment (each group is non-empty).
+      final locWidth = fileDecls.map((d) => '${d.line}:${d.column}'.length).max;
+      final kindWidth = fileDecls.map((d) => d.kind.label.length).max;
 
-      // Column widths for tidy alignment.
-      final locWidth = entry.value
-          .map((d) => '${d.line}:${d.column}'.length)
-          .fold(0, (a, b) => a > b ? a : b);
-      final kindWidth = entry.value
-          .map((d) => d.kind.label.length)
-          .fold(0, (a, b) => a > b ? a : b);
-
-      for (final decl in entry.value) {
+      for (final decl in fileDecls) {
         final loc = '${decl.line}:${decl.column}'.padRight(locWidth);
         final kind = decl.kind.label.padRight(kindWidth);
         final visibility = decl.isPrivate ? 'private' : 'public';

--- a/lib/src/source_index.dart
+++ b/lib/src/source_index.dart
@@ -1,0 +1,119 @@
+/*
+ * AI-Provenance:
+ *   model: claude-opus-4-8
+ *   harness: Claude Code
+ *   plugins:
+ *     - lean-ai-provenance
+ *   skills:
+ *     - mark-ai-provenance
+ */
+
+import 'dart:io';
+
+import 'package:ciach/src/lexing.dart';
+import 'package:pro_lsp/pro_lsp.dart' show DocumentSymbol, Position;
+
+/// A `[start, end)` slice of a file's token stream: the full token list plus
+/// the index bounds of the tokens covered. Callers iterate `[start, end)` but
+/// may still peek neighbours (`tokens[end]`, `tokens[start - 1]`).
+typedef TokenWindow = ({List<Token> tokens, int start, int end});
+
+/// Lazily-computed, per-file view of the source under analysis: its lines,
+/// content, line-start offsets, and token stream, each cached on first use.
+///
+/// Everything the finder needs to translate an LSP [Position] into a byte
+/// offset or a token, without re-reading or re-lexing a file, lives here.
+class SourceIndex {
+  final _lines = <String, List<String>>{};
+  final _content = <String, String>{};
+  final _lineStarts = <String, List<int>>{};
+  final _tokens = <String, List<Token>>{};
+
+  /// The absolute file path a reference [uri] points at.
+  static String pathOf(String uri) => Uri.parse(uri).toFilePath();
+
+  /// Reads [path] from disk, returning `null` if it can't be read.
+  static String? readFile(String path) {
+    try {
+      return File(path).readAsStringSync();
+    } on Object {
+      return null;
+    }
+  }
+
+  /// The lines of the file at [path], read (and cached) on demand.
+  List<String> lines(String path) =>
+      _lines[path] ??= readFile(path)?.split('\n') ?? const [];
+
+  /// Records the [lines] of a file already opened in the analysis server, so
+  /// its content isn't re-read from disk.
+  void cacheLines(String path, List<String> lines) => _lines[path] = lines;
+
+  /// The full text of [path], reconstructed from the cached lines so it matches
+  /// the document content the analysis server resolved positions against.
+  String content(String path) => _content[path] ??= lines(path).join('\n');
+
+  List<int> lineStarts(String path) =>
+      _lineStarts[path] ??= computeLineStarts(content(path));
+
+  List<Token> tokens(String path) => _tokens[path] ??= tokenize(content(path));
+
+  /// Absolute offset of an LSP [position] in [path]'s content, or `null` if out
+  /// of range. LSP columns are UTF-16 code units, which is exactly how Dart
+  /// indexes a `String`, so the arithmetic needs no conversion.
+  int? offsetOf(String path, Position position) {
+    final starts = lineStarts(path);
+    if (position.line < 0 || position.line >= starts.length) {
+      return null;
+    }
+    final offset = starts[position.line] + position.character;
+    if (offset < 0 || offset > content(path).length) {
+      return null;
+    }
+    return offset;
+  }
+
+  /// The token index whose span starts exactly at [position] in [path], or
+  /// `null` if the position doesn't line up with a token start.
+  int? tokenIndexAtPosition(String path, Position position) {
+    final offset = offsetOf(path, position);
+    return offset == null ? null : tokenIndexAt(tokens(path), offset);
+  }
+
+  /// The window of tokens in [path] whose start offset falls within [symbol]'s
+  /// full source range, or `null` if the range can't be resolved. Unifies the
+  /// "scan the tokens inside this declaration" preamble shared by the
+  /// structural detectors.
+  TokenWindow? tokenWindow(String path, DocumentSymbol symbol) {
+    if (content(path).isEmpty) {
+      return null;
+    }
+    final startOff = offsetOf(path, symbol.range.start);
+    final endOff = offsetOf(path, symbol.range.end);
+    if (startOff == null || endOff == null) {
+      return null;
+    }
+    final toks = tokens(path);
+    return (
+      tokens: toks,
+      start: _lowerBoundStart(toks, startOff),
+      end: _lowerBoundStart(toks, endOff),
+    );
+  }
+
+  /// The index of the first token whose start offset is `>= offset` (tokens are
+  /// ordered by start), i.e. the lower bound for a range scan.
+  static int _lowerBoundStart(List<Token> tokens, int offset) {
+    var lo = 0;
+    var hi = tokens.length;
+    while (lo < hi) {
+      final mid = (lo + hi) >> 1;
+      if (tokens[mid].start < offset) {
+        lo = mid + 1;
+      } else {
+        hi = mid;
+      }
+    }
+    return lo;
+  }
+}

--- a/lib/src/symbols.dart
+++ b/lib/src/symbols.dart
@@ -161,10 +161,8 @@ extension PositionGeometry on Position {
 
 /// Whether [name] (possibly qualified, e.g. `Foo._bar`) is library-private —
 /// its simple segment starts with `_`.
-bool isPrivateName(String name) {
-  final simple = name.contains('.') ? name.split('.').last : name;
-  return simple.startsWith('_');
-}
+bool isPrivateName(String name) =>
+    (name.contains('.') ? name.split('.').last : name).startsWith('_');
 
 bool _looksLikeMetadata(String trimmedLine) =>
     trimmedLine.isEmpty ||

--- a/lib/src/symbols.dart
+++ b/lib/src/symbols.dart
@@ -1,0 +1,175 @@
+/*
+ * AI-Provenance:
+ *   model: claude-opus-4-8
+ *   harness: Claude Code
+ *   plugins:
+ *     - lean-ai-provenance
+ *   skills:
+ *     - mark-ai-provenance
+ */
+
+import 'package:ciach/src/models.dart';
+import 'package:pro_lsp/pro_lsp.dart' show DocumentSymbol, Position, SymbolKind;
+
+/// Symbol kinds that introduce a lexical scope; their name becomes the
+/// container for nested members.
+const typeLikeKinds = <SymbolKind>{.class$, .interface$, .enum$, .struct};
+
+/// Names of Dart's overloadable operators. The analysis server reports an
+/// `operator +`/`operator ==`/… declaration as a plain [SymbolKind.method]
+/// named exactly one of these — there is no distinct operator symbol kind —
+/// so this is the only reliable way to recognize one.
+const _operatorNames = <String>{
+  '+',
+  '-',
+  '*',
+  '/',
+  '%',
+  '~/',
+  '&',
+  '|',
+  '^',
+  '~',
+  '<<',
+  '>>',
+  '>>>',
+  '<',
+  '<=',
+  '>',
+  '>=',
+  '==',
+  '[]',
+  '[]=',
+};
+
+/// Symbol-shape predicates and naming rules, kept off the finder so the
+/// classification logic reads as intent rather than mechanics.
+extension SymbolChecks on DocumentSymbol {
+  /// Whether this is an operator overload (`operator +`, `operator ==`, …).
+  bool get isOperator => kind == .method && _operatorNames.contains(name);
+
+  /// Whether this is a `call` method (callable via implicit-call syntax
+  /// `obj(...)`). The reference search can't resolve that syntax back to the
+  /// declaration — like an infix operator — so a used `call` reads as unused.
+  bool get isCallMethod => kind == .method && name == 'call';
+
+  /// Whether this is a private constructor (`Foo._`, `Foo._named`). The server
+  /// names constructors with the class included (`Foo`, `Foo.named`), so the
+  /// private marker is a segment after the last `.` starting with `_`; the
+  /// unnamed constructor (no `.`) is never private here.
+  bool get isPrivateConstructor {
+    if (kind != .constructor) {
+      return false;
+    }
+    final dot = name.lastIndexOf('.');
+    return dot >= 0 && dot + 1 < name.length && name[dot + 1] == '_';
+  }
+
+  /// Whether the parameter list is empty. The server reports the signature in
+  /// [DocumentSymbol.detail] as the parenthesized parameter list (`()`,
+  /// `(int a)`, …); if the detail is missing we can't tell the arity, so treat
+  /// it as empty to avoid missing the zero-parameter marker.
+  bool get hasNoParameters {
+    final detail = this.detail?.trim();
+    if (detail == null || detail.isEmpty) {
+      return true;
+    }
+    final inner = detail.startsWith('(') && detail.endsWith(')')
+        ? detail.substring(1, detail.length - 1).trim()
+        : detail;
+    return inner.isEmpty;
+  }
+
+  /// Whether this is the classic prevent-instantiation marker: a class's sole,
+  /// zero-parameter private constructor (`Foo._();`). [siblings] are the
+  /// constructor's fellow class members, used to confirm it is the class's
+  /// only constructor.
+  bool isPreventInstantiationMarker(List<DocumentSymbol> siblings) =>
+      isPrivateConstructor &&
+      siblings.where((s) => s.kind == .constructor).length == 1 &&
+      hasNoParameters;
+
+  /// The kind ciach reports for this symbol. The analysis server tags enum
+  /// values with [SymbolKind.enum$] (same as the enum type), so remap them to
+  /// [SymbolKind.enumMember] under an enum to match the `enum-value` CLI kind.
+  SymbolKind reportedKind({required bool parentIsEnum}) =>
+      parentIsEnum && kind == .enum$ ? .enumMember : kind;
+
+  /// The name to report for this symbol.
+  ///
+  /// The analysis server names constructor symbols with the class included
+  /// (`Foo` for the unnamed constructor, `Foo.named` for a named one). The
+  /// [container] already carries the class, so strip that prefix and report the
+  /// unnamed constructor as `new` — yielding `Foo.named` / `Foo.new` once
+  /// combined with the container, rather than `Foo.Foo.named` / `Foo.Foo`.
+  String declarationName(String? container) {
+    if (kind != .constructor) {
+      return name;
+    }
+    if (container != null && name.startsWith('$container.')) {
+      return name.substring(container.length + 1);
+    }
+    return name.isEmpty || name == container ? 'new' : name;
+  }
+
+  /// The full source span of this symbol (including its body).
+  DeclarationRange get declarationRange => (
+    startLine: range.start.line,
+    startColumn: range.start.character,
+    endLine: range.end.line,
+    endColumn: range.end.character,
+  );
+
+  /// The first line of this symbol including its contiguous leading
+  /// doc-comment/annotation block (mirrors the removal-side extension), so a
+  /// self-referencing dartdoc link in the class's own doc counts as a
+  /// self-reference.
+  int metadataTopLine(List<String> lines) {
+    final nameLine = selectionRange.start.line;
+    var top = range.start.line <= nameLine ? range.start.line : nameLine;
+    while (top - 1 >= 0 && _looksLikeMetadata(lines[top - 1].trim())) {
+      top--;
+    }
+    return top;
+  }
+
+  /// The annotations, modifiers and doc comments immediately preceding this
+  /// symbol, as a single string, for cheap annotation detection.
+  String leadingMetadata(List<String> lines) {
+    final nameLine = selectionRange.start.line;
+    final top = metadataTopLine(lines);
+    final end = nameLine < lines.length ? nameLine : lines.length - 1;
+    return lines.sublist(top, end + 1).join('\n');
+  }
+}
+
+/// Position geometry against a symbol's source range.
+extension PositionGeometry on Position {
+  /// Whether this position is at or before [end].
+  bool atOrBefore(Position end) =>
+      line < end.line || (line == end.line && character <= end.character);
+
+  /// Whether this position falls within [symbol]'s full source range.
+  bool within(DocumentSymbol symbol) {
+    final start = symbol.range.start;
+    final afterStart =
+        line > start.line ||
+        (line == start.line && character >= start.character);
+    return afterStart && atOrBefore(symbol.range.end);
+  }
+}
+
+/// Whether [name] (possibly qualified, e.g. `Foo._bar`) is library-private —
+/// its simple segment starts with `_`.
+bool isPrivateName(String name) {
+  final simple = name.contains('.') ? name.split('.').last : name;
+  return simple.startsWith('_');
+}
+
+bool _looksLikeMetadata(String trimmedLine) =>
+    trimmedLine.isEmpty ||
+    trimmedLine.startsWith('@') ||
+    trimmedLine.startsWith('//') ||
+    trimmedLine.startsWith('/*') ||
+    trimmedLine.startsWith('*') ||
+    trimmedLine.endsWith('*/');

--- a/lib/src/syntax_rules.dart
+++ b/lib/src/syntax_rules.dart
@@ -100,11 +100,12 @@ extension StructuralChecks on SourceIndex {
   /// initialized, so removing the class's sole constructor would strand it
   /// (`final_not_initialized`).
   bool classHasFinalInstanceField(Candidate classCandidate) =>
-      (classCandidate.symbol.children ?? const []).any(
+      classCandidate.symbol.children?.any(
         (child) =>
             child.kind == .field &&
             _isFinalInstanceField(classCandidate.path, child),
-      );
+      ) ??
+      false;
 
   /// Whether [field] in [path] is declared `final` and is an *instance* field,
   /// determined by scanning the declaration's modifier/type prefix — the tokens
@@ -122,7 +123,7 @@ extension StructuralChecks on SourceIndex {
     for (var i = ti - 1; i >= 0; i--) {
       final t = toks[i];
       if (t.isWord) {
-        if (t.value == 'static' || t.value == 'const') {
+        if (t.value case 'static' || 'const') {
           return false;
         }
         if (t.value == 'final') {
@@ -282,7 +283,7 @@ extension StructuralChecks on SourceIndex {
         }
         depth--;
       } else if (depth == 0) {
-        if (t.value == ',' || t.value == ';') {
+        if (t.value case ',' || ';') {
           return false;
         }
         if (t.value == '=' &&

--- a/lib/src/syntax_rules.dart
+++ b/lib/src/syntax_rules.dart
@@ -1,0 +1,298 @@
+/*
+ * AI-Provenance:
+ *   model: claude-opus-4-8
+ *   harness: Claude Code
+ *   plugins:
+ *     - lean-ai-provenance
+ *   skills:
+ *     - mark-ai-provenance
+ */
+
+import 'package:ciach/src/candidates.dart';
+import 'package:ciach/src/lexing.dart';
+import 'package:ciach/src/source_index.dart';
+import 'package:pro_lsp/pro_lsp.dart' show DocumentSymbol, Location;
+
+/// The lexer token at a resolved reference: the file's token stream plus the
+/// index of the referenced type name.
+typedef _TypeToken = ({List<Token> tokens, int ti});
+
+/// Structural, lexer-level checks over a declaration or a reference — the
+/// syntactic special cases the reference classifier layers on top of the raw
+/// "has references?" verdict. They run over the cached token stream in
+/// [SourceIndex], never a full parse, and are deliberately conservative: when
+/// a shape can't be confirmed they answer in the direction that keeps code.
+extension StructuralChecks on SourceIndex {
+  /// Whether [ctor] is a redirecting factory (`factory X(..) = Target;`) — a
+  /// `=` at depth 0 after `factory` whose next token is a word (not a `=>`
+  /// body).
+  bool isRedirectingFactory(Candidate ctor) {
+    final window = tokenWindow(ctor.path, ctor.symbol);
+    if (window == null) {
+      return false;
+    }
+    final (:tokens, :start, :end) = window;
+    var sawFactory = false;
+    var depth = 0;
+    for (var i = start; i < end; i++) {
+      final t = tokens[i];
+      if (t.isWord) {
+        if (t.value == 'factory') {
+          sawFactory = true;
+        }
+      } else if (t.isOpener) {
+        depth++;
+      } else if (t.isCloser) {
+        depth--;
+      } else if (t.value == '=' &&
+          depth == 0 &&
+          sawFactory &&
+          i + 1 < tokens.length &&
+          tokens[i + 1].isWord) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /// Whether [ctor] forwards to a super constructor *with arguments* — a
+  /// `super.<field>` parameter or a non-empty `super(...)` call. Such a
+  /// constructor exists to satisfy a superclass whose unnamed constructor is
+  /// not zero-arg; removing it (leaving an implicit default constructor that
+  /// calls `super()`) would fail to compile (`no_default_super_constructor`).
+  /// A bare `super()` is not forwarding.
+  ///
+  /// Deliberately conservative: a `super.method()` call in the body is also
+  /// treated as forwarding, which can over-block a safe removal — the tool
+  /// reports the finding rather than risk a build break.
+  bool ctorForwardsSuper(Candidate ctor) {
+    final window = tokenWindow(ctor.path, ctor.symbol);
+    if (window == null) {
+      return false;
+    }
+    final (:tokens, :start, :end) = window;
+    for (var i = start; i < end; i++) {
+      final t = tokens[i];
+      if (!t.isWord || t.value != 'super' || i + 1 >= tokens.length) {
+        continue;
+      }
+      final next = tokens[i + 1];
+      if (next.isWord) {
+        continue;
+      }
+      switch (next.value) {
+        case '.':
+          return true;
+        case '(':
+          final after = i + 2 < tokens.length ? tokens[i + 2] : null;
+          final emptyCall =
+              after != null && !after.isWord && after.value == ')';
+          if (!emptyCall) {
+            return true;
+          }
+      }
+    }
+    return false;
+  }
+
+  /// Whether [classCandidate] declares at least one `final` *instance* field
+  /// (not `static`/`const`). Such a field relies on a constructor to be
+  /// initialized, so removing the class's sole constructor would strand it
+  /// (`final_not_initialized`).
+  bool classHasFinalInstanceField(Candidate classCandidate) =>
+      (classCandidate.symbol.children ?? const []).any(
+        (child) =>
+            child.kind == .field &&
+            _isFinalInstanceField(classCandidate.path, child),
+      );
+
+  /// Whether [field] in [path] is declared `final` and is an *instance* field,
+  /// determined by scanning the declaration's modifier/type prefix — the tokens
+  /// between the field name and the enclosing class body `{` or the previous
+  /// member's terminating `;`. A `static` or `const` modifier disqualifies it
+  /// (those don't depend on a constructor).
+  bool _isFinalInstanceField(String path, DocumentSymbol field) {
+    final ti = tokenIndexAtPosition(path, field.selectionRange.start);
+    if (ti == null) {
+      return false;
+    }
+    final toks = tokens(path);
+    var isFinal = false;
+    var depth = 0;
+    for (var i = ti - 1; i >= 0; i--) {
+      final t = toks[i];
+      if (t.isWord) {
+        if (t.value == 'static' || t.value == 'const') {
+          return false;
+        }
+        if (t.value == 'final') {
+          isFinal = true;
+        }
+      } else if (t.isCloser) {
+        depth++;
+      } else if (t.isOpener) {
+        // A `{` at depth 0 is the class body's opening brace, and an unmatched
+        // `(`/`[` there means the prefix's start — either way, the field
+        // declaration begins here.
+        if (depth == 0) {
+          return isFinal;
+        }
+        depth--;
+      } else if (t.value == ';' && depth == 0) {
+        return isFinal; // previous member/statement boundary
+      }
+    }
+    return isFinal;
+  }
+
+  /// Whether [enumCandidate] iterates its own values via the implicit `values`
+  /// getter from inside its body — a bare `values` (not `x.values`), as in a
+  /// `values.any(…)` helper. Having no `<EnumName>.` prefix, it's invisible to a
+  /// references query on the type ([isDotValuesRef]), so it's found by a source
+  /// scan. Conservative: a local named `values` also matches, which only ever
+  /// retains code, never removes something live.
+  bool enumIteratesOwnValues(Candidate enumCandidate) {
+    final window = tokenWindow(enumCandidate.path, enumCandidate.symbol);
+    if (window == null) {
+      return false;
+    }
+    final (:tokens, :start, :end) = window;
+    for (var i = start; i < end; i++) {
+      final t = tokens[i];
+      if (!t.isWord || t.value != 'values') {
+        continue;
+      }
+      // `.values` here is member access on another receiver, not the enum's own
+      // getter; the qualified form is handled by [isDotValuesRef].
+      final prev = i > 0 ? tokens[i - 1] : null;
+      if (prev != null && !prev.isWord && prev.value == '.') {
+        continue;
+      }
+      return true;
+    }
+    return false;
+  }
+
+  /// Whether reference [loc] is a type name immediately followed by `.values`
+  /// — the qualified `<EnumName>.values` iteration, which reaches every value.
+  /// The implicit bare-`values` form is caught by [enumIteratesOwnValues].
+  /// Precise on purpose: a `.value` access or a `.values` on another symbol
+  /// doesn't count.
+  bool isDotValuesRef(Location loc) {
+    final located = _locateTypeToken(loc);
+    if (located == null) {
+      return false;
+    }
+    final (:tokens, :ti) = located;
+    if (ti + 2 >= tokens.length) {
+      return false;
+    }
+    final dot = tokens[ti + 1];
+    final values = tokens[ti + 2];
+    return !dot.isWord &&
+        dot.value == '.' &&
+        values.isWord &&
+        values.value == 'values';
+  }
+
+  /// Whether reference [loc] to a class is a *type pattern* — a match, not a
+  /// construction — for the opt-in dead-union-member detection.
+  ///
+  /// Recognized as patterns:
+  ///
+  /// * A `case <Type>` pattern — in a `switch` statement, or in an
+  ///   `if (x case …)` / `while (x case …)` header.
+  /// * A switch-*expression* arm `<Type>… => …,`.
+  ///
+  /// Everything else (construction, type annotations, `extends`/`implements`,
+  /// static access, nested sub-patterns, pattern-variable declarations) is not
+  /// a pattern — a real use that keeps the class alive.
+  bool isPatternRef(Location loc) {
+    final located = _locateTypeToken(loc);
+    if (located == null) {
+      return false;
+    }
+    final (:tokens, :ti) = located;
+    final prev = ti > 0 ? tokens[ti - 1] : null;
+    // Any `case <Type>` — switch statement, if-case, or while-case — matches
+    // the type without constructing it.
+    if (prev != null && prev.isWord && prev.value == 'case') {
+      return true;
+    }
+    return _isSwitchExprArm(tokens, ti);
+  }
+
+  /// Resolves [loc] to the lexer token index of the referenced type name,
+  /// returning it with the file's cached tokens, or `null` if the reference
+  /// doesn't line up with a word token.
+  _TypeToken? _locateTypeToken(Location loc) {
+    final path = SourceIndex.pathOf(loc.uri);
+    final ti = tokenIndexAtPosition(path, loc.range.start);
+    if (ti == null) {
+      return null;
+    }
+    final toks = tokens(path);
+    return toks[ti].isWord ? (tokens: toks, ti: ti) : null;
+  }
+
+  /// Whether the type token at [ti] begins a switch-*expression* arm: preceded
+  /// by the `{`/`,` of a `switch (…) {` body and followed by a top-level `=>`.
+  bool _isSwitchExprArm(List<Token> tokens, int ti) {
+    if (ti == 0) {
+      return false;
+    }
+    final prev = tokens[ti - 1];
+    if (prev.isWord || (prev.value != '{' && prev.value != ',')) {
+      return false;
+    }
+    // Find the enclosing `{` (walking back over a preceding arm if prev is `,`).
+    final braceIndex = enclosingOpener(tokens, ti - 1);
+    if (braceIndex == null || tokens[braceIndex].value != '{') {
+      return false;
+    }
+    // `{` must close a `switch (…)` header: the token before it is `)` whose
+    // matching `(` is immediately preceded by `switch`.
+    final closeParen = braceIndex - 1;
+    if (closeParen < 0 ||
+        tokens[closeParen].isWord ||
+        tokens[closeParen].value != ')') {
+      return false;
+    }
+    final openParen = matchingOpenParen(tokens, closeParen);
+    if (openParen == null || openParen == 0) {
+      return false;
+    }
+    final kw = tokens[openParen - 1];
+    if (!kw.isWord || kw.value != 'switch') {
+      return false;
+    }
+    // A top-level `=>` must follow the pattern (so this is an arm, not e.g. a
+    // set/map entry inside a collection literal).
+    var depth = 0;
+    for (var k = ti + 1; k < tokens.length; k++) {
+      final t = tokens[k];
+      if (t.isWord) {
+        continue;
+      }
+      if (t.isOpener) {
+        depth++;
+      } else if (t.isCloser) {
+        if (depth == 0) {
+          return false;
+        }
+        depth--;
+      } else if (depth == 0) {
+        if (t.value == ',' || t.value == ';') {
+          return false;
+        }
+        if (t.value == '=' &&
+            k + 1 < tokens.length &&
+            !tokens[k + 1].isWord &&
+            tokens[k + 1].value == '>') {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ environment:
 
 dependencies:
   args: ^2.7.0
+  collection: ^1.19.0
   glob: ^2.1.3
   path: ^1.9.1
   pro_lsp: ^0.3.0


### PR DESCRIPTION
## What

A pure-refactor pass on the package internals: no behavioural change, no public API change. The two big files (`finder.dart` at 1728 lines, `bin/ciach.dart` at 425) had accreted every feature in one place; this splits them along clear responsibilities and applies idiomatic Dart cleanups throughout.

## Structure

`lib/src/finder.dart` went **1728 → 485 lines**, now just the pipeline orchestrator (discover → collect → check references → report). The concerns it was bundling now live in focused modules:

| Module | Responsibility |
|---|---|
| `lexing.dart` | `Token` + tokenizer + line-starts + bracket/token search |
| `source_index.dart` | cached file text/lines/tokens + position lookups (unified `tokenWindow`) |
| `symbols.dart` | `SymbolKind`/`DocumentSymbol` vocabulary + position geometry |
| `syntax_rules.dart` | token-based structural detectors (factory / super / final-field / patterns / enum `.values`) |
| `reference_classifier.dart` | the used / unused / doc-only decision + self-reference discounting |
| `reference_kinds.dart` | `isDocReference` shared primitive |
| `remove_safety.dart` | the remove-safety pre-pass (`RemoveSafety`) |
| `conventions/freezed.dart` | `@freezed` union deserialization-only arms |
| `conventions/serialization.dart` | `toJson` hook exemption |
| `conventions/flutter_widgets.dart` | `State<Widget>` pairing + coupled `State` removal |
| `candidates.dart` / `concurrency.dart` / `paths.dart` | shared types, `mapPooled`, path helper |
| `cli/args.dart` | CLI argument vocabulary (so adding a flag is one file) |

Every extracted collaborator takes `SourceIndex` explicitly rather than reaching into `Ciach`, so there's no back-dependency on the finder.

## Cleanups

- Unified three copies of the "scan the tokens inside this declaration" loop into `SourceIndex.tokenWindow` (also upgraded to a binary lower-bound).
- Added `package:collection` and used `groupListsBy`, `.max`, `.sorted`, `sortedBy`.
- Replaced null/type checks and null assertions with pattern matching (container keys, separator records, kind parsing, value disjunctions via if-case/switch); leaned on dot shorthands and expression bodies throughout.
- Converted the `Candidate` / `Token` record-typedefs + extensions into real classes with instance members; `DeclKey` is a value class with `==`/`hashCode`.
- `mapPooled` uses `List.generate(...).wait`.

## Verification

- `dart analyze` — no issues
- `dart format --set-exit-if-changed .` — clean
- `dart test` — all 84 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6BkLJcJujdjGWNF4W1vBb)_