### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.3.0
 
 - Lower the minimum Dart SDK constraint from `^3.12.2` to `^3.10.0`.
   ([#20](https://github.com/leancodepl/ciach/pull/20))

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: ciach
 description: >-
   Finds unused (never-referenced) declarations in a Dart/Flutter package by
   driving the Dart analysis server over LSP and querying textDocument/references.
-version: 0.2.0+2
+version: 0.3.0
 repository: https://github.com/leancodepl/ciach
 homepage: https://github.com/leancodepl/ciach
 issue_tracker: https://github.com/leancodepl/ciach/issues


### PR DESCRIPTION
## Summary
- Bump `pubspec.yaml` version from `0.2.0+2` to `0.3.0`
- Rename the `## Unreleased` CHANGELOG section to `## 0.3.0`, rolling up everything accumulated since `0.2.0+2`: the lowered `^3.10.0` SDK floor, `--report-tojson` opt-out, `--generated-suffix`, `--unused-union-members`, several `--remove` correctness fixes, and enum/operator/call-method handling fixes

## Test plan
- [ ] CI (`test.yml`): analyzer, tests, formatting, SDK-floor check
- [ ] Merge and cut the `v0.3.0` tag to trigger `publish.yml`

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01UcD3pdwC5wtUtSVEDj3Vq3

---
_Generated by [Claude Code](https://claude.ai/code/session_01UcD3pdwC5wtUtSVEDj3Vq3)_