### PR TITLE
Add YAML config file support and a --verbose mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,13 @@
 - Add config file support: any option can be set in a `ciach.yaml` in the
   package root, and the command line overrides it. `--config <path>` reads one
   from elsewhere, `--no-config` ignores it.
-- Add `-v`, `--verbose` to narrate a run on stderr: config used, settings
-  resolved, scan phases, what `--remove` touches. Supersedes `--progress`.
+- Add `-v`, `--verbose` to narrate a run on stderr: config used, every setting
+  and the layer it came from, scan phases, what `--remove` touches. Supersedes
+  `--progress`.
+- Resolve options with `package:config`, so each one is declared once for the
+  command line, the config file and its default. Invalid values are now all
+  reported at once, and `--concurrency 0` and a stray second path argument word
+  their errors slightly differently.
 - Document the `--unused-union-members`, `--report-tojson`,
   `--generated-suffix`, and `--help` options in the README, which existed in
   the CLI but were missing from the options table.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@
 - Add `-v`, `--verbose` to narrate a run on stderr: config used, every setting
   and the layer it came from, scan phases, what `--remove` touches. Supersedes
   `--progress`.
-- Resolve options with `package:config`, so each one is declared once for the
-  command line, the config file and its default. Invalid values are now all
-  reported at once, and `--concurrency 0` and a stray second path argument word
-  their errors slightly differently.
 - Document the `--unused-union-members`, `--report-tojson`,
   `--generated-suffix`, and `--help` options in the README, which existed in
   the CLI but were missing from the options table.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+- Add YAML config file support: every command-line option can also be set in a
+  `ciach.yaml` (or `ciach.yml`) in the analyzed package root, discovered
+  automatically. Use `--config <path>` to read one from elsewhere, or
+  `--no-config` to ignore a discovered file. Command-line arguments override
+  the config, which overrides the built-in defaults.
 - Document the `--unused-union-members`, `--report-tojson`,
   `--generated-suffix`, and `--help` options in the README, which existed in
   the CLI but were missing from the options table.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 ## Unreleased
 
 - Add YAML config file support: every command-line option can also be set in a
-  `ciach.yaml` (or `ciach.yml`) in the analyzed package root, discovered
-  automatically. Use `--config <path>` to read one from elsewhere, or
-  `--no-config` to ignore a discovered file. Command-line arguments override
-  the config, which overrides the built-in defaults.
+  `ciach.yaml` in the analyzed package root, discovered automatically. Use
+  `--config <path>` to read one from elsewhere, or `--no-config` to ignore a
+  discovered file. Command-line arguments override the config, which overrides
+  the built-in defaults.
+- Add `-v`, `--verbose` to narrate a run on stderr: the config file that was
+  read and what it set, the settings the run resolved to, each scan phase as it
+  starts, and what `--remove` touches. Supersedes `--progress`.
 - Document the `--unused-union-members`, `--report-tojson`,
   `--generated-suffix`, and `--help` options in the README, which existed in
   the CLI but were missing from the options table.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,10 @@
 ## Unreleased
 
-- Add YAML config file support: every command-line option can also be set in a
-  `ciach.yaml` in the analyzed package root, discovered automatically. Use
-  `--config <path>` to read one from elsewhere, or `--no-config` to ignore a
-  discovered file. Command-line arguments override the config, which overrides
-  the built-in defaults.
-- Add `-v`, `--verbose` to narrate a run on stderr: the config file that was
-  read and what it set, the settings the run resolved to, each scan phase as it
-  starts, and what `--remove` touches. Supersedes `--progress`.
+- Add config file support: any option can be set in a `ciach.yaml` in the
+  package root, and the command line overrides it. `--config <path>` reads one
+  from elsewhere, `--no-config` ignores it.
+- Add `-v`, `--verbose` to narrate a run on stderr: config used, settings
+  resolved, scan phases, what `--remove` touches. Supersedes `--progress`.
 - Document the `--unused-union-members`, `--report-tojson`,
   `--generated-suffix`, and `--help` options in the README, which existed in
   the CLI but were missing from the options table.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ ciach --remove
 
 # Remove without asking (e.g. from a script)
 ciach --remove --force
+
+# Ignore the package's ciach.yaml for one run
+ciach --no-config
 ```
 
 ### Options
@@ -86,6 +89,8 @@ ciach --remove --force
 | --- | --- | --- |
 | `[path]` | `.` | Package root to analyze. |
 | `-h, --help` | — | Print usage information. |
+| `--config <path>` | auto | Read settings from this YAML file instead of the auto-discovered one. See [Configuration file](#configuration-file). |
+| `--no-config` | off | Ignore the config file, even if one is found. |
 | `--[no-]public` | on | Report unused public declarations too. Disable to report only private (`_`-prefixed) ones. |
 | `--[no-]generated` | off | Scan generated files (`*.g.dart`, `*.freezed.dart`, `*.mocks.dart`, …). |
 | `--[no-]overrides` | off | Report `@override` members too. Off by default — see limitations. |
@@ -107,6 +112,64 @@ ciach --remove --force
 
 Exit codes: `0` success, `1` unused found with `--set-exit-if-changed`, `2`
 usage or analysis error.
+
+### Configuration file
+
+Every option above can also live in a `ciach.yaml` (or `ciach.yml`) file in the
+package root, so a project's settings are checked in once instead of being
+retyped on every invocation:
+
+```yaml
+# ciach.yaml
+public: false
+exclude:
+  - 'test/**'
+  - 'tool/**'
+generated-suffix:
+  - .gc.dart
+kinds: [class, function, method]
+format: github
+set-exit-if-changed: true
+concurrency: 8
+```
+
+The key is the long option name, minus the `--` — `public: false` is
+`--no-public`, `unused-union-members: true` is `--unused-union-members` — plus
+`path` for the positional path argument. Repeatable options (`exclude`,
+`include`, `generated-suffix`, `kinds`) take a YAML list, or a bare string when
+there is only one (`exclude: 'test/**'`). With the file above, a plain `ciach`
+behaves like:
+
+```bash
+ciach --no-public -e 'test/**' -e 'tool/**' --generated-suffix .gc.dart \
+  -k class,function,method -f github --set-exit-if-changed -j 8
+```
+
+Unknown keys and values of the wrong type are usage errors (exit `2`) naming
+the offending key, rather than being silently ignored.
+
+**Discovery.** `ciach` looks for `ciach.yaml`, then `ciach.yml`, in the package
+root being analyzed — the `[path]` argument, or the current directory when
+there isn't one. Only that directory: no walking up to parent directories, so
+in a monorepo each package's config is its own. `--config <path>` reads a file
+from anywhere else instead, and errors out if it doesn't exist.
+
+**Precedence.** Command line beats config file beats built-in default. Passing
+an option explicitly always wins, even when the value matches the default
+(`ciach --public` overrides `public: false`), and a repeatable option given on
+the command line replaces the config's list rather than adding to it. To skip a
+checked-in config for one run — say, to see everything a CI-tuned config
+filters out — pass `--no-config`:
+
+```bash
+# Full report, ignoring the project's ciach.yaml
+ciach --no-config
+
+# Settings from somewhere else entirely
+ciach --config tool/ciach-strict.yaml
+```
+
+`--config` and `--no-config` cannot be combined.
 
 ### Doc-only findings
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ ciach --remove --force
 
 # Ignore the package's ciach.yaml for one run
 ciach --no-config
+
+# Explain what's happening (config used, settings, scan phases)
+ciach --verbose
 ```
 
 ### Options
@@ -108,6 +111,7 @@ ciach --no-config
 | `-j, --concurrency <n>` | `16` | Reference queries kept in flight against the analysis server. |
 | `--[no-]color` | auto | Colorize text output. |
 | `--[no-]progress` | auto | Show scan progress on stderr. |
+| `-v, --verbose` | off | Explain what's happening on stderr. See [Verbose mode](#verbose-mode). |
 | `--dart <path>` | current SDK | Path to the `dart` executable to launch the server with. |
 
 Exit codes: `0` success, `1` unused found with `--set-exit-if-changed`, `2`
@@ -115,9 +119,9 @@ usage or analysis error.
 
 ### Configuration file
 
-Every option above can also live in a `ciach.yaml` (or `ciach.yml`) file in the
-package root, so a project's settings are checked in once instead of being
-retyped on every invocation:
+Every option above can also live in a `ciach.yaml` file in the package root, so
+a project's settings are checked in once instead of being retyped on every
+invocation:
 
 ```yaml
 # ciach.yaml
@@ -148,11 +152,12 @@ ciach --no-public -e 'test/**' -e 'tool/**' --generated-suffix .gc.dart \
 Unknown keys and values of the wrong type are usage errors (exit `2`) naming
 the offending key, rather than being silently ignored.
 
-**Discovery.** `ciach` looks for `ciach.yaml`, then `ciach.yml`, in the package
-root being analyzed — the `[path]` argument, or the current directory when
-there isn't one. Only that directory: no walking up to parent directories, so
-in a monorepo each package's config is its own. `--config <path>` reads a file
-from anywhere else instead, and errors out if it doesn't exist.
+**Discovery.** `ciach` looks for exactly one file name, `ciach.yaml`, in the
+package root being analyzed — the `[path]` argument, or the current directory
+when there isn't one. Only that directory: no walking up to parent directories,
+so in a monorepo each package's config is its own. `--config <path>` reads a
+file from anywhere else instead (under any name), and errors out if it doesn't
+exist. Run with `--verbose` to see which file was read and what it set.
 
 **Precedence.** Command line beats config file beats built-in default. Passing
 an option explicitly always wins, even when the value matches the default
@@ -170,6 +175,43 @@ ciach --config tool/ciach-strict.yaml
 ```
 
 `--config` and `--no-config` cannot be combined.
+
+### Verbose mode
+
+`-v` / `--verbose` narrates the run on stderr, stamped with the elapsed time:
+which config file was read (and every option it set), the settings the run
+ended up with after merging command line, config and defaults, each scan phase
+as it starts, and what `--remove` touches.
+
+```console
+$ ciach -v example
+[  0.0s] Read config from example/ciach.yaml.
+[  0.0s]   It sets 2 options:
+[  0.0s]     public: false
+[  0.0s]     exclude: test/**
+[  0.0s] Settings for this run:
+[  0.0s]   path: /home/me/pkg/example
+[  0.0s]   public: false
+…
+[  0.0s]   concurrency: 16
+[  0.0s]   dart: /usr/lib/dart/bin/dart (the SDK running ciach)
+[  0.0s] Discovered 13 Dart file(s) to scan.
+[  0.1s] Starting Dart analysis server…
+[  0.3s] Waiting for initial analysis to complete…
+[  0.3s] Warming 4 generated file(s)…
+[  0.3s] Collecting declarations from 13 file(s)…
+[  0.4s] Checking references for 44 declaration(s)…
+[  0.4s] [13/13] lib/greeting.dart
+[  0.5s] Scanned 13 file(s) and checked 44 declaration(s) in 478ms: 4 unused, 1 referenced only from doc comments.
+```
+
+Everything above goes to stderr, so findings on stdout stay pipeable — `ciach
+-v -f json | jq` works. The first thing to reach for when a config file seems
+not to apply, or when a scan is slower than expected and you want to know which
+phase is eating the time.
+
+`--verbose` supersedes `--progress`: the phase lines cover the same ground, and
+progress's single self-overwriting line would fight with them.
 
 ### Doc-only findings
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ set-exit-if-changed: true
 Command line beats config file beats default — including when the flag matches
 the default (`ciach --public` overrides `public: false`) — and a repeatable
 option given on the command line replaces the config's list rather than adding
-to it. Unknown keys and wrong-typed values are usage errors naming the key.
+to it. Unknown keys and wrong-typed values are usage errors naming the file and
+the key, whether or not the command line overrides that option.
 
 That one file name is looked for in the analyzed package root only, never in
 parent directories, so each package in a monorepo owns its config. `--config
@@ -113,8 +114,8 @@ one. The two can't be combined.
 ### Verbose mode
 
 `-v` narrates the run on stderr, with elapsed times: the config file read and
-what it set, the settings the run resolved to, each scan phase, and what
-`--remove` touches.
+what it set, every setting the run resolved to and which layer it came from,
+each scan phase, and what `--remove` touches.
 
 ```console
 $ ciach -v
@@ -123,7 +124,11 @@ $ ciach -v
 [  0.0s]     public: false
 [  0.0s]     exclude: test/**
 [  0.0s] Settings for this run:
-[  0.0s]   path: /home/me/pkg
+[  0.0s]   path: /home/me/pkg (command line)
+[  0.0s]   public: false (config file)
+[  0.0s]   exclude: test/** (config file)
+[  0.0s]   concurrency: 16 (default)
+[  0.0s]   color: true (auto-detected)
 …
 [  0.1s] Starting Dart analysis server…
 [  0.3s] Collecting declarations from 13 file(s)…

--- a/README.md
+++ b/README.md
@@ -20,70 +20,40 @@ AI-Provenance:
 [![Test status][test-badge]][test-badge-link]
 [![License: Apache 2.0][license-badge]][license-badge-link]
 
-**Dead code detector and unused code finder for Dart and Flutter.** Finds
-**unused (never-referenced) declarations** — classes, functions, methods,
-fields, constants, enum values, and so on — in a Dart or Flutter package, and
+**Dead code detector for Dart and Flutter.** Finds declarations that are never
+referenced — classes, functions, methods, fields, constants, enum values — and
 can remove them for you.
 
-### About the name
-
 *"Ciach!"* — pronounced **/t͡ɕax/** — is Polish for the sound of a clean chop,
-the noise a knife makes right before something falls off. Fitting, since
-that's exactly what this tool finds for you: dead code, waiting to be cut.
+the noise a knife makes right before something falls off.
 
 ## Installation
 
-There are two ways to get the `ciach` command, depending on how you want to
-run it:
+Globally, for a `ciach` command everywhere (installed to `~/.pub-cache/bin`):
 
-- **Global activation** — a single `ciach` command available everywhere,
-  independent of any particular project:
+```bash
+dart pub global activate ciach
+```
 
-  ```bash
-  dart pub global activate ciach
-  ciach
-  ```
+Or as a dev dependency, pinning the version for the team and CI:
 
-  This puts `ciach` in `~/.pub-cache/bin`; add that to your `PATH` if
-  `dart pub global activate` warns that it isn't there already.
+```bash
+dart pub add --dev ciach
+dart run ciach
+```
 
-- **As a dev dependency** — pinned per-project, so everyone on the team (and
-  CI) uses the same version:
-
-  ```bash
-  dart pub add --dev ciach
-  dart run ciach
-  ```
-
-The rest of this README shows bare `ciach …` commands; prefix them with
-`dart run` if you installed it as a dev dependency instead of globally.
+Examples below show bare `ciach …`; prefix them with `dart run` for the second.
 
 ## Usage
 
 ```bash
-# Scan the current package
-ciach
-
-# Scan a specific package
-ciach path/to/package
-
-# Only the highest-confidence dead code (private, never-referenced), as JSON
-ciach --no-public -f json
-
-# GitHub Actions annotations; fail the job if anything is found
-ciach -f github --set-exit-if-changed
-
-# Remove what's found, after confirming
-ciach --remove
-
-# Remove without asking (e.g. from a script)
-ciach --remove --force
-
-# Ignore the package's ciach.yaml for one run
-ciach --no-config
-
-# Explain what's happening (config used, settings, scan phases)
-ciach --verbose
+ciach                                  # scan the current package
+ciach path/to/package                  # scan another package
+ciach --no-public -f json              # private-only (highest confidence), as JSON
+ciach -f github --set-exit-if-changed  # CI: annotations, non-zero if anything is found
+ciach --remove                         # delete the findings, after confirming
+ciach --remove --force                 # …without asking
+ciach --verbose                        # explain what's happening
 ```
 
 ### Options
@@ -119,264 +89,157 @@ usage or analysis error.
 
 ### Configuration file
 
-Every option above can also live in a `ciach.yaml` file in the package root, so
-a project's settings are checked in once instead of being retyped on every
-invocation:
+Every option above can live in a `ciach.yaml` in the package root, keyed by its
+long name minus the `--`, plus `path` for the positional argument:
 
 ```yaml
-# ciach.yaml
-public: false
-exclude:
-  - 'test/**'
-  - 'tool/**'
-generated-suffix:
-  - .gc.dart
+public: false                     # --no-public
+exclude: ['test/**', 'tool/**']   # repeatable options take a list, or a bare string
 kinds: [class, function, method]
 format: github
 set-exit-if-changed: true
-concurrency: 8
 ```
 
-The key is the long option name, minus the `--` — `public: false` is
-`--no-public`, `unused-union-members: true` is `--unused-union-members` — plus
-`path` for the positional path argument. Repeatable options (`exclude`,
-`include`, `generated-suffix`, `kinds`) take a YAML list, or a bare string when
-there is only one (`exclude: 'test/**'`). With the file above, a plain `ciach`
-behaves like:
+Command line beats config file beats default — including when the flag matches
+the default (`ciach --public` overrides `public: false`) — and a repeatable
+option given on the command line replaces the config's list rather than adding
+to it. Unknown keys and wrong-typed values are usage errors naming the key.
 
-```bash
-ciach --no-public -e 'test/**' -e 'tool/**' --generated-suffix .gc.dart \
-  -k class,function,method -f github --set-exit-if-changed -j 8
-```
-
-Unknown keys and values of the wrong type are usage errors (exit `2`) naming
-the offending key, rather than being silently ignored.
-
-**Discovery.** `ciach` looks for exactly one file name, `ciach.yaml`, in the
-package root being analyzed — the `[path]` argument, or the current directory
-when there isn't one. Only that directory: no walking up to parent directories,
-so in a monorepo each package's config is its own. `--config <path>` reads a
-file from anywhere else instead (under any name), and errors out if it doesn't
-exist. Run with `--verbose` to see which file was read and what it set.
-
-**Precedence.** Command line beats config file beats built-in default. Passing
-an option explicitly always wins, even when the value matches the default
-(`ciach --public` overrides `public: false`), and a repeatable option given on
-the command line replaces the config's list rather than adding to it. To skip a
-checked-in config for one run — say, to see everything a CI-tuned config
-filters out — pass `--no-config`:
-
-```bash
-# Full report, ignoring the project's ciach.yaml
-ciach --no-config
-
-# Settings from somewhere else entirely
-ciach --config tool/ciach-strict.yaml
-```
-
-`--config` and `--no-config` cannot be combined.
+That one file name is looked for in the analyzed package root only, never in
+parent directories, so each package in a monorepo owns its config. `--config
+<path>` reads a file from elsewhere instead; `--no-config` ignores a discovered
+one. The two can't be combined.
 
 ### Verbose mode
 
-`-v` / `--verbose` narrates the run on stderr, stamped with the elapsed time:
-which config file was read (and every option it set), the settings the run
-ended up with after merging command line, config and defaults, each scan phase
-as it starts, and what `--remove` touches.
+`-v` narrates the run on stderr, with elapsed times: the config file read and
+what it set, the settings the run resolved to, each scan phase, and what
+`--remove` touches.
 
 ```console
-$ ciach -v example
-[  0.0s] Read config from example/ciach.yaml.
+$ ciach -v
+[  0.0s] Read config from ciach.yaml.
 [  0.0s]   It sets 2 options:
 [  0.0s]     public: false
 [  0.0s]     exclude: test/**
 [  0.0s] Settings for this run:
-[  0.0s]   path: /home/me/pkg/example
-[  0.0s]   public: false
+[  0.0s]   path: /home/me/pkg
 …
-[  0.0s]   concurrency: 16
-[  0.0s]   dart: /usr/lib/dart/bin/dart (the SDK running ciach)
-[  0.0s] Discovered 13 Dart file(s) to scan.
 [  0.1s] Starting Dart analysis server…
-[  0.3s] Waiting for initial analysis to complete…
-[  0.3s] Warming 4 generated file(s)…
 [  0.3s] Collecting declarations from 13 file(s)…
-[  0.4s] Checking references for 44 declaration(s)…
-[  0.4s] [13/13] lib/greeting.dart
 [  0.5s] Scanned 13 file(s) and checked 44 declaration(s) in 478ms: 4 unused, 1 referenced only from doc comments.
 ```
 
-Everything above goes to stderr, so findings on stdout stay pipeable — `ciach
--v -f json | jq` works. The first thing to reach for when a config file seems
-not to apply, or when a scan is slower than expected and you want to know which
-phase is eating the time.
-
-`--verbose` supersedes `--progress`: the phase lines cover the same ground, and
-progress's single self-overwriting line would fight with them.
+All of it goes to stderr, so `ciach -v -f json | jq` still works. Reach for it
+when a config file seems not to apply, or to see which phase is eating the time.
+It supersedes `--progress`, whose self-overwriting line would fight with it.
 
 ### Doc-only findings
 
-A dartdoc `[Xxx]` comment link resolves to a real declaration, so the
-analysis server counts it as a reference — but "someone linked to this in a
-comment" isn't the same confidence level as "something actually calls this".
-Declarations with no *code* references, only a comment link, are reported
-separately as **doc-only**, in every format:
+A dartdoc `[Xxx]` link resolves to a real declaration, so the analysis server
+counts it as a reference — but a comment mentioning something isn't the same as
+code calling it. Declarations with no *code* references are reported separately,
+in every format:
 
 ```
-$ ciach
 lib/greeting.dart
   15:6  function  danglingFunction  (public)
 
 Referenced only from doc comments — not counted as unused, never removed:
 lib/greeting.dart
   40:6  function  docOnlyMentioned  (public)
-
-Found 1 unused declaration in 1 file (scanned 6 files, 44 declarations, 0.5s). 1 more referenced only from doc comments.
 ```
 
-Doc-only findings are informational: they never count toward
-`--set-exit-if-changed`, are never touched by `--remove`, and get a `::notice`
-(not `::warning`) in `-f github` output. If one really is dead code, remove
-its doc comment link (or the comment itself) and re-run to have it reported
-as properly unused.
+These never count toward `--set-exit-if-changed`, are never touched by
+`--remove`, and get a `::notice` rather than a `::warning` in `-f github`. Drop
+the doc link to have one reported as properly unused.
 
 ### GitHub Actions
-
-Add `ciach` as a dev dependency (see [Installation](#installation)) so the
-version is pinned and `dart pub get` is all the setup CI needs:
 
 ```yaml
 - run: dart pub get
 - run: dart run ciach -f github --set-exit-if-changed
 ```
 
-Each finding becomes a `::warning` annotation shown inline on the PR diff. Run
-it from the repository root so annotation paths resolve; when scanning a
-sub-package (e.g. `ciach -f github app`), the scan path is
-prepended automatically so annotations still point at the right files.
+Each finding becomes a `::warning` annotation inline on the PR diff. Run it from
+the repository root so paths resolve; when scanning a sub-package (`ciach -f
+github app`), the scan path is prepended automatically.
 
 ### Removing declarations
 
-`--remove` deletes every reported declaration from source — its doc comment
-and annotations included — after showing what it's about to remove and asking
-for confirmation:
+`--remove` deletes every reported declaration — doc comment and annotations
+included — after showing what it is about to remove and asking:
 
 ```
-$ ciach --remove
-lib/greeting.dart
-  15:6  function  danglingFunction  (public)
-...
 Found 4 unused declarations in 2 files (scanned 6 files, 44 declarations, 0.5s).
 Remove 4 unused declarations? [y/N] y
 Removed 4 unused declarations from 2 files.
 ```
 
-`--remove --force` skips the prompt; use it in a script once you're confident
-in the results (`--force` on its own, without `--remove`, is a usage error).
-Without a terminal to confirm on (e.g. piped into another program) and
-without `--force`, nothing is removed.
+`--force` skips the prompt (and is a usage error on its own); with no terminal to
+confirm on and no `--force`, nothing is removed. Run `dart format` afterward:
+removal is conservative about *what* it deletes — an ambiguous `int a = 1, b = 2;`
+is left alone unless every declarator is unused — but not about spacing.
 
-Run `dart format` afterward — removal is conservative about *what* to delete
-(it leaves ambiguous multi-variable statements like `int a = 1, b = 2;`
-alone unless every declarator in them is unused) but not about spacing, so
-expect the odd extra blank line.
-
-Because removal acts on whatever the finder reports, it inherits the same
-false-positive risk as the report itself (see [What it skips by
-default](#what-it-skips-by-default) and [Limitations](#limitations) below) —
-enabling `--overrides` or `--operators` widens that risk considerably.
-[Doc-only findings](#doc-only-findings) are never included, regardless of
-those flags. Review the diff (or your test suite) after removing, the same as
+Removal acts on whatever the finder reports, so it inherits the same
+false-positive risk, which `--overrides` and `--operators` widen considerably.
+[Doc-only findings](#doc-only-findings) are never included. Review the diff, as
 you would after any automated refactor.
 
 ## What it skips by default
 
-These are all off by default because they're known sources of false
-positives — a used declaration reported as unused. Each has a flag to opt
-back in, at the cost of reintroducing that risk:
+Each of these is a known source of false positives; the flag opts back in at
+that cost.
 
-- **`main`** — the program entry point. Always skipped; there's no flag for
-  this one.
-- **`@override` members** — they are frequently reached polymorphically or by a
-  framework (Flutter's `build`, `initState`, `dispose`, `toString`, `==`, …),
-  which a name-based reference search can miss. Use `--overrides` to include
-  them.
-- **Operator overloads** (`operator +`, `operator ==`, …) — the analysis
-  server's reference search does not resolve infix operator syntax (`a + b`)
-  back to the operator's declaration, so a used operator is reported as
-  unused every time. See `example/lib/extensions.dart`. Use `--operators` to
-  include them.
-- **`call` methods** — a `call` method makes its object callable via
-  implicit-call syntax (`obj(...)`), which the reference search can't resolve
-  back to the declaration, the same way it can't resolve infix operators. A
-  used `call` method would be reported as unused every time. Always skipped;
-  there's no flag for this one. See `example/lib/callables.dart`.
-- **`@pragma('vm:entry-point')`** — reachable from native code / reflection.
-- **Generated files** — by filename convention and the
-  `GENERATED CODE - DO NOT MODIFY BY HAND` banner. Use `--generated` to include.
-  Even when excluded from the scan, they are still opened while analyzing, so a
-  declaration referenced *only* from generated code (e.g. a `toJson` called
-  from a `.g.dart` part) is not misreported as unused.
-- **`type parameters`** and non-declaration symbols.
+| Skipped | Why | Flag |
+| --- | --- | --- |
+| `main` | the entry point is never unused | — |
+| `@override` members | often reached polymorphically or by a framework (`build`, `initState`, `==`, …), which a name-based search misses | `--overrides` |
+| Operator overloads | the server doesn't resolve `a + b` back to the declaration, so a used operator is flagged every time | `--operators` |
+| `call` methods | implicit-call syntax (`obj(…)`) is unresolvable the same way | — |
+| `@pragma('vm:entry-point')` | reachable from native code or reflection | — |
+| Generated files | by filename convention and the `GENERATED CODE - DO NOT MODIFY BY HAND` banner. Still opened during analysis, so a declaration used only from a `.g.dart` isn't misreported | `--generated` |
+| `toJson()` | `jsonEncode(obj)` calls it by dynamic dispatch, leaving no source-level reference | `--report-tojson` |
+| Type parameters | always "used" within their scope | — |
+| dartdoc `[Xxx]` links | not a code reference; reported as [doc-only](#doc-only-findings) instead of hidden | — |
 
-**Private constructors are *not* skipped.** An unused `ClassName._` is dead code
-like any other and is reported (and removed by `--remove`). When it's the sole,
-zero-parameter `ClassName._()` — the classic prevent-instantiation marker — the
-finding carries a hint suggesting `abstract final class`, the idiomatic way to
-make a static-only class non-instantiable. See `example/lib/private_ctors.dart`.
-
-**dartdoc `[Xxx]` reference links** are a related wrinkle, handled a bit
-differently: a link resolves to a real declaration, so the analysis server
-counts it as a reference, which would otherwise hide genuinely dead code
-(e.g. `/// See [Dog.sound]` would keep `Dog.sound` looking used). Rather than
-a flag, these get their own always-on category — see [Doc-only
-findings](#doc-only-findings).
+Private constructors are **not** skipped: an unused `ClassName._` is dead code
+like any other. A sole zero-parameter `ClassName._()` — the classic
+prevent-instantiation marker — is reported with a hint suggesting `abstract final
+class` instead. See [example/](example) for a runnable demonstration of each case.
 
 ## Limitations
 
-This is a static, reference-based heuristic. Expect to review its output rather
-than delete blindly:
+A static, reference-based heuristic. Review its output rather than deleting
+blindly:
 
-- **Public API of a library package** is legitimately "unused" from the
-  package's own perspective. Prefer `--no-public` for library packages, or treat
-  public findings as advisory.
-- **Reflection / dynamic invocation / serialization** (e.g. `dart:mirrors`,
-  code that is only referenced by name in generated code you excluded) is not
-  visible to a reference search.
-- **Entry points beyond `main`** (isolate entry points, plugin registrants) may
-  need excluding or annotating with `@pragma('vm:entry-point')`.
-- Results are only as good as the analysis: a package that does not analyze
-  cleanly (missing `pub get`, errors) may yield incomplete references.
+- **A library package's public API** is legitimately unused from inside the
+  package. Prefer `--no-public` there, or treat public findings as advisory.
+- **Reflection, dynamic invocation, and names referenced only from generated
+  code you excluded** are invisible to a reference search.
+- **Entry points other than `main`** (isolate entry points, plugin registrants)
+  need excluding or `@pragma('vm:entry-point')`.
+- A package that doesn't analyze cleanly (missing `pub get`, errors) yields
+  incomplete references.
 
 ## Performance
 
-Runtime is dominated by the analysis server, not the tool. Two phases matter:
+Runtime is the analysis server's, not the tool's. It analyzes the whole package
+once per run — tens of seconds for a large Flutter app, and unskippable, since
+incomplete analysis means wrong reference counts — then answers one
+`textDocument/references` per declaration through a pool of `-j` (default 16),
+with scanned files kept open so its resolved-unit cache stays warm.
 
-1. **Initial analysis** — the server analyzes the whole package (and, for a
-   Flutter app, the SDK/dependencies) once before any query. This is a fixed
-   per-run cost (tens of seconds for a large app) and cannot be skipped:
-   incomplete analysis would produce wrong reference counts.
-2. **Reference queries** — one `textDocument/references` per declaration.
-   Requests run through a global pool (`-j/--concurrency`, default 16) and the
-   scanned files are kept open so the server's resolved-unit cache stays warm.
-
-The biggest lever is **how much you ask**:
-
-- **`--no-public`** is by far the cheapest mode. Private declarations are
-  library-scoped, so the server only searches one library per query instead of
-  the whole workspace — often several times faster, and it surfaces the
-  highest-confidence dead code.
-- **`--include` / `--exclude`** to scan only the part of the tree you care
-  about — references are still counted from everywhere, so results stay correct.
-- **`-j`** to tune concurrency; the default (16) is near the point of
-  diminishing returns for the analysis server's internal parallelism.
-
-For repeated runs, compile once to skip the JIT warmup:
-`dart compile exe bin/ciach.dart -o ciach` — `dart pub global activate` already
-does this for you.
+The lever is how much you ask for. `--no-public` is by far the cheapest mode:
+private declarations are library-scoped, so each query searches one library
+instead of the whole workspace, and it surfaces the highest-confidence dead code
+anyway. `--include`/`--exclude` narrow the scan while still counting references
+from everywhere. `dart pub global activate` compiles ahead of time, so there's no
+JIT warmup per run.
 
 ## Library usage
 
-The tool also exposes a public API for running the finder programmatically:
+The finder is also available programmatically:
 
 ```dart
 import 'package:ciach/ciach.dart';
@@ -397,8 +260,7 @@ dart analyze
 dart test          # spins up a real analysis server against the example/ package
 ```
 
-The implementation lives under `lib/src/`; the CLI entry point is `bin/`. See
-[example/](example) for a runnable demonstration.
+The implementation lives under `lib/src/`; the CLI entry point is `bin/`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ the noise a knife makes right before something falls off.
 
 ## Installation
 
-Globally, for a `ciach` command everywhere (installed to `~/.pub-cache/bin`):
+Install it globally for a `ciach` command everywhere, in `~/.pub-cache/bin`:
 
 ```bash
 dart pub global activate ciach
 ```
 
-Or as a dev dependency, pinning the version for the team and CI:
+Or add it as a dev dependency, which pins the version for the team and CI:
 
 ```bash
 dart pub add --dev ciach
@@ -105,9 +105,10 @@ default (`ciach --public` overrides `public: false`), and a repeatable option on
 the command line replaces the config's list rather than adding to it. Unknown
 keys and wrong-typed values are usage errors naming the file and the key.
 
-Only that one file name, in the analyzed package root — never a parent — so each
-package in a monorepo owns its config. `--config <path>` reads one from
-elsewhere; `--no-config` ignores a discovered one; the two can't be combined.
+Discovery looks for that one file name in the analyzed package root, never in a
+parent, so each package in a monorepo owns its config. `--config <path>` reads
+one from elsewhere; `--no-config` ignores a discovered one; the two can't be
+combined.
 
 ### Verbose mode
 
@@ -213,8 +214,8 @@ class` instead. See [example/](example) for a runnable demonstration of each cas
 
 ## Limitations
 
-A static, reference-based heuristic. Review its output rather than deleting
-blindly:
+This is a static, reference-based heuristic, so review its output rather than
+deleting blindly:
 
 - **A library package's public API** is legitimately unused from inside the
   package. Prefer `--no-public` there, or treat public findings as advisory.

--- a/README.md
+++ b/README.md
@@ -100,22 +100,20 @@ format: github
 set-exit-if-changed: true
 ```
 
-Command line beats config file beats default — including when the flag matches
-the default (`ciach --public` overrides `public: false`) — and a repeatable
-option given on the command line replaces the config's list rather than adding
-to it. Unknown keys and wrong-typed values are usage errors naming the file and
-the key, whether or not the command line overrides that option.
+Command line beats config file beats default, even when the flag matches the
+default (`ciach --public` overrides `public: false`), and a repeatable option on
+the command line replaces the config's list rather than adding to it. Unknown
+keys and wrong-typed values are usage errors naming the file and the key.
 
-That one file name is looked for in the analyzed package root only, never in
-parent directories, so each package in a monorepo owns its config. `--config
-<path>` reads a file from elsewhere instead; `--no-config` ignores a discovered
-one. The two can't be combined.
+Only that one file name, in the analyzed package root — never a parent — so each
+package in a monorepo owns its config. `--config <path>` reads one from
+elsewhere; `--no-config` ignores a discovered one; the two can't be combined.
 
 ### Verbose mode
 
 `-v` narrates the run on stderr, with elapsed times: the config file read and
-what it set, every setting the run resolved to and which layer it came from,
-each scan phase, and what `--remove` touches.
+what it set, every setting and the layer it came from, each scan phase, and what
+`--remove` touches.
 
 ```console
 $ ciach -v
@@ -135,9 +133,9 @@ $ ciach -v
 [  0.5s] Scanned 13 file(s) and checked 44 declaration(s) in 478ms: 4 unused, 1 referenced only from doc comments.
 ```
 
-All of it goes to stderr, so `ciach -v -f json | jq` still works. Reach for it
-when a config file seems not to apply, or to see which phase is eating the time.
-It supersedes `--progress`, whose self-overwriting line would fight with it.
+It all goes to stderr, so `ciach -v -f json | jq` still works. Reach for it when
+a config file seems not to apply, or to find the phase eating the time. It
+supersedes `--progress`, whose self-overwriting line would fight with it.
 
 ### Doc-only findings
 

--- a/bin/ciach.dart
+++ b/bin/ciach.dart
@@ -17,6 +17,7 @@ import 'package:ciach/src/cli/config.dart';
 import 'package:ciach/src/cli/options.dart';
 import 'package:ciach/src/cli/verbose.dart';
 import 'package:ciach/src/reporter.dart';
+import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 
 Future<void> main(List<String> arguments) async {
@@ -83,7 +84,7 @@ Future<int> _run(List<String> arguments) async {
   }
 
   final log = resolved.verbose ? _VerboseLog() : null;
-  log?.lines(describeConfigSource(config, projectDir: projectDir));
+  log?.writeAll(describeConfigSource(config, projectDir: projectDir));
 
   final rootDir = Directory(resolved.rootPath);
   if (!rootDir.existsSync()) {
@@ -103,7 +104,7 @@ Future<int> _run(List<String> arguments) async {
   final showProgress = resolved.showProgress;
   final rootPath = resolved.absoluteRootPath;
 
-  log?.lines(
+  log?.writeAll(
     describeSettings(
       resolved,
       dartExecutable: resolved.dartExecutable == null
@@ -119,7 +120,7 @@ Future<int> _run(List<String> arguments) async {
         // The finder narrates its phases through one callback; verbose keeps
         // every line, plain progress overwrites a single one in place.
         onProgress:
-            log?.call ?? (showProgress ? _ProgressPrinter().update : null),
+            log?.write ?? (showProgress ? _ProgressPrinter().update : null),
       ),
     ).run();
   } on Object catch (e, st) {
@@ -136,7 +137,7 @@ Future<int> _run(List<String> arguments) async {
     stderr.writeln();
   }
 
-  log?.call(
+  log?.write(
     'Scanned ${result.filesScanned} file(s) and checked ${result.declarationsChecked} declaration(s) in ${result.elapsed.inMilliseconds}ms: ${result.unused.length} unused, ${result.docOnly.length} referenced only from doc comments.',
   );
 
@@ -149,7 +150,7 @@ Future<int> _run(List<String> arguments) async {
       final prefix = p
           .split(p.relative(rootPath, from: Directory.current.path))
           .join('/');
-      log?.call("Prefixing annotation paths with '$prefix/'.");
+      log?.write("Prefixing annotation paths with '$prefix/'.");
       stdout.write(Reporter.github(result, pathPrefix: prefix));
     case _:
       stdout.writeln(Reporter.text(result, useColor: useColor));
@@ -158,7 +159,7 @@ Future<int> _run(List<String> arguments) async {
   if (result.unused.isNotEmpty && resolved.remove) {
     await _removeUnused(result, rootPath, resolved, format, useColor, log);
   } else if (result.unused.isNotEmpty) {
-    log?.call('Leaving the findings in place; --remove was not given.');
+    log?.write('Leaving the findings in place; --remove was not given.');
   }
 
   if (result.unused.isNotEmpty && resolved.setExitIfChanged) {
@@ -182,14 +183,14 @@ Future<void> _removeUnused(
 
   final blocked = result.unused.where((d) => d.removalBlocked).length;
   if (blocked > 0) {
-    log?.call(
+    log?.write(
       'Skipping $blocked of $count finding$plural: removing them safely would need a source rewrite (see --unused-union-members and remove safety).',
     );
   }
 
   var proceed = resolved.force;
   if (!proceed) {
-    log?.call('Asking for confirmation; pass --force to skip the prompt.');
+    log?.write('Asking for confirmation; pass --force to skip the prompt.');
     // The chosen --format may not be human-readable; show the findings
     // again so the confirmation prompt is never a shot in the dark.
     if (format != 'text') {
@@ -214,12 +215,11 @@ Future<void> _removeUnused(
   }
 
   if (log != null) {
-    final perFile = <String, int>{};
-    for (final declaration in result.unused.where((d) => !d.removalBlocked)) {
-      perFile.update(declaration.filePath, (n) => n + 1, ifAbsent: () => 1);
-    }
-    for (final entry in perFile.entries) {
-      log.call('Rewriting ${entry.key} (${entry.value} declaration(s)).');
+    final byFile = result.unused
+        .whereNot((d) => d.removalBlocked)
+        .groupFoldBy<String, int>((d) => d.filePath, (n, _) => (n ?? 0) + 1);
+    for (final entry in byFile.entries) {
+      log.write('Rewriting ${entry.key} (${entry.value} declaration(s)).');
     }
   }
 
@@ -246,12 +246,14 @@ Future<void> _removeUnused(
 class _VerboseLog {
   final _stopwatch = Stopwatch()..start();
 
-  void call(String message) {
+  /// Writes one line, prefixed with the elapsed time.
+  void write(String message) {
     final seconds = (_stopwatch.elapsedMilliseconds / 1000).toStringAsFixed(1);
     stderr.writeln('[${seconds.padLeft(5)}s] $message');
   }
 
-  void lines(Iterable<String> messages) => messages.forEach(call);
+  /// Writes a line per message in [messages].
+  void writeAll(Iterable<String> messages) => messages.forEach(write);
 }
 
 /// Prints single-line, overwriting progress to stderr.

--- a/bin/ciach.dart
+++ b/bin/ciach.dart
@@ -53,15 +53,15 @@ Future<int> _run(List<String> arguments) async {
     return 2;
   }
 
-  // Discovery looks in the package root named on the command line — a config
-  // file's own `path` cannot decide where that config file is read from.
+  // The root named on the command line: a config file's own `path` can't decide
+  // where that file is read from.
   final projectDir = args.rest.isEmpty ? '.' : args.rest.first;
 
   final ResolvedOptions resolved;
   final ConfigFile config;
   final CiachConfiguration configuration;
   try {
-    config = ConfigFile.load(
+    config = .load(
       projectDir: projectDir,
       explicitPath: explicitConfig,
       ignore: ignoreConfig,
@@ -70,7 +70,7 @@ Future<int> _run(List<String> arguments) async {
     resolved = resolveOptions(
       configuration,
       colorDefault: stdout.supportsAnsiEscapes,
-      // Progress goes to stderr; default on only when it won't clutter a pipe.
+      // Progress goes to stderr, so default it on only for a terminal.
       progressDefault: stderr.hasTerminal,
     );
   } on UsageException catch (e) {
@@ -114,8 +114,7 @@ Future<int> _run(List<String> arguments) async {
   try {
     result = await Ciach(
       resolved.finderOptions(
-        // The finder narrates its phases through one callback; verbose keeps
-        // every line, plain progress overwrites a single one in place.
+        // Verbose keeps every phase line; progress overwrites one in place.
         onProgress:
             log?.write ?? (showProgress ? _ProgressPrinter().update : null),
       ),
@@ -142,8 +141,8 @@ Future<int> _run(List<String> arguments) async {
     case 'json':
       stdout.writeln(Reporter.json(result));
     case 'github':
-      // GitHub resolves annotation paths from the repo root; make the finding
-      // paths root-relative by prepending the scan root's path from here.
+      // GitHub resolves annotation paths from the repo root, so prepend the
+      // scan root's path from here.
       final prefix = p
           .split(p.relative(rootPath, from: Directory.current.path))
           .join('/');
@@ -165,8 +164,8 @@ Future<int> _run(List<String> arguments) async {
   return 0;
 }
 
-/// Reports what would be removed, confirms unless [ResolvedOptions.force] is
-/// set, and deletes the unused declarations from disk.
+/// Reports what would be removed, confirms unless [ResolvedOptions.force], and
+/// deletes the declarations from disk.
 Future<void> _removeUnused(
   FinderResult result,
   String rootPath,
@@ -224,9 +223,8 @@ Future<void> _removeUnused(
   stdout.writeln(
     "Removed $count unused declaration$plural from $filesChanged file${filesChanged == 1 ? '' : 's'}. Run 'dart format' to tidy up spacing.",
   );
-  // Surface any advisory hints (e.g. a removed prevent-instantiation
-  // constructor) once more, since removing the declaration also removes the
-  // reported line that carried the hint.
+  // Repeat any advisory hints: removing a declaration takes the reported line
+  // that carried its hint with it.
   final removedHints = result.unused
       .where((d) => !d.removalBlocked && d.hint != null)
       .map((d) => '${d.qualifiedName}: ${d.hint}')
@@ -236,20 +234,18 @@ Future<void> _removeUnused(
   }
 }
 
-/// Prints `--verbose` narration to stderr, one durable line per message,
-/// stamped with the elapsed time so slow phases stand out.
-///
-/// stderr, not stdout, so `-f json` output stays machine-readable.
+/// Prints `--verbose` narration to stderr — not stdout, so `-f json` stays
+/// machine-readable — one line per message, stamped with the elapsed time.
 class _VerboseLog {
   final _stopwatch = Stopwatch()..start();
 
-  /// Writes one line, prefixed with the elapsed time.
+  /// Writes one stamped line.
   void write(String message) {
     final seconds = (_stopwatch.elapsedMilliseconds / 1000).toStringAsFixed(1);
     stderr.writeln('[${seconds.padLeft(5)}s] $message');
   }
 
-  /// Writes a line per message in [messages].
+  /// Writes a line per message.
   void writeAll(Iterable<String> messages) => messages.forEach(write);
 }
 

--- a/bin/ciach.dart
+++ b/bin/ciach.dart
@@ -15,6 +15,7 @@ import 'package:ciach/ciach.dart';
 import 'package:ciach/src/cli/args.dart';
 import 'package:ciach/src/cli/config.dart';
 import 'package:ciach/src/cli/options.dart';
+import 'package:ciach/src/cli/verbose.dart';
 import 'package:ciach/src/reporter.dart';
 import 'package:path/path.dart' as p;
 
@@ -57,12 +58,15 @@ Future<int> _run(List<String> arguments) async {
     return 2;
   }
 
+  // Discovery looks in the package root named on the command line — a config
+  // file's own `path` cannot decide where that config file is read from.
+  final projectDir = rest.isEmpty ? '.' : rest.first;
+
   final ResolvedOptions resolved;
+  final LoadedConfig loaded;
   try {
-    // Discovery looks in the package root named on the command line — a config
-    // file's own `path` cannot decide where that config file is read from.
-    final loaded = loadConfig(
-      projectDir: rest.isEmpty ? '.' : rest.first,
+    loaded = loadConfig(
+      projectDir: projectDir,
       explicitPath: explicitConfig,
       ignore: ignoreConfig,
     );
@@ -77,6 +81,9 @@ Future<int> _run(List<String> arguments) async {
     stderr.writeln(e.message);
     return 2;
   }
+
+  final log = resolved.verbose ? _VerboseLog() : null;
+  log?.lines(describeConfigSource(loaded, projectDir: projectDir));
 
   final rootDir = Directory(resolved.rootPath);
   if (!rootDir.existsSync()) {
@@ -95,9 +102,20 @@ Future<int> _run(List<String> arguments) async {
   final format = resolved.format;
   final useColor = resolved.useColor;
   final showProgress = resolved.showProgress;
+  final rootPath = p.normalize(rootDir.absolute.path);
+
+  log?.lines(
+    describeSettings(
+      resolved,
+      rootPath: rootPath,
+      dartExecutable: resolved.dartExecutable == null
+          ? '${Platform.resolvedExecutable} (the SDK running ciach)'
+          : '${resolved.dartExecutable} (--dart)',
+    ),
+  );
 
   final options = FinderOptions(
-    rootPath: rootDir.absolute.path,
+    rootPath: rootPath,
     includeGlobs: resolved.includeGlobs,
     excludeGlobs: resolved.excludeGlobs,
     kinds: resolved.kinds,
@@ -110,7 +128,9 @@ Future<int> _run(List<String> arguments) async {
     reportToJson: resolved.reportToJson,
     concurrency: resolved.concurrency,
     dartExecutable: resolved.dartExecutable,
-    onProgress: showProgress ? _ProgressPrinter().update : null,
+    // The finder narrates its phases through one callback; verbose keeps every
+    // line, plain progress overwrites a single one in place.
+    onProgress: log?.call ?? (showProgress ? _ProgressPrinter().update : null),
   );
 
   final FinderResult result;
@@ -130,6 +150,13 @@ Future<int> _run(List<String> arguments) async {
     stderr.writeln();
   }
 
+  log?.call(
+    'Scanned ${result.filesScanned} file(s) and checked '
+    '${result.declarationsChecked} declaration(s) in '
+    '${result.elapsed.inMilliseconds}ms: ${result.unused.length} unused, '
+    '${result.docOnly.length} referenced only from doc comments.',
+  );
+
   switch (format) {
     case 'json':
       stdout.writeln(Reporter.json(result));
@@ -137,23 +164,18 @@ Future<int> _run(List<String> arguments) async {
       // GitHub resolves annotation paths from the repo root; make the finding
       // paths root-relative by prepending the scan root's path from here.
       final prefix = p
-          .split(
-            p.relative(rootDir.absolute.path, from: Directory.current.path),
-          )
+          .split(p.relative(rootPath, from: Directory.current.path))
           .join('/');
+      log?.call("Prefixing annotation paths with '$prefix/'.");
       stdout.write(Reporter.github(result, pathPrefix: prefix));
     case _:
       stdout.writeln(Reporter.text(result, useColor: useColor));
   }
 
   if (result.unused.isNotEmpty && resolved.remove) {
-    await _removeUnused(
-      result,
-      rootDir.absolute.path,
-      resolved,
-      format,
-      useColor,
-    );
+    await _removeUnused(result, rootPath, resolved, format, useColor, log);
+  } else if (result.unused.isNotEmpty) {
+    log?.call('Leaving the findings in place; --remove was not given.');
   }
 
   if (result.unused.isNotEmpty && resolved.setExitIfChanged) {
@@ -170,12 +192,22 @@ Future<void> _removeUnused(
   ResolvedOptions resolved,
   String format,
   bool useColor,
+  _VerboseLog? log,
 ) async {
   final count = result.unused.length;
   final plural = count == 1 ? '' : 's';
 
+  final blocked = result.unused.where((d) => d.removalBlocked).length;
+  if (blocked > 0) {
+    log?.call(
+      'Skipping $blocked of $count finding$plural: removing them safely would '
+      'need a source rewrite (see --unused-union-members and remove safety).',
+    );
+  }
+
   var proceed = resolved.force;
   if (!proceed) {
+    log?.call('Asking for confirmation; pass --force to skip the prompt.');
     // The chosen --format may not be human-readable; show the findings
     // again so the confirmation prompt is never a shot in the dark.
     if (format != 'text') {
@@ -200,6 +232,16 @@ Future<void> _removeUnused(
     return;
   }
 
+  if (log != null) {
+    final perFile = <String, int>{};
+    for (final declaration in result.unused.where((d) => !d.removalBlocked)) {
+      perFile.update(declaration.filePath, (n) => n + 1, ifAbsent: () => 1);
+    }
+    for (final entry in perFile.entries) {
+      log.call('Rewriting ${entry.key} (${entry.value} declaration(s)).');
+    }
+  }
+
   final filesChanged = removeDeclarations(result.unused, rootPath);
   stdout.writeln(
     'Removed $count unused declaration$plural from $filesChanged '
@@ -215,6 +257,21 @@ Future<void> _removeUnused(
   for (final note in removedHints) {
     stdout.writeln('Note: $note');
   }
+}
+
+/// Prints `--verbose` narration to stderr, one durable line per message,
+/// stamped with the elapsed time so slow phases stand out.
+///
+/// stderr, not stdout, so `-f json` output stays machine-readable.
+class _VerboseLog {
+  final _stopwatch = Stopwatch()..start();
+
+  void call(String message) {
+    final seconds = (_stopwatch.elapsedMilliseconds / 1000).toStringAsFixed(1);
+    stderr.writeln('[${seconds.padLeft(5)}s] $message');
+  }
+
+  void lines(Iterable<String> messages) => messages.forEach(call);
 }
 
 /// Prints single-line, overwriting progress to stderr.

--- a/bin/ciach.dart
+++ b/bin/ciach.dart
@@ -63,16 +63,16 @@ Future<int> _run(List<String> arguments) async {
   final projectDir = rest.isEmpty ? '.' : rest.first;
 
   final ResolvedOptions resolved;
-  final LoadedConfig loaded;
+  final ConfigFile config;
   try {
-    loaded = loadConfig(
+    config = ConfigFile.load(
       projectDir: projectDir,
       explicitPath: explicitConfig,
       ignore: ignoreConfig,
     );
     resolved = resolveOptions(
       args,
-      loaded.config,
+      config,
       colorDefault: stdout.supportsAnsiEscapes,
       // Progress goes to stderr; default on only when it won't clutter a pipe.
       progressDefault: stderr.hasTerminal,
@@ -83,7 +83,7 @@ Future<int> _run(List<String> arguments) async {
   }
 
   final log = resolved.verbose ? _VerboseLog() : null;
-  log?.lines(describeConfigSource(loaded, projectDir: projectDir));
+  log?.lines(describeConfigSource(config, projectDir: projectDir));
 
   final rootDir = Directory(resolved.rootPath);
   if (!rootDir.existsSync()) {
@@ -102,40 +102,27 @@ Future<int> _run(List<String> arguments) async {
   final format = resolved.format;
   final useColor = resolved.useColor;
   final showProgress = resolved.showProgress;
-  final rootPath = p.normalize(rootDir.absolute.path);
+  final rootPath = resolved.absoluteRootPath;
 
   log?.lines(
     describeSettings(
       resolved,
-      rootPath: rootPath,
       dartExecutable: resolved.dartExecutable == null
           ? '${Platform.resolvedExecutable} (the SDK running ciach)'
           : '${resolved.dartExecutable} (--dart)',
     ),
   );
 
-  final options = FinderOptions(
-    rootPath: rootPath,
-    includeGlobs: resolved.includeGlobs,
-    excludeGlobs: resolved.excludeGlobs,
-    kinds: resolved.kinds,
-    includePublic: resolved.includePublic,
-    includeGenerated: resolved.includeGenerated,
-    additionalGeneratedSuffixes: resolved.additionalGeneratedSuffixes,
-    skipOverrides: !resolved.overrides,
-    skipOperators: !resolved.operators,
-    unusedUnionMembers: resolved.unusedUnionMembers,
-    reportToJson: resolved.reportToJson,
-    concurrency: resolved.concurrency,
-    dartExecutable: resolved.dartExecutable,
-    // The finder narrates its phases through one callback; verbose keeps every
-    // line, plain progress overwrites a single one in place.
-    onProgress: log?.call ?? (showProgress ? _ProgressPrinter().update : null),
-  );
-
   final FinderResult result;
   try {
-    result = await Ciach(options).run();
+    result = await Ciach(
+      resolved.finderOptions(
+        // The finder narrates its phases through one callback; verbose keeps
+        // every line, plain progress overwrites a single one in place.
+        onProgress:
+            log?.call ?? (showProgress ? _ProgressPrinter().update : null),
+      ),
+    ).run();
   } on Object catch (e, st) {
     if (showProgress) {
       stderr.writeln();

--- a/bin/ciach.dart
+++ b/bin/ciach.dart
@@ -93,8 +93,7 @@ Future<int> _run(List<String> arguments) async {
 
   if (resolved.force && !resolved.remove) {
     stderr.writeln(
-      'Skipping the removal prompt only makes sense when removing: --force '
-      '(or `force: true`) requires --remove (or `remove: true`).',
+      'Skipping the removal prompt only makes sense when removing: --force (or `force: true`) requires --remove (or `remove: true`).',
     );
     return 2;
   }
@@ -138,10 +137,7 @@ Future<int> _run(List<String> arguments) async {
   }
 
   log?.call(
-    'Scanned ${result.filesScanned} file(s) and checked '
-    '${result.declarationsChecked} declaration(s) in '
-    '${result.elapsed.inMilliseconds}ms: ${result.unused.length} unused, '
-    '${result.docOnly.length} referenced only from doc comments.',
+    'Scanned ${result.filesScanned} file(s) and checked ${result.declarationsChecked} declaration(s) in ${result.elapsed.inMilliseconds}ms: ${result.unused.length} unused, ${result.docOnly.length} referenced only from doc comments.',
   );
 
   switch (format) {
@@ -187,8 +183,7 @@ Future<void> _removeUnused(
   final blocked = result.unused.where((d) => d.removalBlocked).length;
   if (blocked > 0) {
     log?.call(
-      'Skipping $blocked of $count finding$plural: removing them safely would '
-      'need a source rewrite (see --unused-union-members and remove safety).',
+      'Skipping $blocked of $count finding$plural: removing them safely would need a source rewrite (see --unused-union-members and remove safety).',
     );
   }
 
@@ -202,8 +197,7 @@ Future<void> _removeUnused(
     }
     if (!stdin.hasTerminal) {
       stdout.writeln(
-        'Refusing to remove declarations without a terminal to confirm on; '
-        'pass --force to remove without asking.',
+        'Refusing to remove declarations without a terminal to confirm on; pass --force to remove without asking.',
       );
       return;
     }
@@ -231,8 +225,7 @@ Future<void> _removeUnused(
 
   final filesChanged = removeDeclarations(result.unused, rootPath);
   stdout.writeln(
-    'Removed $count unused declaration$plural from $filesChanged '
-    "file${filesChanged == 1 ? '' : 's'}. Run 'dart format' to tidy up spacing.",
+    "Removed $count unused declaration$plural from $filesChanged file${filesChanged == 1 ? '' : 's'}. Run 'dart format' to tidy up spacing.",
   );
   // Surface any advisory hints (e.g. a removed prevent-instantiation
   // constructor) once more, since removing the declaration also removes the

--- a/bin/ciach.dart
+++ b/bin/ciach.dart
@@ -18,6 +18,7 @@ import 'package:ciach/src/cli/options.dart';
 import 'package:ciach/src/cli/verbose.dart';
 import 'package:ciach/src/reporter.dart';
 import 'package:collection/collection.dart';
+import 'package:config/config.dart';
 import 'package:path/path.dart' as p;
 
 Future<void> main(List<String> arguments) async {
@@ -45,13 +46,6 @@ Future<int> _run(List<String> arguments) async {
     return 0;
   }
 
-  final rest = args.rest;
-  if (rest.length > 1) {
-    stderr.writeln(
-      'Expected at most one path argument, got: ${rest.join(', ')}',
-    );
-    return 2;
-  }
   final ignoreConfig = args.flag('no-config');
   final explicitConfig = args.option('config');
   if (ignoreConfig && explicitConfig != null) {
@@ -61,23 +55,27 @@ Future<int> _run(List<String> arguments) async {
 
   // Discovery looks in the package root named on the command line — a config
   // file's own `path` cannot decide where that config file is read from.
-  final projectDir = rest.isEmpty ? '.' : rest.first;
+  final projectDir = args.rest.isEmpty ? '.' : args.rest.first;
 
   final ResolvedOptions resolved;
   final ConfigFile config;
+  final CiachConfiguration configuration;
   try {
     config = ConfigFile.load(
       projectDir: projectDir,
       explicitPath: explicitConfig,
       ignore: ignoreConfig,
     );
+    configuration = resolveConfiguration(args, config);
     resolved = resolveOptions(
-      args,
-      config,
+      configuration,
       colorDefault: stdout.supportsAnsiEscapes,
       // Progress goes to stderr; default on only when it won't clutter a pipe.
       progressDefault: stderr.hasTerminal,
     );
+  } on UsageException catch (e) {
+    stderr.writeln(e.message);
+    return 2;
   } on FormatException catch (e) {
     stderr.writeln(e.message);
     return 2;
@@ -106,10 +104,9 @@ Future<int> _run(List<String> arguments) async {
 
   log?.writeAll(
     describeSettings(
+      configuration,
       resolved,
-      dartExecutable: resolved.dartExecutable == null
-          ? '${Platform.resolvedExecutable} (the SDK running ciach)'
-          : '${resolved.dartExecutable} (--dart)',
+      dartExecutable: resolved.dartExecutable ?? Platform.resolvedExecutable,
     ),
   );
 

--- a/bin/ciach.dart
+++ b/bin/ciach.dart
@@ -13,6 +13,8 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:ciach/ciach.dart';
 import 'package:ciach/src/cli/args.dart';
+import 'package:ciach/src/cli/config.dart';
+import 'package:ciach/src/cli/options.dart';
 import 'package:ciach/src/reporter.dart';
 import 'package:path/path.dart' as p;
 
@@ -48,62 +50,66 @@ Future<int> _run(List<String> arguments) async {
     );
     return 2;
   }
-  final rootPath = rest.isEmpty ? '.' : rest.first;
-  final rootDir = Directory(rootPath);
-  if (!rootDir.existsSync()) {
-    stderr.writeln('Path does not exist: $rootPath');
+  final ignoreConfig = args.flag('no-config');
+  final explicitConfig = args.option('config');
+  if (ignoreConfig && explicitConfig != null) {
+    stderr.writeln('--config cannot be combined with --no-config.');
     return 2;
   }
 
-  if (args.flag('force') && !args.flag('remove')) {
-    stderr.writeln('--force requires --remove.');
-    return 2;
-  }
-
-  final Set<SymbolKind> kinds;
+  final ResolvedOptions resolved;
   try {
-    kinds = parseKinds(args.multiOption('kinds'));
+    // Discovery looks in the package root named on the command line — a config
+    // file's own `path` cannot decide where that config file is read from.
+    final loaded = loadConfig(
+      projectDir: rest.isEmpty ? '.' : rest.first,
+      explicitPath: explicitConfig,
+      ignore: ignoreConfig,
+    );
+    resolved = resolveOptions(
+      args,
+      loaded.config,
+      colorDefault: stdout.supportsAnsiEscapes,
+      // Progress goes to stderr; default on only when it won't clutter a pipe.
+      progressDefault: stderr.hasTerminal,
+    );
   } on FormatException catch (e) {
     stderr.writeln(e.message);
     return 2;
   }
 
-  // `allowed` on the option already rejects unknown values during parsing.
-  final format = args.option('format')!;
-
-  final useColor = args.wasParsed('color')
-      ? args.flag('color')
-      : stdout.supportsAnsiEscapes;
-  // Progress goes to stderr; default on only when it won't clutter a pipe.
-  final showProgress = args.wasParsed('progress')
-      ? args.flag('progress')
-      : stderr.hasTerminal;
-
-  final int concurrency;
-  try {
-    concurrency = int.parse(args.option('concurrency')!);
-    if (concurrency < 1) {
-      throw const FormatException();
-    }
-  } on FormatException {
-    stderr.writeln('--concurrency must be a positive integer.');
+  final rootDir = Directory(resolved.rootPath);
+  if (!rootDir.existsSync()) {
+    stderr.writeln('Path does not exist: ${resolved.rootPath}');
     return 2;
   }
 
+  if (resolved.force && !resolved.remove) {
+    stderr.writeln(
+      'Skipping the removal prompt only makes sense when removing: --force '
+      '(or `force: true`) requires --remove (or `remove: true`).',
+    );
+    return 2;
+  }
+
+  final format = resolved.format;
+  final useColor = resolved.useColor;
+  final showProgress = resolved.showProgress;
+
   final options = FinderOptions(
     rootPath: rootDir.absolute.path,
-    includeGlobs: args.multiOption('include'),
-    excludeGlobs: args.multiOption('exclude'),
-    kinds: kinds,
-    includePublic: args.flag('public'),
-    includeGenerated: args.flag('generated'),
-    additionalGeneratedSuffixes: args.multiOption('generated-suffix'),
-    skipOverrides: !args.flag('overrides'),
-    skipOperators: !args.flag('operators'),
-    unusedUnionMembers: args.flag('unused-union-members'),
-    reportToJson: args.flag('report-tojson'),
-    concurrency: concurrency,
-    dartExecutable: args.option('dart'),
+    includeGlobs: resolved.includeGlobs,
+    excludeGlobs: resolved.excludeGlobs,
+    kinds: resolved.kinds,
+    includePublic: resolved.includePublic,
+    includeGenerated: resolved.includeGenerated,
+    additionalGeneratedSuffixes: resolved.additionalGeneratedSuffixes,
+    skipOverrides: !resolved.overrides,
+    skipOperators: !resolved.operators,
+    unusedUnionMembers: resolved.unusedUnionMembers,
+    reportToJson: resolved.reportToJson,
+    concurrency: resolved.concurrency,
+    dartExecutable: resolved.dartExecutable,
     onProgress: showProgress ? _ProgressPrinter().update : null,
   );
 
@@ -140,29 +146,35 @@ Future<int> _run(List<String> arguments) async {
       stdout.writeln(Reporter.text(result, useColor: useColor));
   }
 
-  if (result.unused.isNotEmpty && args.flag('remove')) {
-    await _removeUnused(result, rootDir.absolute.path, args, format, useColor);
+  if (result.unused.isNotEmpty && resolved.remove) {
+    await _removeUnused(
+      result,
+      rootDir.absolute.path,
+      resolved,
+      format,
+      useColor,
+    );
   }
 
-  if (result.unused.isNotEmpty && args.flag('set-exit-if-changed')) {
+  if (result.unused.isNotEmpty && resolved.setExitIfChanged) {
     return 1;
   }
   return 0;
 }
 
-/// Reports what would be removed, confirms unless [ArgResults.flag]
-/// `'force'` is set, and deletes the unused declarations from disk.
+/// Reports what would be removed, confirms unless [ResolvedOptions.force] is
+/// set, and deletes the unused declarations from disk.
 Future<void> _removeUnused(
   FinderResult result,
   String rootPath,
-  ArgResults args,
+  ResolvedOptions resolved,
   String format,
   bool useColor,
 ) async {
   final count = result.unused.length;
   final plural = count == 1 ? '' : 's';
 
-  var proceed = args.flag('force');
+  var proceed = resolved.force;
   if (!proceed) {
     // The chosen --format may not be human-readable; show the findings
     // again so the confirmation prompt is never a shot in the dark.

--- a/lib/src/cli/args.dart
+++ b/lib/src/cli/args.dart
@@ -74,8 +74,8 @@ ArgParser buildParser() => .new()
   ..addOption(
     'config',
     help:
-        'Path to a YAML config file. Defaults to ${configFileNames.first} (or\n'
-        '${configFileNames.last}) in the analyzed package root, when present.',
+        'Path to a YAML config file. Defaults to $configFileName in the\n'
+        'analyzed package root, when present.',
     valueHelp: 'path',
   )
   // Not a negatable `config` flag — `config` is the option above — but a flag
@@ -199,6 +199,15 @@ ArgParser buildParser() => .new()
     'progress',
     help: 'Show scan progress on stderr. Defaults to on for a terminal.',
   )
+  ..addFlag(
+    'verbose',
+    abbr: 'v',
+    help:
+        'Explain what is happening on stderr: which config file was used and\n'
+        'what it set, the settings the run ended up with, each scan phase as\n'
+        'it starts, and what --remove touches. Supersedes --progress, whose\n'
+        'single overwriting line would fight with it.',
+  )
   ..addOption(
     'concurrency',
     abbr: 'j',
@@ -229,13 +238,13 @@ Usage: ciach [options] [path]
 ${parser.usage}
 
 Config file:
-  Every option above can also be set in a YAML file — ${configFileNames.first}
-  (or ${configFileNames.last}) in the package root, picked up automatically —
-  using the long option name as the key, plus `path` for the positional
-  argument. Anything passed on the command line wins over the file, and
-  --no-config ignores it entirely.
+  Every option above can also be set in a YAML file — $configFileName in the
+  package root, picked up automatically — using the long option name as the
+  key, plus `path` for the positional argument. Anything passed on the command
+  line wins over the file, and --no-config ignores it entirely. Run with
+  --verbose to see which file was read and what it set.
 
-    # ${configFileNames.first}
+    # $configFileName
     public: false
     exclude:
       - 'test/**'

--- a/lib/src/cli/args.dart
+++ b/lib/src/cli/args.dart
@@ -58,16 +58,11 @@ Set<SymbolKind> parseKinds(List<String> raw) {
   };
 }
 
-/// Every setting ciach accepts, declared once.
+/// Every setting ciach accepts, declared once for the command line, the config
+/// file (`configKey`) and its default.
 ///
-/// Each option carries its command-line spelling, its help text, its default,
-/// and — for everything settable in a config file — the `configKey` a
-/// `ciach.yaml` entry is read from. `package:config` resolves a value for each
-/// from the command line first, then the config file, then the default, so
-/// there is one place to add a setting and no second list to keep in step.
-///
-/// The two config-file options themselves ([config] and [noConfig]) and
-/// [help] have no `configKey`: a config file can't decide whether it is read.
+/// [help], [config] and [noConfig] have no `configKey`: a config file doesn't
+/// get to decide whether it is read.
 enum CiachOption<V> implements OptionDefinition<V> {
   help(
     FlagOption(
@@ -87,8 +82,7 @@ enum CiachOption<V> implements OptionDefinition<V> {
           'analyzed package root, when present.',
     ),
   ),
-  // Not a negatable `config` flag — `config` is the option above — but a flag
-  // in its own right, so `--no-config` reads the way you'd expect it to.
+  // A flag of its own, not a negated `config` — that name is the option above.
   noConfig(
     FlagOption(
       argName: 'no-config',
@@ -249,11 +243,10 @@ enum CiachOption<V> implements OptionDefinition<V> {
       configKey: '/kinds',
       defaultsTo: [],
       valueHelp: 'kind,kind',
-      // Validated here so an unknown kind is rejected wherever it came from,
-      // with the same message; parseKinds does the conversion later.
+      // Rejects an unknown kind wherever it came from; the conversion to
+      // symbol kinds happens later.
       customValidator: parseKinds,
-      // The valid kinds come from kindAliases, so they are listed in `usage`
-      // rather than duplicated in this const help text.
+      // Listed in `usage`, which can read them off kindAliases.
       helpText:
           'Restrict to these declaration kinds (comma-separated).\n'
           'The kinds are listed at the end of this help.',
@@ -332,22 +325,18 @@ enum CiachOption<V> implements OptionDefinition<V> {
   @override
   final ConfigOptionBase<V> option;
 
-  /// The `ciach.yaml` key this option is read from, without the leading `/` of
-  /// its JSON pointer — `null` for an option a config file can't set.
+  /// The `ciach.yaml` key for this option, its JSON pointer without the `/`.
   String? get configKey => option.configKey?.substring(1);
 }
 
-/// A [Configuration] over ciach's own options, named so the `dynamic` type
-/// argument the option enum needs is written just the once.
+/// Ciach's resolved options, named so the enum's `dynamic` argument is written
+/// once.
 typedef CiachConfiguration = Configuration<CiachOption<dynamic>>;
 
-/// The file name looked for when discovering a config in the project
-/// directory.
+/// The file name config discovery looks for in the project directory.
 const configFileName = 'ciach.yaml';
 
-/// Builds the argument parser for [CiachOption.values], so the command line is
-/// parsed (and `--help` rendered) from the same declarations the config file
-/// and the defaults are read from.
+/// The argument parser for [CiachOption.values].
 ArgParser buildParser() {
   final parser = ArgParser();
   prepareOptionsForParsing(CiachOption.values, parser);
@@ -369,11 +358,10 @@ Declaration kinds (-k, --kinds):
 ${_wrapped(kindNames, indent: '  ')}
 
 Config file:
-  Every option above can also be set in a YAML file — $configFileName in the
-  package root, picked up automatically — using the long option name as the
-  key, plus `path` for the positional argument. Anything passed on the command
-  line wins over the file, and --no-config ignores it entirely. Run with
-  --verbose to see which file was read and what it set.
+  Every option above can also be set in $configFileName in the package root,
+  keyed by its long name, plus `path` for the positional argument. The command
+  line wins over the file; --no-config ignores the file; --verbose says which
+  file was read and what it set.
 
     # $configFileName
     public: false
@@ -404,8 +392,7 @@ Examples:
   # Remove without asking (e.g. in a script)
   ciach --remove --force''';
 
-/// [text] broken into [indent]-prefixed lines of at most [width] characters,
-/// splitting on the spaces after its commas.
+/// [text] as [indent]-prefixed lines of at most [width] characters.
 String _wrapped(String text, {String indent = '', int width = 76}) {
   final lines = <String>[];
   for (final word in text.split(' ')) {

--- a/lib/src/cli/args.dart
+++ b/lib/src/cli/args.dart
@@ -10,8 +10,8 @@
 
 import 'package:args/args.dart';
 import 'package:ciach/ciach.dart';
-import 'package:ciach/src/cli/config.dart';
 import 'package:collection/collection.dart';
+import 'package:config/config.dart';
 
 /// Friendly `--kinds` names mapped to LSP symbol kinds.
 const kindAliases = <String, SymbolKind>{
@@ -38,10 +38,6 @@ String get kindNames => kindAliases.keys.sorted().join(', ');
 /// The accepted `--format` values; the first one is the default.
 const formatNames = ['text', 'json', 'github'];
 
-/// The `--concurrency` default, as a string so the parser can show it in
-/// `--help` and the resolver can parse it back the same way.
-const defaultConcurrency = '16';
-
 /// Parses the `--kinds` values (comma-separated, repeatable) into symbol kinds,
 /// falling back to [FinderOptions.defaultKinds] when none are given.
 ///
@@ -62,169 +58,301 @@ Set<SymbolKind> parseKinds(List<String> raw) {
   };
 }
 
-/// Builds the CLI argument parser. Every flag and option ciach accepts is
-/// declared here, so adding one is a single-file change.
-ArgParser buildParser() => .new()
-  ..addFlag(
-    'help',
-    abbr: 'h',
-    negatable: false,
-    help: 'Print this usage information.',
-  )
-  ..addOption(
-    'config',
-    help:
-        'Path to a YAML config file. Defaults to $configFileName in the\n'
-        'analyzed package root, when present.',
-    valueHelp: 'path',
-  )
+/// Every setting ciach accepts, declared once.
+///
+/// Each option carries its command-line spelling, its help text, its default,
+/// and — for everything settable in a config file — the `configKey` a
+/// `ciach.yaml` entry is read from. `package:config` resolves a value for each
+/// from the command line first, then the config file, then the default, so
+/// there is one place to add a setting and no second list to keep in step.
+///
+/// The two config-file options themselves ([config] and [noConfig]) and
+/// [help] have no `configKey`: a config file can't decide whether it is read.
+enum CiachOption<V> implements OptionDefinition<V> {
+  help(
+    FlagOption(
+      argName: 'help',
+      argAbbrev: 'h',
+      negatable: false,
+      defaultsTo: false,
+      helpText: 'Print this usage information.',
+    ),
+  ),
+  config(
+    StringOption(
+      argName: 'config',
+      valueHelp: 'path',
+      helpText:
+          'Path to a YAML config file. Defaults to $configFileName in the\n'
+          'analyzed package root, when present.',
+    ),
+  ),
   // Not a negatable `config` flag — `config` is the option above — but a flag
   // in its own right, so `--no-config` reads the way you'd expect it to.
-  ..addFlag(
-    'no-config',
-    negatable: false,
-    help:
-        'Ignore any config file, including one that would be discovered\n'
-        'automatically. Cannot be combined with --config.',
-  )
-  ..addFlag(
-    'public',
-    defaultsTo: true,
-    help:
-        'Report unused public declarations too. Disable to report only\n'
-        'private (underscore-prefixed) declarations, which are the\n'
-        'highest-confidence dead code.',
-  )
-  ..addFlag(
-    'generated',
-    help: 'Scan generated files (*.g.dart, *.freezed.dart, …). Off by default.',
-  )
-  ..addFlag(
-    'overrides',
-    help:
-        'Report members annotated with @override too. Off by default,\n'
-        'since overrides are often reached polymorphically and a plain\n'
-        'reference search can miss those uses.',
-  )
-  ..addFlag(
-    'operators',
-    help:
-        'Report operator overloads (operator +, operator ==, …) too. Off\n'
-        'by default: the analysis server never resolves infix operator\n'
-        "syntax (a + b) back to the operator's declaration, so a used\n"
-        'operator is reported as unused every time.',
-  )
-  ..addFlag(
-    'unused-union-members',
-    help:
-        'Also flag a class whose only references are type patterns over its\n'
-        '(sealed) supertype — matched but never constructed. Off by default:\n'
-        'a `case Foo():` arm otherwise counts as a use. Report-only: these\n'
-        'findings are surfaced but --remove never deletes them or their\n'
-        'pattern arms (removing a sealed member and rewriting its switches\n'
-        'is left to a human). Conservative: any reference that is not clearly\n'
-        'a type pattern keeps the class alive.',
-  )
-  ..addFlag(
-    'report-tojson',
-    help:
-        'Report a `toJson()` serialization hook as unused too. Off by\n'
-        'default: `jsonEncode(obj)` calls `obj.toJson()` by dynamic dispatch\n'
-        'with no source-level `.toJson()` reference for the search to see, so\n'
-        'a live serializer would be flagged. Enable to audit dead `toJson`s.',
-  )
-  ..addFlag(
-    'set-exit-if-changed',
-    help:
-        'Exit with a non-zero status when any unused declaration is found\n'
-        '(useful in CI).',
-  )
-  ..addFlag(
-    'remove',
-    help:
-        'Remove unused declarations from source after reporting them.\n'
-        'Prompts for confirmation first, unless --force is also given.',
-  )
-  ..addFlag(
-    'force',
-    help: 'Skip the confirmation prompt for --remove. Requires --remove.',
-  )
-  ..addMultiOption(
-    'exclude',
-    abbr: 'e',
-    help: 'Glob(s), relative to the root, of files to skip. Repeatable.',
-    valueHelp: 'glob',
-  )
-  ..addMultiOption(
-    'include',
-    abbr: 'i',
-    help: 'If given, only scan files matching these glob(s). Repeatable.',
-    valueHelp: 'glob',
-  )
-  ..addMultiOption(
-    'generated-suffix',
-    help:
-        'Additional filename suffix to treat as generated (and so\n'
-        'exclude from the scan), on top of the built-in set (*.g.dart,\n'
-        '*.freezed.dart, …). Use for custom code generators, e.g.\n'
-        '--generated-suffix .gc.dart. Include the leading dot. Repeatable.\n'
-        'Ignored when --generated is set.',
-    valueHelp: 'suffix',
-  )
-  ..addMultiOption(
-    'kinds',
-    abbr: 'k',
-    help:
-        'Restrict to these declaration kinds (comma-separated).\n'
-        'Valid: $kindNames.',
-    valueHelp: 'kind,kind',
-  )
-  ..addOption(
-    'format',
-    abbr: 'f',
-    allowed: formatNames,
-    defaultsTo: formatNames.first,
-    help: 'Output format.',
-    allowedHelp: {
-      'text': 'Human-readable, grouped by file.',
-      'json': 'Machine-readable JSON.',
-      'github': 'GitHub Actions `::warning` annotations.',
-    },
-  )
-  ..addFlag(
-    'color',
-    help: 'Colorize text output. Defaults to auto-detecting the terminal.',
-  )
-  ..addFlag(
-    'progress',
-    help: 'Show scan progress on stderr. Defaults to on for a terminal.',
-  )
-  ..addFlag(
-    'verbose',
-    abbr: 'v',
-    help:
-        'Explain what is happening on stderr: which config file was used and\n'
-        'what it set, the settings the run ended up with, each scan phase as\n'
-        'it starts, and what --remove touches. Supersedes --progress, whose\n'
-        'single overwriting line would fight with it.',
-  )
-  ..addOption(
-    'concurrency',
-    abbr: 'j',
-    defaultsTo: defaultConcurrency,
-    help:
-        'How many reference queries to run against the analysis server at\n'
-        'once. Higher can be faster on large projects, up to the limit of\n'
-        'the analysis server parallelism.',
-    valueHelp: 'n',
-  )
-  ..addOption(
-    'dart',
-    help:
-        'Path to the dart executable used to launch the analysis server.\n'
-        'Defaults to the SDK running this tool.',
-    valueHelp: 'path',
+  noConfig(
+    FlagOption(
+      argName: 'no-config',
+      negatable: false,
+      defaultsTo: false,
+      helpText:
+          'Ignore any config file, including one that would be discovered\n'
+          'automatically. Cannot be combined with --config.',
+    ),
+  ),
+  path(
+    StringOption(
+      argPos: 0,
+      configKey: '/path',
+      defaultsTo: '.',
+      helpText: 'Package root to analyze.',
+    ),
+  ),
+  public(
+    FlagOption(
+      argName: 'public',
+      configKey: '/public',
+      defaultsTo: true,
+      helpText:
+          'Report unused public declarations too. Disable to report only\n'
+          'private (underscore-prefixed) declarations, which are the\n'
+          'highest-confidence dead code.',
+    ),
+  ),
+  generated(
+    FlagOption(
+      argName: 'generated',
+      configKey: '/generated',
+      defaultsTo: false,
+      helpText:
+          'Scan generated files (*.g.dart, *.freezed.dart, …). Off by default.',
+    ),
+  ),
+  overrides(
+    FlagOption(
+      argName: 'overrides',
+      configKey: '/overrides',
+      defaultsTo: false,
+      helpText:
+          'Report members annotated with @override too. Off by default,\n'
+          'since overrides are often reached polymorphically and a plain\n'
+          'reference search can miss those uses.',
+    ),
+  ),
+  operators(
+    FlagOption(
+      argName: 'operators',
+      configKey: '/operators',
+      defaultsTo: false,
+      helpText:
+          'Report operator overloads (operator +, operator ==, …) too. Off\n'
+          'by default: the analysis server never resolves infix operator\n'
+          "syntax (a + b) back to the operator's declaration, so a used\n"
+          'operator is reported as unused every time.',
+    ),
+  ),
+  unusedUnionMembers(
+    FlagOption(
+      argName: 'unused-union-members',
+      configKey: '/unused-union-members',
+      defaultsTo: false,
+      helpText:
+          'Also flag a class whose only references are type patterns over its\n'
+          '(sealed) supertype — matched but never constructed. Off by default:\n'
+          'a `case Foo():` arm otherwise counts as a use. Report-only: these\n'
+          'findings are surfaced but --remove never deletes them or their\n'
+          'pattern arms (removing a sealed member and rewriting its switches\n'
+          'is left to a human). Conservative: any reference that is not clearly\n'
+          'a type pattern keeps the class alive.',
+    ),
+  ),
+  reportToJson(
+    FlagOption(
+      argName: 'report-tojson',
+      configKey: '/report-tojson',
+      defaultsTo: false,
+      helpText:
+          'Report a `toJson()` serialization hook as unused too. Off by\n'
+          'default: `jsonEncode(obj)` calls `obj.toJson()` by dynamic dispatch\n'
+          'with no source-level `.toJson()` reference for the search to see, so\n'
+          'a live serializer would be flagged. Enable to audit dead `toJson`s.',
+    ),
+  ),
+  setExitIfChanged(
+    FlagOption(
+      argName: 'set-exit-if-changed',
+      configKey: '/set-exit-if-changed',
+      negatable: false,
+      defaultsTo: false,
+      helpText:
+          'Exit with a non-zero status when any unused declaration is found\n'
+          '(useful in CI).',
+    ),
+  ),
+  remove(
+    FlagOption(
+      argName: 'remove',
+      configKey: '/remove',
+      negatable: false,
+      defaultsTo: false,
+      helpText:
+          'Remove unused declarations from source after reporting them.\n'
+          'Prompts for confirmation first, unless --force is also given.',
+    ),
+  ),
+  force(
+    FlagOption(
+      argName: 'force',
+      configKey: '/force',
+      negatable: false,
+      defaultsTo: false,
+      helpText: 'Skip the confirmation prompt for --remove. Requires --remove.',
+    ),
+  ),
+  exclude(
+    MultiStringOption.noSplit(
+      argName: 'exclude',
+      argAbbrev: 'e',
+      configKey: '/exclude',
+      defaultsTo: [],
+      valueHelp: 'glob',
+      helpText: 'Glob(s), relative to the root, of files to skip. Repeatable.',
+    ),
+  ),
+  include(
+    MultiStringOption.noSplit(
+      argName: 'include',
+      argAbbrev: 'i',
+      configKey: '/include',
+      defaultsTo: [],
+      valueHelp: 'glob',
+      helpText: 'If given, only scan files matching these glob(s). Repeatable.',
+    ),
+  ),
+  generatedSuffix(
+    MultiStringOption.noSplit(
+      argName: 'generated-suffix',
+      configKey: '/generated-suffix',
+      defaultsTo: [],
+      valueHelp: 'suffix',
+      helpText:
+          'Additional filename suffix to treat as generated (and so\n'
+          'exclude from the scan), on top of the built-in set (*.g.dart,\n'
+          '*.freezed.dart, …). Use for custom code generators, e.g.\n'
+          '--generated-suffix .gc.dart. Include the leading dot. Repeatable.\n'
+          'Ignored when --generated is set.',
+    ),
+  ),
+  kinds(
+    MultiStringOption(
+      argName: 'kinds',
+      argAbbrev: 'k',
+      configKey: '/kinds',
+      defaultsTo: [],
+      valueHelp: 'kind,kind',
+      // Validated here so an unknown kind is rejected wherever it came from,
+      // with the same message; parseKinds does the conversion later.
+      customValidator: parseKinds,
+      // The valid kinds come from kindAliases, so they are listed in `usage`
+      // rather than duplicated in this const help text.
+      helpText:
+          'Restrict to these declaration kinds (comma-separated).\n'
+          'The kinds are listed at the end of this help.',
+    ),
+  ),
+  format(
+    StringOption(
+      argName: 'format',
+      argAbbrev: 'f',
+      configKey: '/format',
+      allowedValues: formatNames,
+      defaultsTo: 'text',
+      helpText: 'Output format.',
+      allowedHelp: {
+        'text': 'Human-readable, grouped by file.',
+        'json': 'Machine-readable JSON.',
+        'github': 'GitHub Actions `::warning` annotations.',
+      },
+    ),
+  ),
+  color(
+    FlagOption(
+      argName: 'color',
+      configKey: '/color',
+      helpText:
+          'Colorize text output. Defaults to auto-detecting the terminal.',
+    ),
+  ),
+  progress(
+    FlagOption(
+      argName: 'progress',
+      configKey: '/progress',
+      helpText: 'Show scan progress on stderr. Defaults to on for a terminal.',
+    ),
+  ),
+  verbose(
+    FlagOption(
+      argName: 'verbose',
+      argAbbrev: 'v',
+      configKey: '/verbose',
+      defaultsTo: false,
+      helpText:
+          'Explain what is happening on stderr: which config file was used and\n'
+          'what it set, the settings the run ended up with, each scan phase as\n'
+          'it starts, and what --remove touches. Supersedes --progress, whose\n'
+          'single overwriting line would fight with it.',
+    ),
+  ),
+  concurrency(
+    IntOption(
+      argName: 'concurrency',
+      argAbbrev: 'j',
+      configKey: '/concurrency',
+      valueHelp: 'n',
+      defaultsTo: 16,
+      min: 1,
+      helpText:
+          'How many reference queries to run against the analysis server at\n'
+          'once. Higher can be faster on large projects, up to the limit of\n'
+          'the analysis server parallelism.',
+    ),
+  ),
+  dart(
+    StringOption(
+      argName: 'dart',
+      configKey: '/dart',
+      valueHelp: 'path',
+      helpText:
+          'Path to the dart executable used to launch the analysis server.\n'
+          'Defaults to the SDK running this tool.',
+    ),
   );
+
+  const CiachOption(this.option);
+
+  @override
+  final ConfigOptionBase<V> option;
+
+  /// The `ciach.yaml` key this option is read from, without the leading `/` of
+  /// its JSON pointer — `null` for an option a config file can't set.
+  String? get configKey => option.configKey?.substring(1);
+}
+
+/// A [Configuration] over ciach's own options, named so the `dynamic` type
+/// argument the option enum needs is written just the once.
+typedef CiachConfiguration = Configuration<CiachOption<dynamic>>;
+
+/// The file name looked for when discovering a config in the project
+/// directory.
+const configFileName = 'ciach.yaml';
+
+/// Builds the argument parser for [CiachOption.values], so the command line is
+/// parsed (and `--help` rendered) from the same declarations the config file
+/// and the defaults are read from.
+ArgParser buildParser() {
+  final parser = ArgParser();
+  prepareOptionsForParsing(CiachOption.values, parser);
+  return parser;
+}
 
 /// The full `--help` text, wrapping [parser]'s generated option list.
 String usage(ArgParser parser) =>
@@ -236,6 +364,9 @@ Usage: ciach [options] [path]
   path   Package root to analyze (defaults to the current directory).
 
 ${parser.usage}
+
+Declaration kinds (-k, --kinds):
+${_wrapped(kindNames, indent: '  ')}
 
 Config file:
   Every option above can also be set in a YAML file — $configFileName in the
@@ -272,3 +403,17 @@ Examples:
 
   # Remove without asking (e.g. in a script)
   ciach --remove --force''';
+
+/// [text] broken into [indent]-prefixed lines of at most [width] characters,
+/// splitting on the spaces after its commas.
+String _wrapped(String text, {String indent = '', int width = 76}) {
+  final lines = <String>[];
+  for (final word in text.split(' ')) {
+    if (lines.isEmpty || '${lines.last} $word'.length > width) {
+      lines.add('$indent$word');
+    } else {
+      lines[lines.length - 1] = '${lines.last} $word';
+    }
+  }
+  return lines.join('\n');
+}

--- a/lib/src/cli/args.dart
+++ b/lib/src/cli/args.dart
@@ -10,6 +10,7 @@
 
 import 'package:args/args.dart';
 import 'package:ciach/ciach.dart';
+import 'package:ciach/src/cli/config.dart';
 import 'package:collection/collection.dart';
 
 /// Friendly `--kinds` names mapped to LSP symbol kinds.
@@ -33,6 +34,13 @@ const kindAliases = <String, SymbolKind>{
 
 /// The `--kinds` alias names, sorted, for help text and error messages.
 String get kindNames => kindAliases.keys.sorted().join(', ');
+
+/// The accepted `--format` values; the first one is the default.
+const formatNames = ['text', 'json', 'github'];
+
+/// The `--concurrency` default, as a string so the parser can show it in
+/// `--help` and the resolver can parse it back the same way.
+const defaultConcurrency = '16';
 
 /// Parses the `--kinds` values (comma-separated, repeatable) into symbol kinds,
 /// falling back to [FinderOptions.defaultKinds] when none are given.
@@ -62,6 +70,22 @@ ArgParser buildParser() => .new()
     abbr: 'h',
     negatable: false,
     help: 'Print this usage information.',
+  )
+  ..addOption(
+    'config',
+    help:
+        'Path to a YAML config file. Defaults to ${configFileNames.first} (or\n'
+        '${configFileNames.last}) in the analyzed package root, when present.',
+    valueHelp: 'path',
+  )
+  // Not a negatable `config` flag — `config` is the option above — but a flag
+  // in its own right, so `--no-config` reads the way you'd expect it to.
+  ..addFlag(
+    'no-config',
+    negatable: false,
+    help:
+        'Ignore any config file, including one that would be discovered\n'
+        'automatically. Cannot be combined with --config.',
   )
   ..addFlag(
     'public',
@@ -158,8 +182,8 @@ ArgParser buildParser() => .new()
   ..addOption(
     'format',
     abbr: 'f',
-    allowed: ['text', 'json', 'github'],
-    defaultsTo: 'text',
+    allowed: formatNames,
+    defaultsTo: formatNames.first,
     help: 'Output format.',
     allowedHelp: {
       'text': 'Human-readable, grouped by file.',
@@ -178,7 +202,7 @@ ArgParser buildParser() => .new()
   ..addOption(
     'concurrency',
     abbr: 'j',
-    defaultsTo: '16',
+    defaultsTo: defaultConcurrency,
     help:
         'How many reference queries to run against the analysis server at\n'
         'once. Higher can be faster on large projects, up to the limit of\n'
@@ -204,12 +228,32 @@ Usage: ciach [options] [path]
 
 ${parser.usage}
 
+Config file:
+  Every option above can also be set in a YAML file — ${configFileNames.first}
+  (or ${configFileNames.last}) in the package root, picked up automatically —
+  using the long option name as the key, plus `path` for the positional
+  argument. Anything passed on the command line wins over the file, and
+  --no-config ignores it entirely.
+
+    # ${configFileNames.first}
+    public: false
+    exclude:
+      - 'test/**'
+    kinds: [class, function]
+    format: json
+
 Examples:
   # Scan the current package
   ciach
 
   # Only private declarations, excluding tests, as JSON
   ciach --no-public -e 'test/**' -f json lib/
+
+  # Read settings from a config file elsewhere
+  ciach --config tool/ciach.yaml
+
+  # Ignore the package's config file for one run
+  ciach --no-config
 
   # GitHub Actions annotations, fail the job if anything is found
   ciach -f github --set-exit-if-changed

--- a/lib/src/cli/config.dart
+++ b/lib/src/cli/config.dart
@@ -223,7 +223,7 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
 
   int? _positiveInt(String key) => switch (settings[key]) {
     null => null,
-    final int value when value > 0 => value,
+    final int value && > 0 => value,
     final other => _wrong(key, 'a positive integer', other),
   };
 

--- a/lib/src/cli/config.dart
+++ b/lib/src/cli/config.dart
@@ -1,13 +1,12 @@
 import 'dart:io';
 
 import 'package:ciach/src/cli/args.dart';
-import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
-/// File names looked for, in order, when discovering a config file in the
-/// project directory.
-const configFileNames = ['ciach.yaml', 'ciach.yml'];
+/// The file name looked for when discovering a config in the project
+/// directory.
+const configFileName = 'ciach.yaml';
 
 /// Every key a config file may contain. Each one mirrors the command-line
 /// flag of the same name (`path` mirrors the positional path argument), so
@@ -30,6 +29,7 @@ const configKeys = <String>{
   'format',
   'color',
   'progress',
+  'verbose',
   'concurrency',
   'dart',
 };
@@ -58,6 +58,7 @@ class CiachConfig {
     this.format,
     this.color,
     this.progress,
+    this.verbose,
     this.concurrency,
     this.dart,
   });
@@ -114,6 +115,7 @@ class CiachConfig {
       format: reader.oneOf('format', formatNames),
       color: reader.boolean('color'),
       progress: reader.boolean('progress'),
+      verbose: reader.boolean('verbose'),
       concurrency: reader.positiveInt('concurrency'),
       dart: reader.string('dart'),
     );
@@ -171,21 +173,70 @@ class CiachConfig {
   /// Mirrors `--[no-]progress`.
   final bool? progress;
 
+  /// Mirrors `--[no-]verbose`.
+  final bool? verbose;
+
   /// Mirrors `--concurrency`.
   final int? concurrency;
 
   /// Mirrors `--dart`.
   final String? dart;
+
+  /// The settings this config actually specifies, keyed by config key and
+  /// ordered like [configKeys] — the basis of the `--verbose` rundown of what a
+  /// file contributed.
+  Map<String, Object?> get settings => {
+    'path': ?path,
+    'public': ?public,
+    'generated': ?generated,
+    'overrides': ?overrides,
+    'operators': ?operators,
+    'unused-union-members': ?unusedUnionMembers,
+    'report-tojson': ?reportToJson,
+    'set-exit-if-changed': ?setExitIfChanged,
+    'remove': ?remove,
+    'force': ?force,
+    'exclude': ?exclude,
+    'include': ?include,
+    'generated-suffix': ?generatedSuffix,
+    'kinds': ?kinds,
+    'format': ?format,
+    'color': ?color,
+    'progress': ?progress,
+    'verbose': ?verbose,
+    'concurrency': ?concurrency,
+    'dart': ?dart,
+  };
 }
 
-/// A config file that was loaded, together with where it came from.
-typedef LoadedConfig = ({CiachConfig config, String? path});
+/// The outcome of looking for a config file.
+class LoadedConfig {
+  /// Records a config-file lookup and what it produced.
+  const LoadedConfig({
+    required this.config,
+    required this.path,
+    this.ignored = false,
+  });
+
+  /// The settings read from [path], or an empty config when there was nothing
+  /// to read (or when it was [ignored]).
+  final CiachConfig config;
+
+  /// The config file this came from, or — when [ignored] — the file that was
+  /// skipped. `null` when no config file was found at all.
+  final String? path;
+
+  /// Whether a config file was deliberately skipped (`--no-config`). Nothing
+  /// was read or parsed in that case, so even an invalid file is no error.
+  final bool ignored;
+}
 
 /// Resolves and loads the config file for a run.
 ///
-/// Returns an empty config (and a `null` path) when [ignore] is set or when no
-/// config file is found. [explicitPath] — from `--config` — is loaded as-is;
-/// otherwise [configFileNames] are looked for in [projectDir].
+/// [explicitPath] — from `--config` — is loaded as-is; otherwise
+/// [configFileName] is looked for in [projectDir]. With [ignore] set the file
+/// is located (so `--verbose` can name what it skipped) but never read, and the
+/// returned config is empty.
 ///
 /// Throws a [FormatException] when [explicitPath] does not exist or when the
 /// file cannot be parsed.
@@ -194,8 +245,13 @@ LoadedConfig loadConfig({
   String? explicitPath,
   bool ignore = false,
 }) {
+  final discovered = File(p.join(projectDir, configFileName));
   if (ignore) {
-    return (config: const CiachConfig(), path: null);
+    return LoadedConfig(
+      config: const CiachConfig(),
+      path: discovered.existsSync() ? discovered.path : null,
+      ignored: true,
+    );
   }
 
   final File file;
@@ -205,14 +261,10 @@ LoadedConfig loadConfig({
       throw FormatException('Config file does not exist: $explicitPath');
     }
   } else {
-    final found = configFileNames
-        .map((name) => File(p.join(projectDir, name)))
-        .where((f) => f.existsSync())
-        .firstOrNull;
-    if (found == null) {
-      return (config: const CiachConfig(), path: null);
+    if (!discovered.existsSync()) {
+      return const LoadedConfig(config: CiachConfig(), path: null);
     }
-    file = found;
+    file = discovered;
   }
 
   final String source;
@@ -222,7 +274,7 @@ LoadedConfig loadConfig({
     throw FormatException('Cannot read config file ${file.path}: ${e.message}');
   }
 
-  return (
+  return LoadedConfig(
     config: CiachConfig.parse(source, origin: file.path),
     path: file.path,
   );

--- a/lib/src/cli/config.dart
+++ b/lib/src/cli/config.dart
@@ -2,50 +2,24 @@ import 'dart:io';
 
 import 'package:ciach/src/cli/args.dart';
 import 'package:collection/collection.dart';
+import 'package:config/config.dart';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
-/// The file name looked for when discovering a config in the project
-/// directory.
-const configFileName = 'ciach.yaml';
+/// Every key a config file may contain: the config key of each option that
+/// declares one, so the accepted set follows [CiachOption] rather than being
+/// maintained alongside it.
+final configKeys = {for (final option in CiachOption.values) ?option.configKey};
 
-/// Every key a config file may contain. Each one mirrors the command-line
-/// flag of the same name (`path` mirrors the positional path argument), so
-/// there is exactly one name to learn per setting.
-const configKeys = <String>{
-  'path',
-  'public',
-  'generated',
-  'overrides',
-  'operators',
-  'unused-union-members',
-  'report-tojson',
-  'set-exit-if-changed',
-  'remove',
-  'force',
-  'exclude',
-  'include',
-  'generated-suffix',
-  'kinds',
-  'format',
-  'color',
-  'progress',
-  'verbose',
-  'concurrency',
-  'dart',
-};
-
-/// A config file: the settings it holds, where it came from, and typed readers
-/// for pulling values out of it.
+/// A config file: the settings it holds, where it came from, and the typed
+/// lookups that hand them to `package:config`.
 ///
-/// Deliberately *not* a field per option. The options are already declared once
-/// in `buildParser`, and `resolveOptions` is the one place that reads them all;
-/// a second hand-written list of the same twenty names would only be something
-/// to forget to update. What the file sets lives in [settings] — validated on
-/// the way in for shape and unknown keys, and on the way out for type — while
-/// `ResolvedOptions` is where a run's settings become properly typed and
-/// non-nullable.
-class ConfigFile {
+/// As a [ConfigurationBroker] this is the config-file layer of option
+/// resolution — the command line still wins, and the option's own default is
+/// still the fallback. What stays ciach's own business is everything about the
+/// file itself: where to look for it, whether to read it at all, and reporting
+/// a malformed one against the path it came from.
+class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
   const ConfigFile._({
     required this.settings,
     required this.path,
@@ -58,9 +32,9 @@ class ConfigFile {
   /// Parses [source] as a config file whose settings came from [origin]
   /// (a file path, which becomes [path] and names the file in errors).
   ///
-  /// Throws a [FormatException] on a document that isn't a map of options, or
-  /// one carrying a key that is not in [configKeys]. Individual values are
-  /// checked as they are read, by the readers below.
+  /// Throws a [FormatException] on a document that isn't a map of options, one
+  /// carrying a key that is not in [configKeys], or a value whose type doesn't
+  /// suit its option.
   factory ConfigFile.parse(String source, {required String origin}) {
     final Object? document;
     try {
@@ -88,7 +62,7 @@ class ConfigFile {
       );
     }
 
-    return ConfigFile._(
+    final file = ConfigFile._(
       settings: {
         for (final entry in document.entries)
           // A key with no value (`public:`) counts as unset, so commenting a
@@ -100,6 +74,12 @@ class ConfigFile {
       path: origin,
       ignored: false,
     );
+
+    // Type-check the whole file up front. Resolution only asks for the keys it
+    // ends up needing, so without this a bad value under an option the command
+    // line overrides would sit in the file unreported.
+    file.settings.keys.forEach(file._typedValue);
+    return file;
   }
 
   /// Finds and reads the config file for a run.
@@ -159,34 +139,54 @@ class ConfigFile {
   /// was read or parsed in that case, so even an invalid file is no error.
   final bool ignored;
 
-  /// A boolean setting, or `null` when the file doesn't set it.
-  bool? boolean(String key) => switch (settings[key]) {
+  /// The config-file value for [key] — a JSON pointer such as `/public` —
+  /// typed to suit its option, or `null` when the file doesn't set it.
+  @override
+  Object? valueOrNull(String key, CiachConfiguration cfg) =>
+      _typedValue(key.startsWith('/') ? key.substring(1) : key);
+
+  /// The value under [key], as the type its option takes.
+  ///
+  /// The type has to come from the option rather than from the value, so that
+  /// `exclude: ['a']` arrives as a `List<String>` (a bare `List<dynamic>` would
+  /// not satisfy the option) and so that a mismatch is reported against the
+  /// file, naming the key and what was expected.
+  ///
+  /// Three settings accept less than their type allows. Their rules live with
+  /// the option — as `allowedValues`, a `customValidator`, a `min` — and are
+  /// applied to whatever the command line provides; these readers hold the file
+  /// to the same rules, from the same [formatNames] and [parseKinds], so that a
+  /// bad value is reported against the file it is written in either way.
+  Object? _typedValue(String key) => switch (_optionFor(key)) {
+    CiachOption.format => _oneOf(key, formatNames),
+    CiachOption.kinds => _kinds(key),
+    CiachOption.concurrency => _positiveInt(key),
+    final option => switch (option.option) {
+      FlagOption() => _boolean(key),
+      IntOption() => _positiveInt(key),
+      MultiOption() => _strings(key),
+      _ => _string(key),
+    },
+  };
+
+  CiachOption<dynamic> _optionFor(String key) =>
+      CiachOption.values.firstWhere((option) => option.configKey == key);
+
+  bool? _boolean(String key) => switch (settings[key]) {
     null => null,
     final bool value => value,
     final other => _wrong(key, 'true or false', other),
   };
 
-  /// A string setting, or `null` when the file doesn't set it.
-  String? string(String key) => switch (settings[key]) {
+  String? _string(String key) => switch (settings[key]) {
     null => null,
     final String value => value,
     final other => _wrong(key, 'a string', other),
   };
 
-  /// A string setting restricted to [allowed] values.
-  String? oneOf(String key, List<String> allowed) {
-    final value = string(key);
-    if (value != null && !allowed.contains(value)) {
-      throw FormatException(
-        "$path: '$key' must be one of ${allowed.join(', ')}, got '$value'.",
-      );
-    }
-    return value;
-  }
-
-  /// A list-of-strings setting, also accepting a bare string as a one-element
-  /// list (`exclude: test/**`).
-  List<String>? strings(String key) => switch (settings[key]) {
+  /// A list of strings, also accepting a bare string as a one-element list
+  /// (`exclude: test/**`).
+  List<String>? _strings(String key) => switch (settings[key]) {
     null => null,
     final String value => [value],
     final Iterable<Object?> values => [
@@ -196,10 +196,21 @@ class ConfigFile {
     final other => _wrong(key, 'a list of strings', other),
   };
 
+  /// A string setting restricted to [allowed] values.
+  String? _oneOf(String key, List<String> allowed) {
+    final value = _string(key);
+    if (value != null && !allowed.contains(value)) {
+      throw FormatException(
+        "$path: '$key' must be one of ${allowed.join(', ')}, got '$value'.",
+      );
+    }
+    return value;
+  }
+
   /// Declaration kind names, left for `parseKinds` to turn into symbol kinds
   /// but validated here, so an unknown kind names the file it came from.
-  List<String>? kinds(String key) {
-    final values = strings(key);
+  List<String>? _kinds(String key) {
+    final values = _strings(key);
     if (values != null) {
       try {
         parseKinds(values);
@@ -210,8 +221,7 @@ class ConfigFile {
     return values;
   }
 
-  /// A positive-integer setting, or `null` when the file doesn't set it.
-  int? positiveInt(String key) => switch (settings[key]) {
+  int? _positiveInt(String key) => switch (settings[key]) {
     null => null,
     final int value when value > 0 => value,
     final other => _wrong(key, 'a positive integer', other),

--- a/lib/src/cli/config.dart
+++ b/lib/src/cli/config.dart
@@ -83,8 +83,7 @@ class ConfigFile {
     if (unknown.isNotEmpty) {
       final valid = (configKeys.toList()..sort()).join(', ');
       throw FormatException(
-        '$origin: unknown option${unknown.length == 1 ? '' : 's'} '
-        "${unknown.map((key) => "'$key'").join(', ')}. Valid options: $valid.",
+        '$origin: unknown option${unknown.length == 1 ? '' : 's'} ${unknown.map((key) => "'$key'").join(', ')}. Valid options: $valid.',
       );
     }
 

--- a/lib/src/cli/config.dart
+++ b/lib/src/cli/config.dart
@@ -1,0 +1,313 @@
+import 'dart:io';
+
+import 'package:ciach/src/cli/args.dart';
+import 'package:collection/collection.dart';
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+/// File names looked for, in order, when discovering a config file in the
+/// project directory.
+const configFileNames = ['ciach.yaml', 'ciach.yml'];
+
+/// Every key a config file may contain. Each one mirrors the command-line
+/// flag of the same name (`path` mirrors the positional path argument), so
+/// there is exactly one name to learn per setting.
+const configKeys = <String>{
+  'path',
+  'public',
+  'generated',
+  'overrides',
+  'operators',
+  'unused-union-members',
+  'report-tojson',
+  'set-exit-if-changed',
+  'remove',
+  'force',
+  'exclude',
+  'include',
+  'generated-suffix',
+  'kinds',
+  'format',
+  'color',
+  'progress',
+  'concurrency',
+  'dart',
+};
+
+/// A config file's contents, with one nullable field per setting.
+///
+/// `null` means "not set here", which is what lets the command line and the
+/// built-in defaults show through — see `resolveOptions`.
+class CiachConfig {
+  /// Creates a config with only the given settings present.
+  const CiachConfig({
+    this.path,
+    this.public,
+    this.generated,
+    this.overrides,
+    this.operators,
+    this.unusedUnionMembers,
+    this.reportToJson,
+    this.setExitIfChanged,
+    this.remove,
+    this.force,
+    this.exclude,
+    this.include,
+    this.generatedSuffix,
+    this.kinds,
+    this.format,
+    this.color,
+    this.progress,
+    this.concurrency,
+    this.dart,
+  });
+
+  /// Parses [source] as a ciach config file.
+  ///
+  /// [origin] names the source in error messages (typically the file path).
+  /// Throws a [FormatException] describing the offending key on a malformed
+  /// document, an unknown key, or a value of the wrong type.
+  factory CiachConfig.parse(String source, {required String origin}) {
+    final Object? document;
+    try {
+      document = loadYaml(source, sourceUrl: Uri.file(origin));
+    } on YamlException catch (e) {
+      throw FormatException('$origin: not valid YAML: ${e.message}');
+    }
+
+    // An empty file parses to null; treat it as "no settings", not an error.
+    if (document == null) {
+      return const CiachConfig();
+    }
+    if (document is! Map) {
+      throw FormatException('$origin: the top level must be a map of options.');
+    }
+
+    final unknown = document.keys
+        .map((k) => '$k')
+        .where((k) => !configKeys.contains(k))
+        .toList();
+    if (unknown.isNotEmpty) {
+      final valid = (configKeys.toList()..sort()).join(', ');
+      throw FormatException(
+        '$origin: unknown option${unknown.length == 1 ? '' : 's'} '
+        "${unknown.map((k) => "'$k'").join(', ')}. Valid options: $valid.",
+      );
+    }
+
+    final reader = _ConfigReader(document, origin);
+    return CiachConfig(
+      path: reader.string('path'),
+      public: reader.boolean('public'),
+      generated: reader.boolean('generated'),
+      overrides: reader.boolean('overrides'),
+      operators: reader.boolean('operators'),
+      unusedUnionMembers: reader.boolean('unused-union-members'),
+      reportToJson: reader.boolean('report-tojson'),
+      setExitIfChanged: reader.boolean('set-exit-if-changed'),
+      remove: reader.boolean('remove'),
+      force: reader.boolean('force'),
+      exclude: reader.strings('exclude'),
+      include: reader.strings('include'),
+      generatedSuffix: reader.strings('generated-suffix'),
+      kinds: reader.kinds('kinds'),
+      format: reader.oneOf('format', formatNames),
+      color: reader.boolean('color'),
+      progress: reader.boolean('progress'),
+      concurrency: reader.positiveInt('concurrency'),
+      dart: reader.string('dart'),
+    );
+  }
+
+  /// Package root to analyze, mirroring the positional `path` argument.
+  final String? path;
+
+  /// Mirrors `--[no-]public`.
+  final bool? public;
+
+  /// Mirrors `--[no-]generated`.
+  final bool? generated;
+
+  /// Mirrors `--[no-]overrides`.
+  final bool? overrides;
+
+  /// Mirrors `--[no-]operators`.
+  final bool? operators;
+
+  /// Mirrors `--[no-]unused-union-members`.
+  final bool? unusedUnionMembers;
+
+  /// Mirrors `--[no-]report-tojson`.
+  final bool? reportToJson;
+
+  /// Mirrors `--set-exit-if-changed`.
+  final bool? setExitIfChanged;
+
+  /// Mirrors `--remove`.
+  final bool? remove;
+
+  /// Mirrors `--force`.
+  final bool? force;
+
+  /// Mirrors `--exclude`; a single string is accepted as a one-element list.
+  final List<String>? exclude;
+
+  /// Mirrors `--include`; a single string is accepted as a one-element list.
+  final List<String>? include;
+
+  /// Mirrors `--generated-suffix`.
+  final List<String>? generatedSuffix;
+
+  /// Mirrors `--kinds`, unparsed. Either a list of kind names or a single
+  /// comma-separated string; `parseKinds` accepts both shapes.
+  final List<String>? kinds;
+
+  /// Mirrors `--format`.
+  final String? format;
+
+  /// Mirrors `--[no-]color`.
+  final bool? color;
+
+  /// Mirrors `--[no-]progress`.
+  final bool? progress;
+
+  /// Mirrors `--concurrency`.
+  final int? concurrency;
+
+  /// Mirrors `--dart`.
+  final String? dart;
+}
+
+/// A config file that was loaded, together with where it came from.
+typedef LoadedConfig = ({CiachConfig config, String? path});
+
+/// Resolves and loads the config file for a run.
+///
+/// Returns an empty config (and a `null` path) when [ignore] is set or when no
+/// config file is found. [explicitPath] — from `--config` — is loaded as-is;
+/// otherwise [configFileNames] are looked for in [projectDir].
+///
+/// Throws a [FormatException] when [explicitPath] does not exist or when the
+/// file cannot be parsed.
+LoadedConfig loadConfig({
+  required String projectDir,
+  String? explicitPath,
+  bool ignore = false,
+}) {
+  if (ignore) {
+    return (config: const CiachConfig(), path: null);
+  }
+
+  final File file;
+  if (explicitPath != null) {
+    file = File(explicitPath);
+    if (!file.existsSync()) {
+      throw FormatException('Config file does not exist: $explicitPath');
+    }
+  } else {
+    final found = configFileNames
+        .map((name) => File(p.join(projectDir, name)))
+        .where((f) => f.existsSync())
+        .firstOrNull;
+    if (found == null) {
+      return (config: const CiachConfig(), path: null);
+    }
+    file = found;
+  }
+
+  final String source;
+  try {
+    source = file.readAsStringSync();
+  } on FileSystemException catch (e) {
+    throw FormatException('Cannot read config file ${file.path}: ${e.message}');
+  }
+
+  return (
+    config: CiachConfig.parse(source, origin: file.path),
+    path: file.path,
+  );
+}
+
+/// Reads typed values out of a parsed YAML map, naming the config file and the
+/// offending key on every type mismatch.
+class _ConfigReader {
+  _ConfigReader(this._map, this._origin);
+
+  final Map<Object?, Object?> _map;
+  final String _origin;
+
+  Never _wrong(String key, String expected, Object? value) =>
+      throw FormatException(
+        "$_origin: '$key' must be $expected, got ${_describe(value)}.",
+      );
+
+  static String _describe(Object? value) => switch (value) {
+    null => 'null',
+    String() => 'a string',
+    bool() => 'a boolean',
+    num() => 'a number',
+    Iterable() => 'a list',
+    Map() => 'a map',
+    _ => '$value',
+  };
+
+  /// The raw value for [key], or `null` when the key is absent. A key present
+  /// with an empty value (`public:`) counts as absent, so commenting a value
+  /// out behaves like deleting the line.
+  Object? _raw(String key) => _map[key];
+
+  bool? boolean(String key) => switch (_raw(key)) {
+    null => null,
+    final bool value => value,
+    final other => _wrong(key, 'true or false', other),
+  };
+
+  String? string(String key) => switch (_raw(key)) {
+    null => null,
+    final String value => value,
+    final other => _wrong(key, 'a string', other),
+  };
+
+  String? oneOf(String key, List<String> allowed) {
+    final value = string(key);
+    if (value != null && !allowed.contains(value)) {
+      throw FormatException(
+        "$_origin: '$key' must be one of ${allowed.join(', ')}, got '$value'.",
+      );
+    }
+    return value;
+  }
+
+  /// A list of strings, also accepting a single string as a one-element list
+  /// (`exclude: test/**`).
+  List<String>? strings(String key) => switch (_raw(key)) {
+    null => null,
+    final String value => [value],
+    final Iterable<Object?> values => [
+      for (final value in values)
+        if (value is String) value else _wrong(key, 'a list of strings', value),
+    ],
+    final other => _wrong(key, 'a list of strings', other),
+  };
+
+  /// Declaration kind names, left unparsed for `parseKinds` to turn into
+  /// symbol kinds, but validated here so an unknown kind names the file it
+  /// came from.
+  List<String>? kinds(String key) {
+    final values = strings(key);
+    if (values != null) {
+      try {
+        parseKinds(values);
+      } on FormatException catch (e) {
+        throw FormatException("$_origin: '$key': ${e.message}");
+      }
+    }
+    return values;
+  }
+
+  int? positiveInt(String key) => switch (_raw(key)) {
+    null => null,
+    final int value when value > 0 => value,
+    final other => _wrong(key, 'a positive integer', other),
+  };
+}

--- a/lib/src/cli/config.dart
+++ b/lib/src/cli/config.dart
@@ -6,19 +6,15 @@ import 'package:config/config.dart';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
-/// Every key a config file may contain: the config key of each option that
-/// declares one, so the accepted set follows [CiachOption] rather than being
-/// maintained alongside it.
+/// Every key a config file may contain, following [CiachOption].
 final configKeys = {for (final option in CiachOption.values) ?option.configKey};
 
-/// A config file: the settings it holds, where it came from, and the typed
-/// lookups that hand them to `package:config`.
+/// The config-file layer of option resolution: a [ConfigurationBroker] over the
+/// settings of a `ciach.yaml`.
 ///
-/// As a [ConfigurationBroker] this is the config-file layer of option
-/// resolution — the command line still wins, and the option's own default is
-/// still the fallback. What stays ciach's own business is everything about the
-/// file itself: where to look for it, whether to read it at all, and reporting
-/// a malformed one against the path it came from.
+/// Where to look for that file, whether to read it at all, and reporting a
+/// malformed one against its path stay ciach's own business; the command line
+/// beating it, and its defaults, are `package:config`'s.
 class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
   const ConfigFile._({
     required this.settings,
@@ -29,12 +25,10 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
   /// A config that sets nothing, from nowhere.
   const ConfigFile.empty() : settings = const {}, path = null, ignored = false;
 
-  /// Parses [source] as a config file whose settings came from [origin]
-  /// (a file path, which becomes [path] and names the file in errors).
+  /// Parses [source], read from the file [origin], which names it in errors.
   ///
-  /// Throws a [FormatException] on a document that isn't a map of options, one
-  /// carrying a key that is not in [configKeys], or a value whose type doesn't
-  /// suit its option.
+  /// Throws a [FormatException] on anything but a map of known keys with values
+  /// their options accept.
   factory ConfigFile.parse(String source, {required String origin}) {
     final Object? document;
     try {
@@ -43,9 +37,9 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
       throw FormatException('$origin: not valid YAML: ${e.message}');
     }
 
-    // An empty file parses to null; treat it as "no settings", not an error.
+    // An empty file parses to null; that is no settings, not an error.
     if (document == null) {
-      return ConfigFile._(settings: const {}, path: origin, ignored: false);
+      return ._(settings: const {}, path: origin, ignored: false);
     }
     if (document is! Map) {
       throw FormatException('$origin: the top level must be a map of options.');
@@ -65,9 +59,8 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
     final file = ConfigFile._(
       settings: {
         for (final entry in document.entries)
-          // A key with no value (`public:`) counts as unset, so commenting a
-          // value out behaves like deleting the line. YAML collections are
-          // unwrapped so settings holds plain Dart values.
+          // A valueless key (`public:`) counts as unset, and YAML collections
+          // are unwrapped to plain Dart ones.
           if (entry.value case final value?)
             '${entry.key}': value is Iterable ? value.toList() : value,
       },
@@ -75,22 +68,20 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
       ignored: false,
     );
 
-    // Type-check the whole file up front. Resolution only asks for the keys it
-    // ends up needing, so without this a bad value under an option the command
-    // line overrides would sit in the file unreported.
+    // Resolution only asks for the keys it needs, so without checking the whole
+    // file here, a bad value under an overridden option would go unreported.
     file.settings.keys.forEach(file._typedValue);
     return file;
   }
 
-  /// Finds and reads the config file for a run.
+  /// Finds and reads the config file for a run: [explicitPath] from `--config`
+  /// if given, else [configFileName] in [projectDir].
   ///
-  /// [explicitPath] — from `--config` — is read as-is; otherwise
-  /// [configFileName] is looked for in [projectDir]. With [ignore] set the file
-  /// is located (so `--verbose` can name what it skipped) but never read, which
-  /// is what makes `--no-config` survive an unparseable config file.
+  /// With [ignore] the file is located but never read, so `--verbose` can name
+  /// what `--no-config` skipped and an unparseable file is no error.
   ///
-  /// Throws a [FormatException] when [explicitPath] does not exist, or when the
-  /// file cannot be read or parsed.
+  /// Throws a [FormatException] if [explicitPath] is missing or the file cannot
+  /// be read or parsed.
   static ConfigFile load({
     required String projectDir,
     String? explicitPath,
@@ -98,7 +89,7 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
   }) {
     final discovered = File(p.join(projectDir, configFileName));
     if (ignore) {
-      return ConfigFile._(
+      return ._(
         settings: const {},
         path: discovered.existsSync() ? discovered.path : null,
         ignored: true,
@@ -113,13 +104,13 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
       }
     } else {
       if (!discovered.existsSync()) {
-        return const ConfigFile.empty();
+        return const .empty();
       }
       file = discovered;
     }
 
     try {
-      return ConfigFile.parse(file.readAsStringSync(), origin: file.path);
+      return .parse(file.readAsStringSync(), origin: file.path);
     } on FileSystemException catch (e) {
       throw FormatException(
         'Cannot read config file ${file.path}: ${e.message}',
@@ -127,40 +118,33 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
     }
   }
 
-  /// What the file sets, keyed by config key, in the order it set them. Only
-  /// keys the file actually carries a value for appear.
+  /// What the file sets, keyed by config key, in the order it set them.
   final Map<String, Object?> settings;
 
-  /// The file these settings came from, or — when [ignored] — the file that was
-  /// skipped. `null` when there was no config file at all.
+  /// The file the [settings] came from, or that [ignored] skipped; `null` when
+  /// there was no config file at all.
   final String? path;
 
-  /// Whether a config file was deliberately skipped (`--no-config`). Nothing
-  /// was read or parsed in that case, so even an invalid file is no error.
+  /// Whether `--no-config` skipped a file, leaving it unread.
   final bool ignored;
 
-  /// The config-file value for [key] — a JSON pointer such as `/public` —
-  /// typed to suit its option, or `null` when the file doesn't set it.
+  /// The value for [key], a JSON pointer such as `/public`.
   @override
   Object? valueOrNull(String key, CiachConfiguration cfg) =>
       _typedValue(key.startsWith('/') ? key.substring(1) : key);
 
   /// The value under [key], as the type its option takes.
   ///
-  /// The type has to come from the option rather than from the value, so that
-  /// `exclude: ['a']` arrives as a `List<String>` (a bare `List<dynamic>` would
-  /// not satisfy the option) and so that a mismatch is reported against the
-  /// file, naming the key and what was expected.
+  /// The type comes from the option, not the value, so that `exclude: ['a']`
+  /// arrives as the `List<String>` the option needs rather than a
+  /// `List<dynamic>`, and a mismatch names the file and the key.
   ///
-  /// Three settings accept less than their type allows. Their rules live with
-  /// the option — as `allowedValues`, a `customValidator`, a `min` — and are
-  /// applied to whatever the command line provides; these readers hold the file
-  /// to the same rules, from the same [formatNames] and [parseKinds], so that a
-  /// bad value is reported against the file it is written in either way.
+  /// The first three accept less than their type allows, and `package:config`
+  /// keeps its own validators internal, so they reuse what the options declare.
   Object? _typedValue(String key) => switch (_optionFor(key)) {
-    CiachOption.format => _oneOf(key, formatNames),
-    CiachOption.kinds => _kinds(key),
-    CiachOption.concurrency => _positiveInt(key),
+    .format => _oneOf(key, formatNames),
+    .kinds => _kinds(key),
+    .concurrency => _positiveInt(key),
     final option => switch (option.option) {
       FlagOption() => _boolean(key),
       IntOption() => _positiveInt(key),
@@ -184,8 +168,7 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
     final other => _wrong(key, 'a string', other),
   };
 
-  /// A list of strings, also accepting a bare string as a one-element list
-  /// (`exclude: test/**`).
+  /// A list of strings, or a bare string as a one-element list.
   List<String>? _strings(String key) => switch (settings[key]) {
     null => null,
     final String value => [value],
@@ -207,8 +190,7 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
     return value;
   }
 
-  /// Declaration kind names, left for `parseKinds` to turn into symbol kinds
-  /// but validated here, so an unknown kind names the file it came from.
+  /// Kind names, validated but left unconverted.
   List<String>? _kinds(String key) {
     final values = _strings(key);
     if (values != null) {
@@ -227,7 +209,7 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
     final other => _wrong(key, 'a positive integer', other),
   };
 
-  /// Reports a value of the wrong type, naming the file and the key.
+  /// Reports the wrong type, naming the file and the key.
   Never _wrong(String key, String expected, Object? value) =>
       throw FormatException(
         "$path: '$key' must be $expected, got ${_describe(value)}.",

--- a/lib/src/cli/config.dart
+++ b/lib/src/cli/config.dart
@@ -34,41 +34,33 @@ const configKeys = <String>{
   'dart',
 };
 
-/// A config file's contents, with one nullable field per setting.
+/// A config file: the settings it holds, where it came from, and typed readers
+/// for pulling values out of it.
 ///
-/// `null` means "not set here", which is what lets the command line and the
-/// built-in defaults show through — see `resolveOptions`.
-class CiachConfig {
-  /// Creates a config with only the given settings present.
-  const CiachConfig({
-    this.path,
-    this.public,
-    this.generated,
-    this.overrides,
-    this.operators,
-    this.unusedUnionMembers,
-    this.reportToJson,
-    this.setExitIfChanged,
-    this.remove,
-    this.force,
-    this.exclude,
-    this.include,
-    this.generatedSuffix,
-    this.kinds,
-    this.format,
-    this.color,
-    this.progress,
-    this.verbose,
-    this.concurrency,
-    this.dart,
+/// Deliberately *not* a field per option. The options are already declared once
+/// in `buildParser`, and `resolveOptions` is the one place that reads them all;
+/// a second hand-written list of the same twenty names would only be something
+/// to forget to update. What the file sets lives in [settings] — validated on
+/// the way in for shape and unknown keys, and on the way out for type — while
+/// `ResolvedOptions` is where a run's settings become properly typed and
+/// non-nullable.
+class ConfigFile {
+  const ConfigFile._({
+    required this.settings,
+    required this.path,
+    required this.ignored,
   });
 
-  /// Parses [source] as a ciach config file.
+  /// A config that sets nothing, from nowhere.
+  const ConfigFile.empty() : settings = const {}, path = null, ignored = false;
+
+  /// Parses [source] as a config file whose settings came from [origin]
+  /// (a file path, which becomes [path] and names the file in errors).
   ///
-  /// [origin] names the source in error messages (typically the file path).
-  /// Throws a [FormatException] describing the offending key on a malformed
-  /// document, an unknown key, or a value of the wrong type.
-  factory CiachConfig.parse(String source, {required String origin}) {
+  /// Throws a [FormatException] on a document that isn't a map of options, or
+  /// one carrying a key that is not in [configKeys]. Individual values are
+  /// checked as they are read, by the readers below.
+  factory ConfigFile.parse(String source, {required String origin}) {
     final Object? document;
     try {
       document = loadYaml(source, sourceUrl: Uri.file(origin));
@@ -78,219 +70,157 @@ class CiachConfig {
 
     // An empty file parses to null; treat it as "no settings", not an error.
     if (document == null) {
-      return const CiachConfig();
+      return ConfigFile._(settings: const {}, path: origin, ignored: false);
     }
     if (document is! Map) {
       throw FormatException('$origin: the top level must be a map of options.');
     }
 
     final unknown = document.keys
-        .map((k) => '$k')
-        .where((k) => !configKeys.contains(k))
+        .map((key) => '$key')
+        .where((key) => !configKeys.contains(key))
         .toList();
     if (unknown.isNotEmpty) {
       final valid = (configKeys.toList()..sort()).join(', ');
       throw FormatException(
         '$origin: unknown option${unknown.length == 1 ? '' : 's'} '
-        "${unknown.map((k) => "'$k'").join(', ')}. Valid options: $valid.",
+        "${unknown.map((key) => "'$key'").join(', ')}. Valid options: $valid.",
       );
     }
 
-    final reader = _ConfigReader(document, origin);
-    return CiachConfig(
-      path: reader.string('path'),
-      public: reader.boolean('public'),
-      generated: reader.boolean('generated'),
-      overrides: reader.boolean('overrides'),
-      operators: reader.boolean('operators'),
-      unusedUnionMembers: reader.boolean('unused-union-members'),
-      reportToJson: reader.boolean('report-tojson'),
-      setExitIfChanged: reader.boolean('set-exit-if-changed'),
-      remove: reader.boolean('remove'),
-      force: reader.boolean('force'),
-      exclude: reader.strings('exclude'),
-      include: reader.strings('include'),
-      generatedSuffix: reader.strings('generated-suffix'),
-      kinds: reader.kinds('kinds'),
-      format: reader.oneOf('format', formatNames),
-      color: reader.boolean('color'),
-      progress: reader.boolean('progress'),
-      verbose: reader.boolean('verbose'),
-      concurrency: reader.positiveInt('concurrency'),
-      dart: reader.string('dart'),
+    return ConfigFile._(
+      settings: {
+        for (final entry in document.entries)
+          // A key with no value (`public:`) counts as unset, so commenting a
+          // value out behaves like deleting the line. YAML collections are
+          // unwrapped so settings holds plain Dart values.
+          if (entry.value case final value?)
+            '${entry.key}': value is Iterable ? value.toList() : value,
+      },
+      path: origin,
+      ignored: false,
     );
   }
 
-  /// Package root to analyze, mirroring the positional `path` argument.
-  final String? path;
+  /// Finds and reads the config file for a run.
+  ///
+  /// [explicitPath] — from `--config` — is read as-is; otherwise
+  /// [configFileName] is looked for in [projectDir]. With [ignore] set the file
+  /// is located (so `--verbose` can name what it skipped) but never read, which
+  /// is what makes `--no-config` survive an unparseable config file.
+  ///
+  /// Throws a [FormatException] when [explicitPath] does not exist, or when the
+  /// file cannot be read or parsed.
+  static ConfigFile load({
+    required String projectDir,
+    String? explicitPath,
+    bool ignore = false,
+  }) {
+    final discovered = File(p.join(projectDir, configFileName));
+    if (ignore) {
+      return ConfigFile._(
+        settings: const {},
+        path: discovered.existsSync() ? discovered.path : null,
+        ignored: true,
+      );
+    }
 
-  /// Mirrors `--[no-]public`.
-  final bool? public;
+    final File file;
+    if (explicitPath != null) {
+      file = File(explicitPath);
+      if (!file.existsSync()) {
+        throw FormatException('Config file does not exist: $explicitPath');
+      }
+    } else {
+      if (!discovered.existsSync()) {
+        return const ConfigFile.empty();
+      }
+      file = discovered;
+    }
 
-  /// Mirrors `--[no-]generated`.
-  final bool? generated;
+    try {
+      return ConfigFile.parse(file.readAsStringSync(), origin: file.path);
+    } on FileSystemException catch (e) {
+      throw FormatException(
+        'Cannot read config file ${file.path}: ${e.message}',
+      );
+    }
+  }
 
-  /// Mirrors `--[no-]overrides`.
-  final bool? overrides;
+  /// What the file sets, keyed by config key, in the order it set them. Only
+  /// keys the file actually carries a value for appear.
+  final Map<String, Object?> settings;
 
-  /// Mirrors `--[no-]operators`.
-  final bool? operators;
-
-  /// Mirrors `--[no-]unused-union-members`.
-  final bool? unusedUnionMembers;
-
-  /// Mirrors `--[no-]report-tojson`.
-  final bool? reportToJson;
-
-  /// Mirrors `--set-exit-if-changed`.
-  final bool? setExitIfChanged;
-
-  /// Mirrors `--remove`.
-  final bool? remove;
-
-  /// Mirrors `--force`.
-  final bool? force;
-
-  /// Mirrors `--exclude`; a single string is accepted as a one-element list.
-  final List<String>? exclude;
-
-  /// Mirrors `--include`; a single string is accepted as a one-element list.
-  final List<String>? include;
-
-  /// Mirrors `--generated-suffix`.
-  final List<String>? generatedSuffix;
-
-  /// Mirrors `--kinds`, unparsed. Either a list of kind names or a single
-  /// comma-separated string; `parseKinds` accepts both shapes.
-  final List<String>? kinds;
-
-  /// Mirrors `--format`.
-  final String? format;
-
-  /// Mirrors `--[no-]color`.
-  final bool? color;
-
-  /// Mirrors `--[no-]progress`.
-  final bool? progress;
-
-  /// Mirrors `--[no-]verbose`.
-  final bool? verbose;
-
-  /// Mirrors `--concurrency`.
-  final int? concurrency;
-
-  /// Mirrors `--dart`.
-  final String? dart;
-
-  /// The settings this config actually specifies, keyed by config key and
-  /// ordered like [configKeys] — the basis of the `--verbose` rundown of what a
-  /// file contributed.
-  Map<String, Object?> get settings => {
-    'path': ?path,
-    'public': ?public,
-    'generated': ?generated,
-    'overrides': ?overrides,
-    'operators': ?operators,
-    'unused-union-members': ?unusedUnionMembers,
-    'report-tojson': ?reportToJson,
-    'set-exit-if-changed': ?setExitIfChanged,
-    'remove': ?remove,
-    'force': ?force,
-    'exclude': ?exclude,
-    'include': ?include,
-    'generated-suffix': ?generatedSuffix,
-    'kinds': ?kinds,
-    'format': ?format,
-    'color': ?color,
-    'progress': ?progress,
-    'verbose': ?verbose,
-    'concurrency': ?concurrency,
-    'dart': ?dart,
-  };
-}
-
-/// The outcome of looking for a config file.
-class LoadedConfig {
-  /// Records a config-file lookup and what it produced.
-  const LoadedConfig({
-    required this.config,
-    required this.path,
-    this.ignored = false,
-  });
-
-  /// The settings read from [path], or an empty config when there was nothing
-  /// to read (or when it was [ignored]).
-  final CiachConfig config;
-
-  /// The config file this came from, or — when [ignored] — the file that was
-  /// skipped. `null` when no config file was found at all.
+  /// The file these settings came from, or — when [ignored] — the file that was
+  /// skipped. `null` when there was no config file at all.
   final String? path;
 
   /// Whether a config file was deliberately skipped (`--no-config`). Nothing
   /// was read or parsed in that case, so even an invalid file is no error.
   final bool ignored;
-}
 
-/// Resolves and loads the config file for a run.
-///
-/// [explicitPath] — from `--config` — is loaded as-is; otherwise
-/// [configFileName] is looked for in [projectDir]. With [ignore] set the file
-/// is located (so `--verbose` can name what it skipped) but never read, and the
-/// returned config is empty.
-///
-/// Throws a [FormatException] when [explicitPath] does not exist or when the
-/// file cannot be parsed.
-LoadedConfig loadConfig({
-  required String projectDir,
-  String? explicitPath,
-  bool ignore = false,
-}) {
-  final discovered = File(p.join(projectDir, configFileName));
-  if (ignore) {
-    return LoadedConfig(
-      config: const CiachConfig(),
-      path: discovered.existsSync() ? discovered.path : null,
-      ignored: true,
-    );
-  }
+  /// A boolean setting, or `null` when the file doesn't set it.
+  bool? boolean(String key) => switch (settings[key]) {
+    null => null,
+    final bool value => value,
+    final other => _wrong(key, 'true or false', other),
+  };
 
-  final File file;
-  if (explicitPath != null) {
-    file = File(explicitPath);
-    if (!file.existsSync()) {
-      throw FormatException('Config file does not exist: $explicitPath');
+  /// A string setting, or `null` when the file doesn't set it.
+  String? string(String key) => switch (settings[key]) {
+    null => null,
+    final String value => value,
+    final other => _wrong(key, 'a string', other),
+  };
+
+  /// A string setting restricted to [allowed] values.
+  String? oneOf(String key, List<String> allowed) {
+    final value = string(key);
+    if (value != null && !allowed.contains(value)) {
+      throw FormatException(
+        "$path: '$key' must be one of ${allowed.join(', ')}, got '$value'.",
+      );
     }
-  } else {
-    if (!discovered.existsSync()) {
-      return const LoadedConfig(config: CiachConfig(), path: null);
+    return value;
+  }
+
+  /// A list-of-strings setting, also accepting a bare string as a one-element
+  /// list (`exclude: test/**`).
+  List<String>? strings(String key) => switch (settings[key]) {
+    null => null,
+    final String value => [value],
+    final Iterable<Object?> values => [
+      for (final value in values)
+        if (value is String) value else _wrong(key, 'a list of strings', value),
+    ],
+    final other => _wrong(key, 'a list of strings', other),
+  };
+
+  /// Declaration kind names, left for `parseKinds` to turn into symbol kinds
+  /// but validated here, so an unknown kind names the file it came from.
+  List<String>? kinds(String key) {
+    final values = strings(key);
+    if (values != null) {
+      try {
+        parseKinds(values);
+      } on FormatException catch (e) {
+        throw FormatException("$path: '$key': ${e.message}");
+      }
     }
-    file = discovered;
+    return values;
   }
 
-  final String source;
-  try {
-    source = file.readAsStringSync();
-  } on FileSystemException catch (e) {
-    throw FormatException('Cannot read config file ${file.path}: ${e.message}');
-  }
+  /// A positive-integer setting, or `null` when the file doesn't set it.
+  int? positiveInt(String key) => switch (settings[key]) {
+    null => null,
+    final int value when value > 0 => value,
+    final other => _wrong(key, 'a positive integer', other),
+  };
 
-  return LoadedConfig(
-    config: CiachConfig.parse(source, origin: file.path),
-    path: file.path,
-  );
-}
-
-/// Reads typed values out of a parsed YAML map, naming the config file and the
-/// offending key on every type mismatch.
-class _ConfigReader {
-  _ConfigReader(this._map, this._origin);
-
-  final Map<Object?, Object?> _map;
-  final String _origin;
-
+  /// Reports a value of the wrong type, naming the file and the key.
   Never _wrong(String key, String expected, Object? value) =>
       throw FormatException(
-        "$_origin: '$key' must be $expected, got ${_describe(value)}.",
+        "$path: '$key' must be $expected, got ${_describe(value)}.",
       );
 
   static String _describe(Object? value) => switch (value) {
@@ -301,65 +231,5 @@ class _ConfigReader {
     Iterable() => 'a list',
     Map() => 'a map',
     _ => '$value',
-  };
-
-  /// The raw value for [key], or `null` when the key is absent. A key present
-  /// with an empty value (`public:`) counts as absent, so commenting a value
-  /// out behaves like deleting the line.
-  Object? _raw(String key) => _map[key];
-
-  bool? boolean(String key) => switch (_raw(key)) {
-    null => null,
-    final bool value => value,
-    final other => _wrong(key, 'true or false', other),
-  };
-
-  String? string(String key) => switch (_raw(key)) {
-    null => null,
-    final String value => value,
-    final other => _wrong(key, 'a string', other),
-  };
-
-  String? oneOf(String key, List<String> allowed) {
-    final value = string(key);
-    if (value != null && !allowed.contains(value)) {
-      throw FormatException(
-        "$_origin: '$key' must be one of ${allowed.join(', ')}, got '$value'.",
-      );
-    }
-    return value;
-  }
-
-  /// A list of strings, also accepting a single string as a one-element list
-  /// (`exclude: test/**`).
-  List<String>? strings(String key) => switch (_raw(key)) {
-    null => null,
-    final String value => [value],
-    final Iterable<Object?> values => [
-      for (final value in values)
-        if (value is String) value else _wrong(key, 'a list of strings', value),
-    ],
-    final other => _wrong(key, 'a list of strings', other),
-  };
-
-  /// Declaration kind names, left unparsed for `parseKinds` to turn into
-  /// symbol kinds, but validated here so an unknown kind names the file it
-  /// came from.
-  List<String>? kinds(String key) {
-    final values = strings(key);
-    if (values != null) {
-      try {
-        parseKinds(values);
-      } on FormatException catch (e) {
-        throw FormatException("$_origin: '$key': ${e.message}");
-      }
-    }
-    return values;
-  }
-
-  int? positiveInt(String key) => switch (_raw(key)) {
-    null => null,
-    final int value when value > 0 => value,
-    final other => _wrong(key, 'a positive integer', other),
   };
 }

--- a/lib/src/cli/config.dart
+++ b/lib/src/cli/config.dart
@@ -22,7 +22,7 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
     required this.ignored,
   });
 
-  /// A config that sets nothing, from nowhere.
+  /// Creates a config that sets nothing, from nowhere.
   const ConfigFile.empty() : settings = const {}, path = null, ignored = false;
 
   /// Parses [source], read from the file [origin], which names it in errors.
@@ -154,7 +154,7 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
   };
 
   CiachOption<dynamic> _optionFor(String key) =>
-      CiachOption.values.firstWhere((option) => option.configKey == key);
+      .values.firstWhere((option) => option.configKey == key);
 
   bool? _boolean(String key) => switch (settings[key]) {
     null => null,
@@ -168,7 +168,7 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
     final other => _wrong(key, 'a string', other),
   };
 
-  /// A list of strings, or a bare string as a one-element list.
+  /// The strings under [key], accepting a bare string as a one-element list.
   List<String>? _strings(String key) => switch (settings[key]) {
     null => null,
     final String value => [value],
@@ -179,7 +179,7 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
     final other => _wrong(key, 'a list of strings', other),
   };
 
-  /// A string setting restricted to [allowed] values.
+  /// The string under [key], which has to be one of [allowed].
   String? _oneOf(String key, List<String> allowed) {
     final value = _string(key);
     if (value != null && !allowed.contains(value)) {
@@ -190,7 +190,7 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
     return value;
   }
 
-  /// Kind names, validated but left unconverted.
+  /// The kind names under [key], validated but not yet converted.
   List<String>? _kinds(String key) {
     final values = _strings(key);
     if (values != null) {

--- a/lib/src/cli/config.dart
+++ b/lib/src/cli/config.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:ciach/src/cli/args.dart';
+import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
@@ -78,7 +79,7 @@ class ConfigFile {
 
     final unknown = document.keys
         .map((key) => '$key')
-        .where((key) => !configKeys.contains(key))
+        .whereNot(configKeys.contains)
         .toList();
     if (unknown.isNotEmpty) {
       final valid = (configKeys.toList()..sort()).join(', ');

--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -26,6 +26,7 @@ class ResolvedOptions {
     required this.format,
     required this.useColor,
     required this.showProgress,
+    required this.verbose,
     required this.concurrency,
     required this.dartExecutable,
   });
@@ -80,8 +81,13 @@ class ResolvedOptions {
   /// Whether to colorize text output.
   final bool useColor;
 
-  /// Whether to show scan progress on stderr.
+  /// Whether to show scan progress on stderr. Always `false` when [verbose] is
+  /// set: the durable verbose log covers the same phases, and a single
+  /// overwriting progress line would fight with it.
   final bool showProgress;
+
+  /// Whether to explain what is happening on stderr.
+  final bool verbose;
 
   /// See [FinderOptions.concurrency].
   final int concurrency;
@@ -116,6 +122,7 @@ ResolvedOptions resolveOptions(
   }
 
   final rest = args.rest;
+  final verbose = flag('verbose', config.verbose, defaultsTo: false);
 
   final int concurrency;
   final rawConcurrency = args.wasParsed('concurrency')
@@ -161,11 +168,10 @@ ResolvedOptions resolveOptions(
         ? args.option('format')!
         : config.format ?? formatNames.first,
     useColor: flag('color', config.color, defaultsTo: colorDefault),
-    showProgress: flag(
-      'progress',
-      config.progress,
-      defaultsTo: progressDefault,
-    ),
+    showProgress:
+        !verbose &&
+        flag('progress', config.progress, defaultsTo: progressDefault),
+    verbose: verbose,
     concurrency: concurrency,
     dartExecutable: args.option('dart') ?? config.dart,
   );

--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -2,16 +2,16 @@ import 'package:args/args.dart';
 import 'package:ciach/ciach.dart';
 import 'package:ciach/src/cli/args.dart';
 import 'package:ciach/src/cli/config.dart';
+import 'package:config/config.dart';
 import 'package:path/path.dart' as p;
 
-/// Everything a run needs, after merging the three layers that can supply a
-/// setting: the command line wins over the config file, which wins over the
-/// built-in defaults.
+/// Everything a run needs, in the types the rest of the tool works in.
 ///
-/// Nothing downstream asks where a setting came from, so this is the last type
-/// in the CLI that knows: past here the settings are plain, non-nullable
-/// values. [finderOptions] hands the finder's share of them over to the
-/// library's own [FinderOptions].
+/// Which layer each value came from is `package:config`'s business — by the
+/// time a [ResolvedOptions] exists, a setting is just a value. What this adds
+/// on top of the resolved [Configuration] is the conversions the finder wants
+/// (`--kinds` names to [SymbolKind]s, the two inverted flags), the terminal
+/// fallbacks for the settings that auto-detect, and [finderOptions].
 class ResolvedOptions {
   /// Creates a fully resolved set of options.
   const ResolvedOptions({
@@ -126,89 +126,55 @@ class ResolvedOptions {
       );
 }
 
-/// Merges [args] over [config] over the built-in defaults.
+/// Resolves every [CiachOption] from [args] and [config], the command line
+/// winning over the file and the file over the option's default.
 ///
-/// A command-line flag counts as given only when it was actually parsed, so an
-/// option left off the command line falls through to the config file. The two
-/// auto-detected settings take their last resort from [colorDefault] and
-/// [progressDefault], which the caller probes off the terminal.
+/// Throws a [UsageException] listing every problem when a value is missing or
+/// malformed, whichever layer it came from.
+CiachConfiguration resolveConfiguration(ArgResults args, ConfigFile config) =>
+    Configuration.resolve(
+      options: CiachOption.values,
+      argResults: args,
+      configBroker: config,
+    );
+
+/// The settings of [configuration] in the types the rest of the tool wants.
 ///
-/// This is the only place that reads every config key, which is what keeps the
-/// config file honest: a value of the wrong type — or an unknown `--kinds` or
-/// non-positive `--concurrency` from either layer — throws a [FormatException]
-/// with a user-facing message naming what was wrong.
+/// [colorDefault] and [progressDefault] stand in for the two settings that
+/// auto-detect when nothing asked for them either way; the caller probes those
+/// off the terminal.
 ResolvedOptions resolveOptions(
-  ArgResults args,
-  ConfigFile config, {
+  CiachConfiguration configuration, {
   required bool colorDefault,
   required bool progressDefault,
 }) {
-  // Each helper reads the config value *before* deciding whether to use it, so
-  // a malformed setting is still reported when the command line happens to
-  // override that same option — the file is wrong either way.
-
-  /// A flag: the config value only shows through when the argv omits it.
-  bool flag(String name, {required bool defaultsTo}) {
-    final fromConfig = config.boolean(name);
-    return args.wasParsed(name) ? args.flag(name) : fromConfig ?? defaultsTo;
-  }
-
-  /// A repeatable option; an empty argv list means "not given". The command
-  /// line replaces the config's list rather than adding to it.
-  List<String> multi(String name, [List<String>? fromConfig]) {
-    final values = args.multiOption(name);
-    return values.isNotEmpty ? values : fromConfig ?? const [];
-  }
-
-  final rest = args.rest;
-  final verbose = flag('verbose', defaultsTo: false);
-  // Read on its own rather than behind `!verbose &&`, which would short-circuit
-  // past the config read — and so past its type check — on a verbose run.
-  final progress = flag('progress', defaultsTo: progressDefault);
-  final configPath = config.string('path');
-  final configDart = config.string('dart');
-  final configFormat = config.oneOf('format', formatNames);
-
-  final int concurrency;
-  final configConcurrency = config.positiveInt('concurrency');
-  final rawConcurrency = args.wasParsed('concurrency')
-      ? args.option('concurrency')!
-      : configConcurrency?.toString() ?? defaultConcurrency;
-  try {
-    concurrency = int.parse(rawConcurrency);
-    if (concurrency < 1) {
-      throw const FormatException();
-    }
-  } on FormatException {
-    throw const FormatException('--concurrency must be a positive integer.');
-  }
+  final verbose = configuration.value(CiachOption.verbose);
+  final progress =
+      configuration.optionalValue(CiachOption.progress) ?? progressDefault;
 
   return ResolvedOptions(
-    rootPath: rest.isNotEmpty ? rest.first : configPath ?? '.',
-    includeGlobs: multi('include', config.strings('include')),
-    excludeGlobs: multi('exclude', config.strings('exclude')),
-    additionalGeneratedSuffixes: multi(
-      'generated-suffix',
-      config.strings('generated-suffix'),
+    rootPath: configuration.value(CiachOption.path),
+    includeGlobs: configuration.value(CiachOption.include),
+    excludeGlobs: configuration.value(CiachOption.exclude),
+    additionalGeneratedSuffixes: configuration.value(
+      CiachOption.generatedSuffix,
     ),
-    // Throws a FormatException naming the offending kind, as documented.
-    kinds: parseKinds(multi('kinds', config.kinds('kinds'))),
-    includePublic: flag('public', defaultsTo: true),
-    includeGenerated: flag('generated', defaultsTo: false),
-    overrides: flag('overrides', defaultsTo: false),
-    operators: flag('operators', defaultsTo: false),
-    unusedUnionMembers: flag('unused-union-members', defaultsTo: false),
-    reportToJson: flag('report-tojson', defaultsTo: false),
-    setExitIfChanged: flag('set-exit-if-changed', defaultsTo: false),
-    remove: flag('remove', defaultsTo: false),
-    force: flag('force', defaultsTo: false),
-    format: args.wasParsed('format')
-        ? args.option('format')!
-        : configFormat ?? formatNames.first,
-    useColor: flag('color', defaultsTo: colorDefault),
+    // Already validated by the option; this only converts the names.
+    kinds: parseKinds(configuration.value(CiachOption.kinds)),
+    includePublic: configuration.value(CiachOption.public),
+    includeGenerated: configuration.value(CiachOption.generated),
+    overrides: configuration.value(CiachOption.overrides),
+    operators: configuration.value(CiachOption.operators),
+    unusedUnionMembers: configuration.value(CiachOption.unusedUnionMembers),
+    reportToJson: configuration.value(CiachOption.reportToJson),
+    setExitIfChanged: configuration.value(CiachOption.setExitIfChanged),
+    remove: configuration.value(CiachOption.remove),
+    force: configuration.value(CiachOption.force),
+    format: configuration.value(CiachOption.format),
+    useColor: configuration.optionalValue(CiachOption.color) ?? colorDefault,
     showProgress: progress && !verbose,
     verbose: verbose,
-    concurrency: concurrency,
-    dartExecutable: args.option('dart') ?? configDart,
+    concurrency: configuration.value(CiachOption.concurrency),
+    dartExecutable: configuration.optionalValue(CiachOption.dart),
   );
 }

--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -2,10 +2,16 @@ import 'package:args/args.dart';
 import 'package:ciach/ciach.dart';
 import 'package:ciach/src/cli/args.dart';
 import 'package:ciach/src/cli/config.dart';
+import 'package:path/path.dart' as p;
 
 /// Everything a run needs, after merging the three layers that can supply a
 /// setting: the command line wins over the config file, which wins over the
 /// built-in defaults.
+///
+/// Nothing downstream asks where a setting came from, so this is the last type
+/// in the CLI that knows: past here the settings are plain, non-nullable
+/// values. [finderOptions] hands the finder's share of them over to the
+/// library's own [FinderOptions].
 class ResolvedOptions {
   /// Creates a fully resolved set of options.
   const ResolvedOptions({
@@ -31,7 +37,8 @@ class ResolvedOptions {
     required this.dartExecutable,
   });
 
-  /// Package root to analyze, as written (still relative to the cwd).
+  /// Package root to analyze, as written — still relative to the cwd. Use
+  /// [absoluteRootPath] for the resolved location.
   final String rootPath;
 
   /// See [FinderOptions.includeGlobs].
@@ -94,6 +101,29 @@ class ResolvedOptions {
 
   /// See [FinderOptions.dartExecutable].
   final String? dartExecutable;
+
+  /// [rootPath] resolved against the current directory, which is what the
+  /// finder, the remover and the reporters all work in terms of.
+  String get absoluteRootPath => p.normalize(p.absolute(rootPath));
+
+  /// The finder's share of these settings, reporting progress to [onProgress].
+  FinderOptions finderOptions({void Function(String message)? onProgress}) =>
+      FinderOptions(
+        rootPath: absoluteRootPath,
+        includeGlobs: includeGlobs,
+        excludeGlobs: excludeGlobs,
+        additionalGeneratedSuffixes: additionalGeneratedSuffixes,
+        kinds: kinds,
+        includePublic: includePublic,
+        includeGenerated: includeGenerated,
+        skipOverrides: !overrides,
+        skipOperators: !operators,
+        unusedUnionMembers: unusedUnionMembers,
+        reportToJson: reportToJson,
+        concurrency: concurrency,
+        dartExecutable: dartExecutable,
+        onProgress: onProgress,
+      );
 }
 
 /// Merges [args] over [config] over the built-in defaults.
@@ -103,31 +133,47 @@ class ResolvedOptions {
 /// auto-detected settings take their last resort from [colorDefault] and
 /// [progressDefault], which the caller probes off the terminal.
 ///
-/// Throws a [FormatException] with a user-facing message on an invalid
-/// `--kinds` value or a non-positive `--concurrency`.
+/// This is the only place that reads every config key, which is what keeps the
+/// config file honest: a value of the wrong type — or an unknown `--kinds` or
+/// non-positive `--concurrency` from either layer — throws a [FormatException]
+/// with a user-facing message naming what was wrong.
 ResolvedOptions resolveOptions(
   ArgResults args,
-  CiachConfig config, {
+  ConfigFile config, {
   required bool colorDefault,
   required bool progressDefault,
 }) {
-  /// The config value only shows through for a flag absent from the argv.
-  bool flag(String name, bool? fromConfig, {required bool defaultsTo}) =>
-      args.wasParsed(name) ? args.flag(name) : fromConfig ?? defaultsTo;
+  // Each helper reads the config value *before* deciding whether to use it, so
+  // a malformed setting is still reported when the command line happens to
+  // override that same option — the file is wrong either way.
 
-  /// Ditto for a repeatable option: an empty argv list means "not given".
-  List<String> multi(String name, List<String>? fromConfig) {
+  /// A flag: the config value only shows through when the argv omits it.
+  bool flag(String name, {required bool defaultsTo}) {
+    final fromConfig = config.boolean(name);
+    return args.wasParsed(name) ? args.flag(name) : fromConfig ?? defaultsTo;
+  }
+
+  /// A repeatable option; an empty argv list means "not given". The command
+  /// line replaces the config's list rather than adding to it.
+  List<String> multi(String name, [List<String>? fromConfig]) {
     final values = args.multiOption(name);
     return values.isNotEmpty ? values : fromConfig ?? const [];
   }
 
   final rest = args.rest;
-  final verbose = flag('verbose', config.verbose, defaultsTo: false);
+  final verbose = flag('verbose', defaultsTo: false);
+  // Read on its own rather than behind `!verbose &&`, which would short-circuit
+  // past the config read — and so past its type check — on a verbose run.
+  final progress = flag('progress', defaultsTo: progressDefault);
+  final configPath = config.string('path');
+  final configDart = config.string('dart');
+  final configFormat = config.oneOf('format', formatNames);
 
   final int concurrency;
+  final configConcurrency = config.positiveInt('concurrency');
   final rawConcurrency = args.wasParsed('concurrency')
       ? args.option('concurrency')!
-      : config.concurrency?.toString() ?? defaultConcurrency;
+      : configConcurrency?.toString() ?? defaultConcurrency;
   try {
     concurrency = int.parse(rawConcurrency);
     if (concurrency < 1) {
@@ -138,41 +184,31 @@ ResolvedOptions resolveOptions(
   }
 
   return ResolvedOptions(
-    rootPath: rest.isNotEmpty ? rest.first : config.path ?? '.',
-    includeGlobs: multi('include', config.include),
-    excludeGlobs: multi('exclude', config.exclude),
+    rootPath: rest.isNotEmpty ? rest.first : configPath ?? '.',
+    includeGlobs: multi('include', config.strings('include')),
+    excludeGlobs: multi('exclude', config.strings('exclude')),
     additionalGeneratedSuffixes: multi(
       'generated-suffix',
-      config.generatedSuffix,
+      config.strings('generated-suffix'),
     ),
     // Throws a FormatException naming the offending kind, as documented.
-    kinds: parseKinds(multi('kinds', config.kinds)),
-    includePublic: flag('public', config.public, defaultsTo: true),
-    includeGenerated: flag('generated', config.generated, defaultsTo: false),
-    overrides: flag('overrides', config.overrides, defaultsTo: false),
-    operators: flag('operators', config.operators, defaultsTo: false),
-    unusedUnionMembers: flag(
-      'unused-union-members',
-      config.unusedUnionMembers,
-      defaultsTo: false,
-    ),
-    reportToJson: flag('report-tojson', config.reportToJson, defaultsTo: false),
-    setExitIfChanged: flag(
-      'set-exit-if-changed',
-      config.setExitIfChanged,
-      defaultsTo: false,
-    ),
-    remove: flag('remove', config.remove, defaultsTo: false),
-    force: flag('force', config.force, defaultsTo: false),
+    kinds: parseKinds(multi('kinds', config.kinds('kinds'))),
+    includePublic: flag('public', defaultsTo: true),
+    includeGenerated: flag('generated', defaultsTo: false),
+    overrides: flag('overrides', defaultsTo: false),
+    operators: flag('operators', defaultsTo: false),
+    unusedUnionMembers: flag('unused-union-members', defaultsTo: false),
+    reportToJson: flag('report-tojson', defaultsTo: false),
+    setExitIfChanged: flag('set-exit-if-changed', defaultsTo: false),
+    remove: flag('remove', defaultsTo: false),
+    force: flag('force', defaultsTo: false),
     format: args.wasParsed('format')
         ? args.option('format')!
-        : config.format ?? formatNames.first,
-    useColor: flag('color', config.color, defaultsTo: colorDefault),
-    showProgress:
-        !verbose &&
-        flag('progress', config.progress, defaultsTo: progressDefault),
+        : configFormat ?? formatNames.first,
+    useColor: flag('color', defaultsTo: colorDefault),
+    showProgress: progress && !verbose,
     verbose: verbose,
     concurrency: concurrency,
-    dartExecutable: args.option('dart') ?? config.dart,
+    dartExecutable: args.option('dart') ?? configDart,
   );
 }

--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -1,0 +1,172 @@
+import 'package:args/args.dart';
+import 'package:ciach/ciach.dart';
+import 'package:ciach/src/cli/args.dart';
+import 'package:ciach/src/cli/config.dart';
+
+/// Everything a run needs, after merging the three layers that can supply a
+/// setting: the command line wins over the config file, which wins over the
+/// built-in defaults.
+class ResolvedOptions {
+  /// Creates a fully resolved set of options.
+  const ResolvedOptions({
+    required this.rootPath,
+    required this.includeGlobs,
+    required this.excludeGlobs,
+    required this.additionalGeneratedSuffixes,
+    required this.kinds,
+    required this.includePublic,
+    required this.includeGenerated,
+    required this.overrides,
+    required this.operators,
+    required this.unusedUnionMembers,
+    required this.reportToJson,
+    required this.setExitIfChanged,
+    required this.remove,
+    required this.force,
+    required this.format,
+    required this.useColor,
+    required this.showProgress,
+    required this.concurrency,
+    required this.dartExecutable,
+  });
+
+  /// Package root to analyze, as written (still relative to the cwd).
+  final String rootPath;
+
+  /// See [FinderOptions.includeGlobs].
+  final List<String> includeGlobs;
+
+  /// See [FinderOptions.excludeGlobs].
+  final List<String> excludeGlobs;
+
+  /// See [FinderOptions.additionalGeneratedSuffixes].
+  final List<String> additionalGeneratedSuffixes;
+
+  /// See [FinderOptions.kinds].
+  final Set<SymbolKind> kinds;
+
+  /// See [FinderOptions.includePublic].
+  final bool includePublic;
+
+  /// See [FinderOptions.includeGenerated].
+  final bool includeGenerated;
+
+  /// Whether to report `@override` members; the inverse of
+  /// [FinderOptions.skipOverrides].
+  final bool overrides;
+
+  /// Whether to report operator overloads; the inverse of
+  /// [FinderOptions.skipOperators].
+  final bool operators;
+
+  /// See [FinderOptions.unusedUnionMembers].
+  final bool unusedUnionMembers;
+
+  /// See [FinderOptions.reportToJson].
+  final bool reportToJson;
+
+  /// Whether to exit non-zero when anything is found.
+  final bool setExitIfChanged;
+
+  /// Whether to remove what is reported.
+  final bool remove;
+
+  /// Whether to skip the removal confirmation prompt.
+  final bool force;
+
+  /// Output format: one of [formatNames].
+  final String format;
+
+  /// Whether to colorize text output.
+  final bool useColor;
+
+  /// Whether to show scan progress on stderr.
+  final bool showProgress;
+
+  /// See [FinderOptions.concurrency].
+  final int concurrency;
+
+  /// See [FinderOptions.dartExecutable].
+  final String? dartExecutable;
+}
+
+/// Merges [args] over [config] over the built-in defaults.
+///
+/// A command-line flag counts as given only when it was actually parsed, so an
+/// option left off the command line falls through to the config file. The two
+/// auto-detected settings take their last resort from [colorDefault] and
+/// [progressDefault], which the caller probes off the terminal.
+///
+/// Throws a [FormatException] with a user-facing message on an invalid
+/// `--kinds` value or a non-positive `--concurrency`.
+ResolvedOptions resolveOptions(
+  ArgResults args,
+  CiachConfig config, {
+  required bool colorDefault,
+  required bool progressDefault,
+}) {
+  /// The config value only shows through for a flag absent from the argv.
+  bool flag(String name, bool? fromConfig, {required bool defaultsTo}) =>
+      args.wasParsed(name) ? args.flag(name) : fromConfig ?? defaultsTo;
+
+  /// Ditto for a repeatable option: an empty argv list means "not given".
+  List<String> multi(String name, List<String>? fromConfig) {
+    final values = args.multiOption(name);
+    return values.isNotEmpty ? values : fromConfig ?? const [];
+  }
+
+  final rest = args.rest;
+
+  final int concurrency;
+  final rawConcurrency = args.wasParsed('concurrency')
+      ? args.option('concurrency')!
+      : config.concurrency?.toString() ?? defaultConcurrency;
+  try {
+    concurrency = int.parse(rawConcurrency);
+    if (concurrency < 1) {
+      throw const FormatException();
+    }
+  } on FormatException {
+    throw const FormatException('--concurrency must be a positive integer.');
+  }
+
+  return ResolvedOptions(
+    rootPath: rest.isNotEmpty ? rest.first : config.path ?? '.',
+    includeGlobs: multi('include', config.include),
+    excludeGlobs: multi('exclude', config.exclude),
+    additionalGeneratedSuffixes: multi(
+      'generated-suffix',
+      config.generatedSuffix,
+    ),
+    // Throws a FormatException naming the offending kind, as documented.
+    kinds: parseKinds(multi('kinds', config.kinds)),
+    includePublic: flag('public', config.public, defaultsTo: true),
+    includeGenerated: flag('generated', config.generated, defaultsTo: false),
+    overrides: flag('overrides', config.overrides, defaultsTo: false),
+    operators: flag('operators', config.operators, defaultsTo: false),
+    unusedUnionMembers: flag(
+      'unused-union-members',
+      config.unusedUnionMembers,
+      defaultsTo: false,
+    ),
+    reportToJson: flag('report-tojson', config.reportToJson, defaultsTo: false),
+    setExitIfChanged: flag(
+      'set-exit-if-changed',
+      config.setExitIfChanged,
+      defaultsTo: false,
+    ),
+    remove: flag('remove', config.remove, defaultsTo: false),
+    force: flag('force', config.force, defaultsTo: false),
+    format: args.wasParsed('format')
+        ? args.option('format')!
+        : config.format ?? formatNames.first,
+    useColor: flag('color', config.color, defaultsTo: colorDefault),
+    showProgress: flag(
+      'progress',
+      config.progress,
+      defaultsTo: progressDefault,
+    ),
+    concurrency: concurrency,
+    dartExecutable: args.option('dart') ?? config.dart,
+  );
+}

--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -53,15 +53,14 @@ class ResolvedOptions {
   final String format;
   final bool useColor;
 
-  /// Always `false` when [verbose] is set, whose durable lines the overwriting
-  /// progress line would fight with.
+  /// Whether to show scan progress. Always `false` when [verbose] is set, whose
+  /// durable lines the overwriting progress line would fight with.
   final bool showProgress;
   final bool verbose;
   final int concurrency;
   final String? dartExecutable;
 
-  /// [rootPath] against the current directory, as everything downstream wants
-  /// it.
+  /// [rootPath] resolved against the current directory.
   String get absoluteRootPath => p.normalize(p.absolute(rootPath));
 
   /// The finder's share of these settings, reporting progress to [onProgress].

--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -5,15 +5,9 @@ import 'package:ciach/src/cli/config.dart';
 import 'package:config/config.dart';
 import 'package:path/path.dart' as p;
 
-/// Everything a run needs, in the types the rest of the tool works in.
-///
-/// Which layer each value came from is `package:config`'s business — by the
-/// time a [ResolvedOptions] exists, a setting is just a value. What this adds
-/// on top of the resolved [Configuration] is the conversions the finder wants
-/// (`--kinds` names to [SymbolKind]s, the two inverted flags), the terminal
-/// fallbacks for the settings that auto-detect, and [finderOptions].
+/// A resolved [Configuration] in the types the rest of the tool works in: kind
+/// names converted, the inverted flags flipped, the auto-detected ones settled.
 class ResolvedOptions {
-  /// Creates a fully resolved set of options.
   const ResolvedOptions({
     required this.rootPath,
     required this.includeGlobs,
@@ -37,78 +31,42 @@ class ResolvedOptions {
     required this.dartExecutable,
   });
 
-  /// Package root to analyze, as written — still relative to the cwd. Use
-  /// [absoluteRootPath] for the resolved location.
+  /// Package root to analyze, as written; see [absoluteRootPath].
   final String rootPath;
-
-  /// See [FinderOptions.includeGlobs].
   final List<String> includeGlobs;
-
-  /// See [FinderOptions.excludeGlobs].
   final List<String> excludeGlobs;
-
-  /// See [FinderOptions.additionalGeneratedSuffixes].
   final List<String> additionalGeneratedSuffixes;
-
-  /// See [FinderOptions.kinds].
   final Set<SymbolKind> kinds;
-
-  /// See [FinderOptions.includePublic].
   final bool includePublic;
-
-  /// See [FinderOptions.includeGenerated].
   final bool includeGenerated;
 
-  /// Whether to report `@override` members; the inverse of
-  /// [FinderOptions.skipOverrides].
+  /// Whether to report `@override` members — inverted for the finder.
   final bool overrides;
 
-  /// Whether to report operator overloads; the inverse of
-  /// [FinderOptions.skipOperators].
+  /// Whether to report operator overloads — inverted for the finder.
   final bool operators;
-
-  /// See [FinderOptions.unusedUnionMembers].
   final bool unusedUnionMembers;
-
-  /// See [FinderOptions.reportToJson].
   final bool reportToJson;
-
-  /// Whether to exit non-zero when anything is found.
   final bool setExitIfChanged;
-
-  /// Whether to remove what is reported.
   final bool remove;
-
-  /// Whether to skip the removal confirmation prompt.
   final bool force;
-
-  /// Output format: one of [formatNames].
   final String format;
-
-  /// Whether to colorize text output.
   final bool useColor;
 
-  /// Whether to show scan progress on stderr. Always `false` when [verbose] is
-  /// set: the durable verbose log covers the same phases, and a single
-  /// overwriting progress line would fight with it.
+  /// Always `false` when [verbose] is set, whose durable lines the overwriting
+  /// progress line would fight with.
   final bool showProgress;
-
-  /// Whether to explain what is happening on stderr.
   final bool verbose;
-
-  /// See [FinderOptions.concurrency].
   final int concurrency;
-
-  /// See [FinderOptions.dartExecutable].
   final String? dartExecutable;
 
-  /// [rootPath] resolved against the current directory, which is what the
-  /// finder, the remover and the reporters all work in terms of.
+  /// [rootPath] against the current directory, as everything downstream wants
+  /// it.
   String get absoluteRootPath => p.normalize(p.absolute(rootPath));
 
   /// The finder's share of these settings, reporting progress to [onProgress].
   FinderOptions finderOptions({void Function(String message)? onProgress}) =>
-      FinderOptions(
+      .new(
         rootPath: absoluteRootPath,
         includeGlobs: includeGlobs,
         excludeGlobs: excludeGlobs,
@@ -127,22 +85,18 @@ class ResolvedOptions {
 }
 
 /// Resolves every [CiachOption] from [args] and [config], the command line
-/// winning over the file and the file over the option's default.
+/// winning over the file and the file over the default.
 ///
-/// Throws a [UsageException] listing every problem when a value is missing or
-/// malformed, whichever layer it came from.
+/// Throws a [UsageException] listing every malformed value, from either layer.
 CiachConfiguration resolveConfiguration(ArgResults args, ConfigFile config) =>
-    Configuration.resolve(
+    .resolve(
       options: CiachOption.values,
       argResults: args,
       configBroker: config,
     );
 
-/// The settings of [configuration] in the types the rest of the tool wants.
-///
-/// [colorDefault] and [progressDefault] stand in for the two settings that
-/// auto-detect when nothing asked for them either way; the caller probes those
-/// off the terminal.
+/// The settings of [configuration], with [colorDefault] and [progressDefault]
+/// standing in for the two nobody asked for either way.
 ResolvedOptions resolveOptions(
   CiachConfiguration configuration, {
   required bool colorDefault,
@@ -152,7 +106,7 @@ ResolvedOptions resolveOptions(
   final progress =
       configuration.optionalValue(CiachOption.progress) ?? progressDefault;
 
-  return ResolvedOptions(
+  return .new(
     rootPath: configuration.value(CiachOption.path),
     includeGlobs: configuration.value(CiachOption.include),
     excludeGlobs: configuration.value(CiachOption.exclude),

--- a/lib/src/cli/verbose.dart
+++ b/lib/src/cli/verbose.dart
@@ -79,7 +79,8 @@ List<String> describeSettings(
 /// A value as it reads in the verbose log: an empty list is `(none)`, a
 /// non-empty one is comma-separated, everything else is itself.
 String _value(Object? value) => switch (value) {
-  final List<Object?> list => list.isEmpty ? '(none)' : list.join(', '),
+  [] => '(none)',
+  final List<Object?> list => list.join(', '),
   _ => '$value',
 };
 

--- a/lib/src/cli/verbose.dart
+++ b/lib/src/cli/verbose.dart
@@ -16,18 +16,18 @@ List<String> describeConfigSource(
   final path = config.path;
 
   if (config.ignored) {
-    final message = path != null
-        ? 'Ignoring the config file $path (--no-config).'
-        : 'Ignoring any config file (--no-config); there is no '
-              '$configFileName in $projectDir anyway.';
-    return [message];
+    return [
+      if (path != null)
+        'Ignoring the config file $path (--no-config).'
+      else
+        'Ignoring any config file (--no-config); there is no $configFileName in $projectDir anyway.',
+    ];
   }
 
   if (path == null) {
-    final message =
-        'No $configFileName in $projectDir; using command-line arguments '
-        'and built-in defaults.';
-    return [message];
+    return [
+      'No $configFileName in $projectDir; using command-line arguments and built-in defaults.',
+    ];
   }
 
   final settings = config.settings;

--- a/lib/src/cli/verbose.dart
+++ b/lib/src/cli/verbose.dart
@@ -10,12 +10,12 @@ import 'package:pro_lsp/pro_lsp.dart' show SymbolKind;
 /// [projectDir] is the directory discovery looked in, named so a config that
 /// silently didn't apply — because it sits somewhere else — is obvious.
 List<String> describeConfigSource(
-  LoadedConfig loaded, {
+  ConfigFile config, {
   required String projectDir,
 }) {
-  final path = loaded.path;
+  final path = config.path;
 
-  if (loaded.ignored) {
+  if (config.ignored) {
     final message = path != null
         ? 'Ignoring the config file $path (--no-config).'
         : 'Ignoring any config file (--no-config); there is no '
@@ -30,7 +30,7 @@ List<String> describeConfigSource(
     return [message];
   }
 
-  final settings = loaded.config.settings;
+  final settings = config.settings;
   return [
     'Read config from $path.',
     if (settings.isEmpty)
@@ -47,16 +47,14 @@ List<String> describeConfigSource(
 /// command line, the config file and the defaults have been merged — the answer
 /// to "why did it behave like that?".
 ///
-/// [rootPath] is the resolved absolute package root and [dartExecutable] the
-/// `dart` the analysis server will be launched with, both of which the caller
-/// resolves.
+/// [dartExecutable] is the `dart` the analysis server will be launched with,
+/// which only the caller can resolve — it falls back to the SDK running ciach.
 List<String> describeSettings(
   ResolvedOptions resolved, {
-  required String rootPath,
   required String dartExecutable,
 }) => [
   'Settings for this run:',
-  '  path: $rootPath',
+  '  path: ${resolved.absoluteRootPath}',
   '  public: ${resolved.includePublic}',
   '  generated: ${resolved.includeGenerated}',
   '  overrides: ${resolved.overrides}',

--- a/lib/src/cli/verbose.dart
+++ b/lib/src/cli/verbose.dart
@@ -1,0 +1,95 @@
+import 'package:ciach/src/cli/config.dart';
+import 'package:ciach/src/cli/options.dart';
+import 'package:ciach/src/models.dart';
+import 'package:collection/collection.dart';
+import 'package:pro_lsp/pro_lsp.dart' show SymbolKind;
+
+/// The `--verbose` account of where the run's settings came from: the config
+/// file that was read (and what it set), skipped, or looked for in vain.
+///
+/// [projectDir] is the directory discovery looked in, named so a config that
+/// silently didn't apply — because it sits somewhere else — is obvious.
+List<String> describeConfigSource(
+  LoadedConfig loaded, {
+  required String projectDir,
+}) {
+  final path = loaded.path;
+
+  if (loaded.ignored) {
+    final message = path != null
+        ? 'Ignoring the config file $path (--no-config).'
+        : 'Ignoring any config file (--no-config); there is no '
+              '$configFileName in $projectDir anyway.';
+    return [message];
+  }
+
+  if (path == null) {
+    final message =
+        'No $configFileName in $projectDir; using command-line arguments '
+        'and built-in defaults.';
+    return [message];
+  }
+
+  final settings = loaded.config.settings;
+  return [
+    'Read config from $path.',
+    if (settings.isEmpty)
+      '  It sets nothing; using command-line arguments and built-in defaults.'
+    else ...[
+      '  It sets ${settings.length} option${settings.length == 1 ? '' : 's'}:',
+      for (final entry in settings.entries)
+        '    ${entry.key}: ${_value(entry.value)}',
+    ],
+  ];
+}
+
+/// The `--verbose` rundown of the settings the run actually uses, after the
+/// command line, the config file and the defaults have been merged — the answer
+/// to "why did it behave like that?".
+///
+/// [rootPath] is the resolved absolute package root and [dartExecutable] the
+/// `dart` the analysis server will be launched with, both of which the caller
+/// resolves.
+List<String> describeSettings(
+  ResolvedOptions resolved, {
+  required String rootPath,
+  required String dartExecutable,
+}) => [
+  'Settings for this run:',
+  '  path: $rootPath',
+  '  public: ${resolved.includePublic}',
+  '  generated: ${resolved.includeGenerated}',
+  '  overrides: ${resolved.overrides}',
+  '  operators: ${resolved.operators}',
+  '  unused-union-members: ${resolved.unusedUnionMembers}',
+  '  report-tojson: ${resolved.reportToJson}',
+  '  set-exit-if-changed: ${resolved.setExitIfChanged}',
+  '  remove: ${resolved.remove}',
+  '  force: ${resolved.force}',
+  '  exclude: ${_value(resolved.excludeGlobs)}',
+  '  include: ${_value(resolved.includeGlobs)}',
+  '  generated-suffix: ${_value(resolved.additionalGeneratedSuffixes)}',
+  '  kinds: ${_kinds(resolved.kinds)}',
+  '  format: ${resolved.format}',
+  '  color: ${resolved.useColor}',
+  '  progress: ${resolved.showProgress}',
+  '  verbose: ${resolved.verbose}',
+  '  concurrency: ${resolved.concurrency}',
+  '  dart: $dartExecutable',
+];
+
+/// A value as it reads in the verbose log: an empty list is `(none)`, a
+/// non-empty one is comma-separated, everything else is itself.
+String _value(Object? value) => switch (value) {
+  final List<Object?> list => list.isEmpty ? '(none)' : list.join(', '),
+  _ => '$value',
+};
+
+/// The kind labels, sorted, plus a note when they are simply all of them.
+String _kinds(Set<SymbolKind> kinds) {
+  final labels = kinds.map((kind) => kind.label).sorted().join(', ');
+  return kinds.length == FinderOptions.defaultKinds.length &&
+          kinds.containsAll(FinderOptions.defaultKinds)
+      ? '$labels (all)'
+      : labels;
+}

--- a/lib/src/cli/verbose.dart
+++ b/lib/src/cli/verbose.dart
@@ -59,8 +59,8 @@ List<String> describeSettings(
       '  $key: ${_setting(option, resolved, dartExecutable)} (${_source(configuration.valueSourceType(option))})',
 ];
 
-/// The value of [option] as the run uses it: root made absolute, kinds as
-/// labels, auto-detected flags as they settled.
+/// The value of [option] as the run uses it, with the root made absolute, the
+/// kinds as labels, and the auto-detected flags as they settled.
 String _setting(
   CiachOption<dynamic> option,
   ResolvedOptions resolved,
@@ -108,6 +108,6 @@ String _value(Object? value) => switch (value) {
   _ => '$value',
 };
 
-/// The kind labels, sorted. That they are all of them shows in the source.
+/// The kind labels, sorted.
 String _kinds(Set<SymbolKind> kinds) =>
     kinds.map((kind) => kind.label).sorted().join(', ');

--- a/lib/src/cli/verbose.dart
+++ b/lib/src/cli/verbose.dart
@@ -80,7 +80,7 @@ List<String> describeSettings(
 /// non-empty one is comma-separated, everything else is itself.
 String _value(Object? value) => switch (value) {
   [] => '(none)',
-  final List<Object?> list => list.join(', '),
+  List() => value.join(', '),
   _ => '$value',
 };
 

--- a/lib/src/cli/verbose.dart
+++ b/lib/src/cli/verbose.dart
@@ -1,7 +1,9 @@
+import 'package:ciach/src/cli/args.dart';
 import 'package:ciach/src/cli/config.dart';
 import 'package:ciach/src/cli/options.dart';
 import 'package:ciach/src/models.dart';
 import 'package:collection/collection.dart';
+import 'package:config/config.dart';
 import 'package:pro_lsp/pro_lsp.dart' show SymbolKind;
 
 /// The `--verbose` account of where the run's settings came from: the config
@@ -43,38 +45,67 @@ List<String> describeConfigSource(
   ];
 }
 
-/// The `--verbose` rundown of the settings the run actually uses, after the
-/// command line, the config file and the defaults have been merged — the answer
-/// to "why did it behave like that?".
+/// The `--verbose` rundown of the settings the run actually uses — one line per
+/// config key, each naming the layer its value came from, so "why did it behave
+/// like that?" is answered without guessing.
 ///
-/// [dartExecutable] is the `dart` the analysis server will be launched with,
-/// which only the caller can resolve — it falls back to the SDK running ciach.
+/// [resolved] supplies the values as the tool ended up using them, and
+/// [configuration] the layer each came from. [dartExecutable] is the `dart` the
+/// analysis server will be launched with, which only the caller can resolve.
 List<String> describeSettings(
+  CiachConfiguration configuration,
   ResolvedOptions resolved, {
   required String dartExecutable,
 }) => [
   'Settings for this run:',
-  '  path: ${resolved.absoluteRootPath}',
-  '  public: ${resolved.includePublic}',
-  '  generated: ${resolved.includeGenerated}',
-  '  overrides: ${resolved.overrides}',
-  '  operators: ${resolved.operators}',
-  '  unused-union-members: ${resolved.unusedUnionMembers}',
-  '  report-tojson: ${resolved.reportToJson}',
-  '  set-exit-if-changed: ${resolved.setExitIfChanged}',
-  '  remove: ${resolved.remove}',
-  '  force: ${resolved.force}',
-  '  exclude: ${_value(resolved.excludeGlobs)}',
-  '  include: ${_value(resolved.includeGlobs)}',
-  '  generated-suffix: ${_value(resolved.additionalGeneratedSuffixes)}',
-  '  kinds: ${_kinds(resolved.kinds)}',
-  '  format: ${resolved.format}',
-  '  color: ${resolved.useColor}',
-  '  progress: ${resolved.showProgress}',
-  '  verbose: ${resolved.verbose}',
-  '  concurrency: ${resolved.concurrency}',
-  '  dart: $dartExecutable',
+  for (final option in CiachOption.values)
+    if (option.configKey case final key?)
+      '  $key: ${_setting(option, resolved, dartExecutable)} (${_source(configuration.valueSourceType(option))})',
 ];
+
+/// The value of [option] as the run uses it, which for a few settings is not
+/// quite the raw resolved value: the root is made absolute, the kinds become
+/// labels, and the two auto-detected flags report what they settled on.
+String _setting(
+  CiachOption<dynamic> option,
+  ResolvedOptions resolved,
+  String dartExecutable,
+) => switch (option) {
+  CiachOption.path => resolved.absoluteRootPath,
+  CiachOption.public => '${resolved.includePublic}',
+  CiachOption.generated => '${resolved.includeGenerated}',
+  CiachOption.overrides => '${resolved.overrides}',
+  CiachOption.operators => '${resolved.operators}',
+  CiachOption.unusedUnionMembers => '${resolved.unusedUnionMembers}',
+  CiachOption.reportToJson => '${resolved.reportToJson}',
+  CiachOption.setExitIfChanged => '${resolved.setExitIfChanged}',
+  CiachOption.remove => '${resolved.remove}',
+  CiachOption.force => '${resolved.force}',
+  CiachOption.exclude => _value(resolved.excludeGlobs),
+  CiachOption.include => _value(resolved.includeGlobs),
+  CiachOption.generatedSuffix => _value(resolved.additionalGeneratedSuffixes),
+  CiachOption.kinds => _kinds(resolved.kinds),
+  CiachOption.format => resolved.format,
+  CiachOption.color => '${resolved.useColor}',
+  CiachOption.progress => '${resolved.showProgress}',
+  CiachOption.verbose => '${resolved.verbose}',
+  CiachOption.concurrency => '${resolved.concurrency}',
+  CiachOption.dart => dartExecutable,
+  // Listed by config key, and these three have none — they decide whether a
+  // config file is read at all. Spelled out rather than left to a wildcard so
+  // that a new option has to be given a value here.
+  CiachOption.help || CiachOption.config || CiachOption.noConfig => '',
+};
+
+/// Where a value came from, in the words the user would use for it.
+String _source(ValueSourceType source) => switch (source) {
+  .arg => 'command line',
+  .config => 'config file',
+  .envVar => 'environment',
+  .preset || .custom => 'preset',
+  .defaultValue => 'default',
+  .noValue => 'auto-detected',
+};
 
 /// A value as it reads in the verbose log: an empty list is `(none)`, a
 /// non-empty one is comma-separated, everything else is itself.
@@ -84,11 +115,7 @@ String _value(Object? value) => switch (value) {
   _ => '$value',
 };
 
-/// The kind labels, sorted, plus a note when they are simply all of them.
-String _kinds(Set<SymbolKind> kinds) {
-  final labels = kinds.map((kind) => kind.label).sorted().join(', ');
-  return kinds.length == FinderOptions.defaultKinds.length &&
-          kinds.containsAll(FinderOptions.defaultKinds)
-      ? '$labels (all)'
-      : labels;
-}
+/// The kind labels, sorted. Whether they are all of them is already clear from
+/// the source: nothing restricted them if the value came from the default.
+String _kinds(Set<SymbolKind> kinds) =>
+    kinds.map((kind) => kind.label).sorted().join(', ');

--- a/lib/src/cli/verbose.dart
+++ b/lib/src/cli/verbose.dart
@@ -6,11 +6,9 @@ import 'package:collection/collection.dart';
 import 'package:config/config.dart';
 import 'package:pro_lsp/pro_lsp.dart' show SymbolKind;
 
-/// The `--verbose` account of where the run's settings came from: the config
-/// file that was read (and what it set), skipped, or looked for in vain.
-///
-/// [projectDir] is the directory discovery looked in, named so a config that
-/// silently didn't apply — because it sits somewhere else — is obvious.
+/// The `--verbose` account of the config file: read (and what it set), skipped,
+/// or missing from [projectDir], which is named so a file that sits elsewhere
+/// and silently didn't apply is obvious.
 List<String> describeConfigSource(
   ConfigFile config, {
   required String projectDir,
@@ -45,13 +43,11 @@ List<String> describeConfigSource(
   ];
 }
 
-/// The `--verbose` rundown of the settings the run actually uses — one line per
-/// config key, each naming the layer its value came from, so "why did it behave
-/// like that?" is answered without guessing.
+/// The `--verbose` rundown of the run's settings: one line per config key, each
+/// naming the layer its value came from.
 ///
-/// [resolved] supplies the values as the tool ended up using them, and
-/// [configuration] the layer each came from. [dartExecutable] is the `dart` the
-/// analysis server will be launched with, which only the caller can resolve.
+/// [resolved] supplies the values, [configuration] their layers, and
+/// [dartExecutable] the `dart` only the caller can resolve.
 List<String> describeSettings(
   CiachConfiguration configuration,
   ResolvedOptions resolved, {
@@ -63,41 +59,38 @@ List<String> describeSettings(
       '  $key: ${_setting(option, resolved, dartExecutable)} (${_source(configuration.valueSourceType(option))})',
 ];
 
-/// The value of [option] as the run uses it, which for a few settings is not
-/// quite the raw resolved value: the root is made absolute, the kinds become
-/// labels, and the two auto-detected flags report what they settled on.
+/// The value of [option] as the run uses it: root made absolute, kinds as
+/// labels, auto-detected flags as they settled.
 String _setting(
   CiachOption<dynamic> option,
   ResolvedOptions resolved,
   String dartExecutable,
 ) => switch (option) {
-  CiachOption.path => resolved.absoluteRootPath,
-  CiachOption.public => '${resolved.includePublic}',
-  CiachOption.generated => '${resolved.includeGenerated}',
-  CiachOption.overrides => '${resolved.overrides}',
-  CiachOption.operators => '${resolved.operators}',
-  CiachOption.unusedUnionMembers => '${resolved.unusedUnionMembers}',
-  CiachOption.reportToJson => '${resolved.reportToJson}',
-  CiachOption.setExitIfChanged => '${resolved.setExitIfChanged}',
-  CiachOption.remove => '${resolved.remove}',
-  CiachOption.force => '${resolved.force}',
-  CiachOption.exclude => _value(resolved.excludeGlobs),
-  CiachOption.include => _value(resolved.includeGlobs),
-  CiachOption.generatedSuffix => _value(resolved.additionalGeneratedSuffixes),
-  CiachOption.kinds => _kinds(resolved.kinds),
-  CiachOption.format => resolved.format,
-  CiachOption.color => '${resolved.useColor}',
-  CiachOption.progress => '${resolved.showProgress}',
-  CiachOption.verbose => '${resolved.verbose}',
-  CiachOption.concurrency => '${resolved.concurrency}',
-  CiachOption.dart => dartExecutable,
-  // Listed by config key, and these three have none — they decide whether a
-  // config file is read at all. Spelled out rather than left to a wildcard so
-  // that a new option has to be given a value here.
-  CiachOption.help || CiachOption.config || CiachOption.noConfig => '',
+  .path => resolved.absoluteRootPath,
+  .public => '${resolved.includePublic}',
+  .generated => '${resolved.includeGenerated}',
+  .overrides => '${resolved.overrides}',
+  .operators => '${resolved.operators}',
+  .unusedUnionMembers => '${resolved.unusedUnionMembers}',
+  .reportToJson => '${resolved.reportToJson}',
+  .setExitIfChanged => '${resolved.setExitIfChanged}',
+  .remove => '${resolved.remove}',
+  .force => '${resolved.force}',
+  .exclude => _value(resolved.excludeGlobs),
+  .include => _value(resolved.includeGlobs),
+  .generatedSuffix => _value(resolved.additionalGeneratedSuffixes),
+  .kinds => _kinds(resolved.kinds),
+  .format => resolved.format,
+  .color => '${resolved.useColor}',
+  .progress => '${resolved.showProgress}',
+  .verbose => '${resolved.verbose}',
+  .concurrency => '${resolved.concurrency}',
+  .dart => dartExecutable,
+  // No config key, so never listed; spelled out so a new option must be too.
+  .help || .config || .noConfig => '',
 };
 
-/// Where a value came from, in the words the user would use for it.
+/// Where a value came from, in the user's words.
 String _source(ValueSourceType source) => switch (source) {
   .arg => 'command line',
   .config => 'config file',
@@ -107,15 +100,14 @@ String _source(ValueSourceType source) => switch (source) {
   .noValue => 'auto-detected',
 };
 
-/// A value as it reads in the verbose log: an empty list is `(none)`, a
-/// non-empty one is comma-separated, everything else is itself.
+/// A value as the log reads it: an empty list is `(none)`, a full one is
+/// comma-separated.
 String _value(Object? value) => switch (value) {
   [] => '(none)',
   List() => value.join(', '),
   _ => '$value',
 };
 
-/// The kind labels, sorted. Whether they are all of them is already clear from
-/// the source: nothing restricted them if the value came from the default.
+/// The kind labels, sorted. That they are all of them shows in the source.
 String _kinds(Set<SymbolKind> kinds) =>
     kinds.map((kind) => kind.label).sorted().join(', ');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   path: ^1.9.1
   pro_lsp: ^0.3.0
   stream_channel: ^2.1.4
+  yaml: ^3.1.3
 
 dev_dependencies:
   leancode_lint: ^24.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ environment:
 dependencies:
   args: ^2.7.0
   collection: ^1.19.0
+  config: ^0.9.0
   glob: ^2.1.3
   path: ^1.9.1
   pro_lsp: ^0.3.0

--- a/test/config_test.dart
+++ b/test/config_test.dart
@@ -11,8 +11,8 @@ import 'package:test/test.dart';
 void main() {
   final parser = buildParser();
 
-  /// Resolves [arguments] against [config], with the terminal-probed defaults
-  /// supplied explicitly so a test never depends on the terminal it runs in.
+  /// Resolves [arguments] against [config], the terminal-probed defaults given
+  /// explicitly so no test depends on the terminal it runs in.
   ResolvedOptions resolveWith(
     List<String> arguments,
     ConfigFile config, {
@@ -24,25 +24,22 @@ void main() {
     progressDefault: progressDefault,
   );
 
-  /// Resolves [arguments] against [config] with both auto-detected settings
-  /// off, so only explicit values can turn them on.
+  /// As above, with both auto-detected settings off.
   ResolvedOptions resolve(List<String> arguments, [ConfigFile? config]) =>
       resolveWith(
         arguments,
-        config ?? const ConfigFile.empty(),
+        config ?? const .empty(),
         colorDefault: false,
         progressDefault: false,
       );
 
-  /// The settings a config [source] alone produces, with an empty command line.
+  /// What a config [source] alone resolves to.
   ResolvedOptions resolveFile(String source) =>
-      resolve(const [], ConfigFile.parse(source, origin: 'ciach.yaml'));
+      resolve(const [], .parse(source, origin: 'ciach.yaml'));
 
   group('ConfigFile.parse', () {
     test('reads every option', () {
-      // One file setting all twenty keys, checked through the merge — which is
-      // both what the CLI does with them and where each value's type is
-      // enforced.
+      // Checked through the merge, which is what the CLI does with them.
       final resolved = resolveFile('''
 path: packages/app
 public: false
@@ -88,14 +85,12 @@ dart: /sdk/bin/dart
       expect(resolved.showProgress, isTrue);
       expect(resolved.concurrency, 4);
       expect(resolved.dartExecutable, '/sdk/bin/dart');
-      // `verbose` is exercised on its own: it forces `progress` off.
+      // On its own, since it forces `progress` off.
       expect(resolveFile('verbose: true').verbose, isTrue);
     });
 
     test('covers every command-line option', () {
-      // Guards the promise that anything settable on the command line is
-      // settable in the file: every long option name (bar the config-file
-      // plumbing and --help) must be a config key.
+      // Anything settable on the command line is settable in the file.
       final cliOnly = {'help', 'config', 'no-config'};
       final optionNames = parser.options.keys.toSet().difference(cliOnly);
 
@@ -221,12 +216,9 @@ concurrency: 4
     });
 
     test('checks the type of every key, even one the argv overrides', () {
-      // Resolution is where a config value's type is enforced, so every key
-      // has to be read there whether the command line supersedes it or not —
-      // otherwise a typo would sit in the file unreported. Every option is
-      // given on the command line below, so only an eager read can still catch
-      // the bad value; a map fits no setting, so it is the one wrong value that
-      // works for every key.
+      // Every option is given on the command line below, so only the eager
+      // check when the file is parsed can still catch the bad value. A map fits
+      // no setting, so it is the one wrong value that works for every key.
       const everyOption = [
         '--public',
         '--generated',
@@ -261,7 +253,7 @@ concurrency: 4
         expect(
           () => resolve(
             everyOption,
-            ConfigFile.parse('$key: {a: b}', origin: 'ciach.yaml'),
+            .parse('$key: {a: b}', origin: 'ciach.yaml'),
           ),
           throwsA(isFormatException('ciach.yaml', contains("'$key'"))),
           reason: 'for a map under $key',
@@ -362,8 +354,7 @@ concurrency: 4
     });
 
     test('ignore reads nothing, but still names the file it skipped', () {
-      // Invalid on purpose: with --no-config it is never parsed, so a broken
-      // config file can't fail a run that asked to ignore it.
+      // Invalid on purpose: --no-config never parses it, so it can't fail.
       write('ciach.yaml', 'publik: [unclosed');
 
       final config = ConfigFile.load(projectDir: tempDir.path, ignore: true);
@@ -480,11 +471,11 @@ dart: /sdk/bin/dart
     });
 
     test('explicitly passing a flag at its default value still wins', () {
-      // --public matches the built-in default, so only `wasParsed` can tell it
+      // --public matches the default, so only the layer it came from tells it
       // apart from an absent flag — and it has to, to beat `public: false`.
       final resolved = resolve(const [
         '--public',
-      ], ConfigFile.parse('public: false', origin: 'ciach.yaml'));
+      ], .parse('public: false', origin: 'ciach.yaml'));
 
       expect(resolved.includePublic, isTrue);
     });
@@ -492,7 +483,7 @@ dart: /sdk/bin/dart
     test('auto-detected color and progress are the last resort', () {
       final auto = resolveWith(
         const [],
-        const ConfigFile.empty(),
+        const .empty(),
         colorDefault: true,
         progressDefault: true,
       );
@@ -501,7 +492,7 @@ dart: /sdk/bin/dart
 
       final fromConfig = resolveWith(
         const [],
-        ConfigFile.parse('color: false\nprogress: false', origin: 'c.yaml'),
+        .parse('color: false\nprogress: false', origin: 'c.yaml'),
         colorDefault: true,
         progressDefault: true,
       );
@@ -510,7 +501,7 @@ dart: /sdk/bin/dart
 
       final fromArgs = resolveWith(
         const ['--no-color', '--no-progress'],
-        ConfigFile.parse('color: true\nprogress: true', origin: 'c.yaml'),
+        .parse('color: true\nprogress: true', origin: 'c.yaml'),
         colorDefault: true,
         progressDefault: true,
       );
@@ -525,19 +516,17 @@ dart: /sdk/bin/dart
       expect(
         resolve(const [
           '--no-verbose',
-        ], ConfigFile.parse('verbose: true', origin: 'c.yaml')).verbose,
+        ], .parse('verbose: true', origin: 'c.yaml')).verbose,
         isFalse,
       );
     });
 
     test('verbose supersedes the progress line', () {
-      // Both would write to stderr, the progress line overwriting itself in
-      // place — so verbose wins and progress is switched off, however it was
-      // asked for.
+      // Both write to stderr, so verbose wins however progress was asked for.
       expect(
         resolveWith(
           const ['--verbose', '--progress'],
-          const ConfigFile.empty(),
+          const .empty(),
           colorDefault: false,
           progressDefault: true,
         ).showProgress,
@@ -546,7 +535,7 @@ dart: /sdk/bin/dart
       expect(
         resolveWith(
           const [],
-          ConfigFile.parse('verbose: true\nprogress: true', origin: 'c.yaml'),
+          .parse('verbose: true\nprogress: true', origin: 'c.yaml'),
           colorDefault: false,
           progressDefault: true,
         ).showProgress,
@@ -555,13 +544,13 @@ dart: /sdk/bin/dart
       expect(
         resolveWith(
           const ['--progress'],
-          ConfigFile.parse('verbose: true', origin: 'c.yaml'),
+          .parse('verbose: true', origin: 'c.yaml'),
           colorDefault: false,
           progressDefault: false,
         ).showProgress,
         isFalse,
       );
-      // …but plain progress still works when verbose is off.
+      // …but progress still works when verbose is off.
       expect(resolve(const ['--progress']).showProgress, isTrue);
     });
 
@@ -587,10 +576,8 @@ dart: /sdk/bin/dart
     });
 
     test('reports every problem at once, not just the first', () {
-      // One of the reasons for leaning on package:config: a run with two bad
-      // values is told about both, instead of one error per attempt. (An
-      // out-of-range `--format` is not among them — an option's `allowed` list
-      // is the arg parser's business, so that one fails before resolution.)
+      // An out-of-range `--format` is not among them: an option's `allowed`
+      // list is the arg parser's business, so that fails before resolution.
       expect(
         () => resolve(const ['-k', 'klass', '-j', '0']),
         throwsA(
@@ -617,7 +604,7 @@ dart: /sdk/bin/dart
 
       expect(options.rootPath, p.normalize(p.absolute('.')));
       expect(options.includePublic, isFalse);
-      // The finder's flag is the inverse of the CLI's.
+      // Inverted for the finder.
       expect(options.skipOverrides, isFalse);
       expect(options.skipOperators, isTrue);
       expect(options.excludeGlobs, ['test/**']);

--- a/test/config_test.dart
+++ b/test/config_test.dart
@@ -4,17 +4,31 @@ import 'package:ciach/ciach.dart';
 import 'package:ciach/src/cli/args.dart';
 import 'package:ciach/src/cli/config.dart';
 import 'package:ciach/src/cli/options.dart';
+import 'package:config/config.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 void main() {
   final parser = buildParser();
 
+  /// Resolves [arguments] against [config], with the terminal-probed defaults
+  /// supplied explicitly so a test never depends on the terminal it runs in.
+  ResolvedOptions resolveWith(
+    List<String> arguments,
+    ConfigFile config, {
+    required bool colorDefault,
+    required bool progressDefault,
+  }) => resolveOptions(
+    resolveConfiguration(parser.parse(arguments), config),
+    colorDefault: colorDefault,
+    progressDefault: progressDefault,
+  );
+
   /// Resolves [arguments] against [config] with both auto-detected settings
   /// off, so only explicit values can turn them on.
   ResolvedOptions resolve(List<String> arguments, [ConfigFile? config]) =>
-      resolveOptions(
-        parser.parse(arguments),
+      resolveWith(
+        arguments,
         config ?? const ConfigFile.empty(),
         colorDefault: false,
         progressDefault: false,
@@ -118,7 +132,7 @@ concurrency: 4
       final config = ConfigFile.parse('public:\n', origin: 'ciach.yaml');
 
       expect(config.settings, isEmpty);
-      expect(config.boolean('public'), isNull);
+      expect(resolve(const [], config).includePublic, isTrue);
     });
 
     test('accepts a bare string where a list is expected', () {
@@ -276,7 +290,7 @@ concurrency: 4
       final config = ConfigFile.load(projectDir: tempDir.path);
 
       expect(config.path, p.join(tempDir.path, 'ciach.yaml'));
-      expect(config.boolean('public'), isFalse);
+      expect(config.settings['public'], isFalse);
     });
 
     test('discovers ciach.yaml only, not other spellings', () {
@@ -288,7 +302,7 @@ concurrency: 4
       write('ciach.yaml', 'format: github');
 
       expect(
-        ConfigFile.load(projectDir: tempDir.path).string('format'),
+        ConfigFile.load(projectDir: tempDir.path).settings['format'],
         'github',
       );
     });
@@ -316,7 +330,7 @@ concurrency: 4
         explicitPath: p.join(tempDir.path, 'elsewhere.yaml'),
       );
 
-      expect(config.string('format'), 'json');
+      expect(config.settings['format'], 'json');
     });
 
     test('an explicit path wins over a discoverable file', () {
@@ -328,7 +342,7 @@ concurrency: 4
         explicitPath: p.join(tempDir.path, 'other.yaml'),
       );
 
-      expect(config.string('format'), 'json');
+      expect(config.settings['format'], 'json');
     });
 
     test('reports a missing explicit path', () {
@@ -476,8 +490,8 @@ dart: /sdk/bin/dart
     });
 
     test('auto-detected color and progress are the last resort', () {
-      final auto = resolveOptions(
-        parser.parse(const []),
+      final auto = resolveWith(
+        const [],
         const ConfigFile.empty(),
         colorDefault: true,
         progressDefault: true,
@@ -485,8 +499,8 @@ dart: /sdk/bin/dart
       expect(auto.useColor, isTrue);
       expect(auto.showProgress, isTrue);
 
-      final fromConfig = resolveOptions(
-        parser.parse(const []),
+      final fromConfig = resolveWith(
+        const [],
         ConfigFile.parse('color: false\nprogress: false', origin: 'c.yaml'),
         colorDefault: true,
         progressDefault: true,
@@ -494,8 +508,8 @@ dart: /sdk/bin/dart
       expect(fromConfig.useColor, isFalse);
       expect(fromConfig.showProgress, isFalse);
 
-      final fromArgs = resolveOptions(
-        parser.parse(const ['--no-color', '--no-progress']),
+      final fromArgs = resolveWith(
+        const ['--no-color', '--no-progress'],
         ConfigFile.parse('color: true\nprogress: true', origin: 'c.yaml'),
         colorDefault: true,
         progressDefault: true,
@@ -521,8 +535,8 @@ dart: /sdk/bin/dart
       // place — so verbose wins and progress is switched off, however it was
       // asked for.
       expect(
-        resolveOptions(
-          parser.parse(const ['--verbose', '--progress']),
+        resolveWith(
+          const ['--verbose', '--progress'],
           const ConfigFile.empty(),
           colorDefault: false,
           progressDefault: true,
@@ -530,8 +544,8 @@ dart: /sdk/bin/dart
         isFalse,
       );
       expect(
-        resolveOptions(
-          parser.parse(const []),
+        resolveWith(
+          const [],
           ConfigFile.parse('verbose: true\nprogress: true', origin: 'c.yaml'),
           colorDefault: false,
           progressDefault: true,
@@ -539,8 +553,8 @@ dart: /sdk/bin/dart
         isFalse,
       );
       expect(
-        resolveOptions(
-          parser.parse(const ['--progress']),
+        resolveWith(
+          const ['--progress'],
           ConfigFile.parse('verbose: true', origin: 'c.yaml'),
           colorDefault: false,
           progressDefault: false,
@@ -552,29 +566,39 @@ dart: /sdk/bin/dart
     });
 
     test('rejects a non-positive --concurrency', () {
-      for (final value in ['0', '-1', 'lots']) {
+      for (final value in ['0', '-1']) {
         expect(
           () => resolve(['--concurrency', value]),
-          throwsA(
-            isA<FormatException>().having(
-              (e) => e.message,
-              'message',
-              contains('--concurrency must be a positive integer'),
-            ),
-          ),
+          throwsA(isUsageException(contains('below the minimum (1)'))),
           reason: 'for --concurrency $value',
         );
       }
+      expect(
+        () => resolve(const ['--concurrency', 'lots']),
+        throwsA(isUsageException(contains('lots'))),
+      );
     });
 
     test('rejects an unknown --kinds value', () {
       expect(
         () => resolve(const ['-k', 'klass']),
+        throwsA(isUsageException(contains("Unknown kind 'klass'"))),
+      );
+    });
+
+    test('reports every problem at once, not just the first', () {
+      // One of the reasons for leaning on package:config: a run with two bad
+      // values is told about both, instead of one error per attempt. (An
+      // out-of-range `--format` is not among them — an option's `allowed` list
+      // is the arg parser's business, so that one fails before resolution.)
+      expect(
+        () => resolve(const ['-k', 'klass', '-j', '0']),
         throwsA(
-          isA<FormatException>().having(
-            (e) => e.message,
-            'message',
-            contains("Unknown kind 'klass'"),
+          isUsageException(
+            allOf(
+              contains("Unknown kind 'klass'"),
+              contains('below the minimum (1)'),
+            ),
           ),
         ),
       );
@@ -602,6 +626,10 @@ dart: /sdk/bin/dart
     });
   });
 }
+
+/// A [UsageException] whose message matches [message].
+Matcher isUsageException(Matcher message) =>
+    isA<UsageException>().having((e) => e.message, 'message', message);
 
 /// A [FormatException] whose message names [origin] and matches [message].
 Matcher isFormatException(String origin, Matcher message) =>

--- a/test/config_test.dart
+++ b/test/config_test.dart
@@ -12,17 +12,24 @@ void main() {
 
   /// Resolves [arguments] against [config] with both auto-detected settings
   /// off, so only explicit values can turn them on.
-  ResolvedOptions resolve(List<String> arguments, [CiachConfig? config]) =>
+  ResolvedOptions resolve(List<String> arguments, [ConfigFile? config]) =>
       resolveOptions(
         parser.parse(arguments),
-        config ?? const CiachConfig(),
+        config ?? const ConfigFile.empty(),
         colorDefault: false,
         progressDefault: false,
       );
 
-  group('CiachConfig.parse', () {
+  /// The settings a config [source] alone produces, with an empty command line.
+  ResolvedOptions resolveFile(String source) =>
+      resolve(const [], ConfigFile.parse(source, origin: 'ciach.yaml'));
+
+  group('ConfigFile.parse', () {
     test('reads every option', () {
-      final config = CiachConfig.parse('''
+      // One file setting all twenty keys, checked through the merge — which is
+      // both what the CLI does with them and where each value's type is
+      // enforced.
+      final resolved = resolveFile('''
 path: packages/app
 public: false
 generated: true
@@ -42,49 +49,33 @@ generated-suffix:
   - .gc.dart
 kinds: [class, function]
 format: github
-color: false
-progress: false
-verbose: true
+color: true
+progress: true
 concurrency: 4
 dart: /sdk/bin/dart
-''', origin: 'ciach.yaml');
+''');
 
-      expect(config.path, 'packages/app');
-      expect(config.public, isFalse);
-      expect(config.generated, isTrue);
-      expect(config.overrides, isTrue);
-      expect(config.operators, isTrue);
-      expect(config.unusedUnionMembers, isTrue);
-      expect(config.reportToJson, isTrue);
-      expect(config.setExitIfChanged, isTrue);
-      expect(config.remove, isTrue);
-      expect(config.force, isTrue);
-      expect(config.exclude, ['test/**', 'tool/**']);
-      expect(config.include, ['lib/**']);
-      expect(config.generatedSuffix, ['.gc.dart']);
-      expect(config.kinds, ['class', 'function']);
-      expect(config.format, 'github');
-      expect(config.color, isFalse);
-      expect(config.progress, isFalse);
-      expect(config.verbose, isTrue);
-      expect(config.concurrency, 4);
-      expect(config.dart, '/sdk/bin/dart');
-      // Every key that was in the file, and nothing else.
-      expect(config.settings.keys, configKeys);
-    });
-
-    test('settings lists only what the file sets', () {
-      final config = CiachConfig.parse('''
-public: false
-exclude: ['test/**']
-concurrency: 4
-''', origin: 'ciach.yaml');
-
-      expect(config.settings, {
-        'public': false,
-        'exclude': ['test/**'],
-        'concurrency': 4,
-      });
+      expect(resolved.rootPath, 'packages/app');
+      expect(resolved.includePublic, isFalse);
+      expect(resolved.includeGenerated, isTrue);
+      expect(resolved.overrides, isTrue);
+      expect(resolved.operators, isTrue);
+      expect(resolved.unusedUnionMembers, isTrue);
+      expect(resolved.reportToJson, isTrue);
+      expect(resolved.setExitIfChanged, isTrue);
+      expect(resolved.remove, isTrue);
+      expect(resolved.force, isTrue);
+      expect(resolved.excludeGlobs, ['test/**', 'tool/**']);
+      expect(resolved.includeGlobs, ['lib/**']);
+      expect(resolved.additionalGeneratedSuffixes, ['.gc.dart']);
+      expect(resolved.kinds, <SymbolKind>{.class$, .function});
+      expect(resolved.format, 'github');
+      expect(resolved.useColor, isTrue);
+      expect(resolved.showProgress, isTrue);
+      expect(resolved.concurrency, 4);
+      expect(resolved.dartExecutable, '/sdk/bin/dart');
+      // `verbose` is exercised on its own: it forces `progress` off.
+      expect(resolveFile('verbose: true').verbose, isTrue);
     });
 
     test('covers every command-line option', () {
@@ -97,43 +88,53 @@ concurrency: 4
       expect(configKeys.difference({'path'}), optionNames);
     });
 
-    test('leaves unset options null', () {
-      final config = CiachConfig.parse('public: false', origin: 'ciach.yaml');
+    test('settings lists what the file sets, and only that', () {
+      final config = ConfigFile.parse('''
+public: false
+exclude: ['test/**']
+concurrency: 4
+''', origin: 'ciach.yaml');
 
-      expect(config.public, isFalse);
-      expect(config.format, isNull);
-      expect(config.exclude, isNull);
-      expect(config.concurrency, isNull);
+      expect(config.settings, {
+        'public': false,
+        'exclude': ['test/**'],
+        'concurrency': 4,
+      });
+      expect(config.path, 'ciach.yaml');
+      expect(config.ignored, isFalse);
     });
 
     test('treats an empty or comment-only file as no settings', () {
       for (final source in ['', '\n', '# nothing here\n']) {
-        final config = CiachConfig.parse(source, origin: 'ciach.yaml');
-        expect(config.public, isNull, reason: 'for ${source.trim()}');
+        expect(
+          ConfigFile.parse(source, origin: 'ciach.yaml').settings,
+          isEmpty,
+          reason: 'for ${source.trim()}',
+        );
       }
     });
 
     test('treats a valueless key as unset', () {
-      final config = CiachConfig.parse('public:\n', origin: 'ciach.yaml');
+      final config = ConfigFile.parse('public:\n', origin: 'ciach.yaml');
 
-      expect(config.public, isNull);
+      expect(config.settings, isEmpty);
+      expect(config.boolean('public'), isNull);
     });
 
     test('accepts a bare string where a list is expected', () {
-      final config = CiachConfig.parse("exclude: 'test/**'", origin: 'c.yaml');
-
-      expect(config.exclude, ['test/**']);
+      expect(resolveFile("exclude: 'test/**'").excludeGlobs, ['test/**']);
     });
 
     test('accepts comma-separated kinds in one string', () {
-      final config = CiachConfig.parse('kinds: class,method', origin: 'c.yaml');
-
-      expect(resolve(const [], config).kinds, <SymbolKind>{.class$, .method});
+      expect(resolveFile('kinds: class,method').kinds, <SymbolKind>{
+        .class$,
+        .method,
+      });
     });
 
     test('rejects an unknown option, naming the file and valid keys', () {
       expect(
-        () => CiachConfig.parse('publik: false', origin: 'ciach.yaml'),
+        () => ConfigFile.parse('publik: false', origin: 'ciach.yaml'),
         throwsA(
           isFormatException('ciach.yaml', contains("unknown option 'publik'")),
         ),
@@ -142,7 +143,7 @@ concurrency: 4
 
     test('rejects a top-level document that is not a map', () {
       expect(
-        () => CiachConfig.parse('- public', origin: 'ciach.yaml'),
+        () => ConfigFile.parse('- public', origin: 'ciach.yaml'),
         throwsA(
           isFormatException('ciach.yaml', contains('must be a map of options')),
         ),
@@ -151,14 +152,14 @@ concurrency: 4
 
     test('rejects malformed YAML', () {
       expect(
-        () => CiachConfig.parse('public: [unclosed', origin: 'ciach.yaml'),
+        () => ConfigFile.parse('public: [unclosed', origin: 'ciach.yaml'),
         throwsA(isFormatException('ciach.yaml', contains('not valid YAML'))),
       );
     });
 
     test('rejects a non-boolean flag', () {
       expect(
-        () => CiachConfig.parse('public: sometimes', origin: 'ciach.yaml'),
+        () => resolveFile('public: sometimes'),
         throwsA(
           isFormatException(
             'ciach.yaml',
@@ -170,14 +171,14 @@ concurrency: 4
 
     test('rejects a non-string in a list', () {
       expect(
-        () => CiachConfig.parse('exclude: [1]', origin: 'ciach.yaml'),
+        () => resolveFile('exclude: [1]'),
         throwsA(isFormatException('ciach.yaml', contains('a list of strings'))),
       );
     });
 
     test('rejects an unknown format', () {
       expect(
-        () => CiachConfig.parse('format: xml', origin: 'ciach.yaml'),
+        () => resolveFile('format: xml'),
         throwsA(
           isFormatException('ciach.yaml', contains('text, json, github')),
         ),
@@ -186,7 +187,7 @@ concurrency: 4
 
     test('rejects an unknown kind', () {
       expect(
-        () => CiachConfig.parse('kinds: [klass]', origin: 'ciach.yaml'),
+        () => resolveFile('kinds: [klass]'),
         throwsA(
           isFormatException('ciach.yaml', contains("Unknown kind 'klass'")),
         ),
@@ -196,15 +197,66 @@ concurrency: 4
     test('rejects a non-positive concurrency', () {
       for (final value in ['0', '-2', 'many', '1.5']) {
         expect(
-          () => CiachConfig.parse('concurrency: $value', origin: 'c.yaml'),
-          throwsA(isFormatException('c.yaml', contains('positive integer'))),
+          () => resolveFile('concurrency: $value'),
+          throwsA(
+            isFormatException('ciach.yaml', contains('positive integer')),
+          ),
           reason: 'for concurrency: $value',
+        );
+      }
+    });
+
+    test('checks the type of every key, even one the argv overrides', () {
+      // Resolution is where a config value's type is enforced, so every key
+      // has to be read there whether the command line supersedes it or not —
+      // otherwise a typo would sit in the file unreported. Every option is
+      // given on the command line below, so only an eager read can still catch
+      // the bad value; a map fits no setting, so it is the one wrong value that
+      // works for every key.
+      const everyOption = [
+        '--public',
+        '--generated',
+        '--overrides',
+        '--operators',
+        '--unused-union-members',
+        '--report-tojson',
+        '--set-exit-if-changed',
+        '--remove',
+        '--force',
+        '-e',
+        'test/**',
+        '-i',
+        'lib/**',
+        '--generated-suffix',
+        '.gc.dart',
+        '-k',
+        'class',
+        '-f',
+        'json',
+        '--color',
+        '--progress',
+        '--verbose',
+        '-j',
+        '2',
+        '--dart',
+        '/sdk/bin/dart',
+        'lib',
+      ];
+
+      for (final key in configKeys) {
+        expect(
+          () => resolve(
+            everyOption,
+            ConfigFile.parse('$key: {a: b}', origin: 'ciach.yaml'),
+          ),
+          throwsA(isFormatException('ciach.yaml', contains("'$key'"))),
+          reason: 'for a map under $key',
         );
       }
     });
   });
 
-  group('loadConfig', () {
+  group('ConfigFile.load', () {
     late Directory tempDir;
 
     setUp(() {
@@ -221,64 +273,67 @@ concurrency: 4
     test('discovers ciach.yaml in the project directory', () {
       write('ciach.yaml', 'public: false');
 
-      final loaded = loadConfig(projectDir: tempDir.path);
+      final config = ConfigFile.load(projectDir: tempDir.path);
 
-      expect(loaded.path, p.join(tempDir.path, 'ciach.yaml'));
-      expect(loaded.config.public, isFalse);
+      expect(config.path, p.join(tempDir.path, 'ciach.yaml'));
+      expect(config.boolean('public'), isFalse);
     });
 
     test('discovers ciach.yaml only, not other spellings', () {
       write('ciach.yml', 'format: json');
       write('.ciach.yaml', 'format: json');
 
-      expect(loadConfig(projectDir: tempDir.path).path, isNull);
+      expect(ConfigFile.load(projectDir: tempDir.path).path, isNull);
 
       write('ciach.yaml', 'format: github');
 
-      expect(loadConfig(projectDir: tempDir.path).config.format, 'github');
+      expect(
+        ConfigFile.load(projectDir: tempDir.path).string('format'),
+        'github',
+      );
     });
 
     test('returns an empty config when the directory has none', () {
-      final loaded = loadConfig(projectDir: tempDir.path);
+      final config = ConfigFile.load(projectDir: tempDir.path);
 
-      expect(loaded.path, isNull);
-      expect(loaded.config.public, isNull);
+      expect(config.path, isNull);
+      expect(config.settings, isEmpty);
     });
 
     test('does not look outside the project directory', () {
       write('ciach.yaml', 'public: false');
       final nested = Directory(p.join(tempDir.path, 'nested'))..createSync();
 
-      expect(loadConfig(projectDir: nested.path).path, isNull);
+      expect(ConfigFile.load(projectDir: nested.path).path, isNull);
     });
 
     test('loads an explicit path from outside the project directory', () {
       write('elsewhere.yaml', 'format: json');
       final nested = Directory(p.join(tempDir.path, 'nested'))..createSync();
 
-      final loaded = loadConfig(
+      final config = ConfigFile.load(
         projectDir: nested.path,
         explicitPath: p.join(tempDir.path, 'elsewhere.yaml'),
       );
 
-      expect(loaded.config.format, 'json');
+      expect(config.string('format'), 'json');
     });
 
     test('an explicit path wins over a discoverable file', () {
       write('ciach.yaml', 'format: github');
       write('other.yaml', 'format: json');
 
-      final loaded = loadConfig(
+      final config = ConfigFile.load(
         projectDir: tempDir.path,
         explicitPath: p.join(tempDir.path, 'other.yaml'),
       );
 
-      expect(loaded.config.format, 'json');
+      expect(config.string('format'), 'json');
     });
 
     test('reports a missing explicit path', () {
       expect(
-        () => loadConfig(
+        () => ConfigFile.load(
           projectDir: tempDir.path,
           explicitPath: p.join(tempDir.path, 'nope.yaml'),
         ),
@@ -297,28 +352,28 @@ concurrency: 4
       // config file can't fail a run that asked to ignore it.
       write('ciach.yaml', 'publik: [unclosed');
 
-      final loaded = loadConfig(projectDir: tempDir.path, ignore: true);
+      final config = ConfigFile.load(projectDir: tempDir.path, ignore: true);
 
-      expect(loaded.ignored, isTrue);
-      expect(loaded.path, p.join(tempDir.path, 'ciach.yaml'));
-      expect(loaded.config.settings, isEmpty);
+      expect(config.ignored, isTrue);
+      expect(config.path, p.join(tempDir.path, 'ciach.yaml'));
+      expect(config.settings, isEmpty);
     });
 
     test('ignore reports no path when there was no config anyway', () {
-      final loaded = loadConfig(projectDir: tempDir.path, ignore: true);
+      final config = ConfigFile.load(projectDir: tempDir.path, ignore: true);
 
-      expect(loaded.ignored, isTrue);
-      expect(loaded.path, isNull);
+      expect(config.ignored, isTrue);
+      expect(config.path, isNull);
     });
 
     test('ignore skips an explicit path, and its would-be errors', () {
-      final loaded = loadConfig(
+      final config = ConfigFile.load(
         projectDir: tempDir.path,
         explicitPath: p.join(tempDir.path, 'nope.yaml'),
         ignore: true,
       );
 
-      expect(loaded.path, isNull);
+      expect(config.path, isNull);
     });
   });
 
@@ -346,64 +401,17 @@ concurrency: 4
       expect(resolved.dartExecutable, isNull);
     });
 
-    test('takes config values when the command line is silent', () {
-      final resolved = resolve(
-        const [],
-        const CiachConfig(
-          path: 'packages/app',
-          public: false,
-          generated: true,
-          overrides: true,
-          operators: true,
-          unusedUnionMembers: true,
-          reportToJson: true,
-          setExitIfChanged: true,
-          remove: true,
-          force: true,
-          exclude: ['test/**'],
-          include: ['lib/**'],
-          generatedSuffix: ['.gc.dart'],
-          kinds: ['class'],
-          format: 'json',
-          color: true,
-          progress: true,
-          concurrency: 4,
-          dart: '/sdk/bin/dart',
-        ),
-      );
-
-      expect(resolved.rootPath, 'packages/app');
-      expect(resolved.includePublic, isFalse);
-      expect(resolved.includeGenerated, isTrue);
-      expect(resolved.overrides, isTrue);
-      expect(resolved.operators, isTrue);
-      expect(resolved.unusedUnionMembers, isTrue);
-      expect(resolved.reportToJson, isTrue);
-      expect(resolved.setExitIfChanged, isTrue);
-      expect(resolved.remove, isTrue);
-      expect(resolved.force, isTrue);
-      expect(resolved.excludeGlobs, ['test/**']);
-      expect(resolved.includeGlobs, ['lib/**']);
-      expect(resolved.additionalGeneratedSuffixes, ['.gc.dart']);
-      expect(resolved.kinds, {SymbolKind.class$});
-      expect(resolved.format, 'json');
-      expect(resolved.useColor, isTrue);
-      expect(resolved.showProgress, isTrue);
-      expect(resolved.concurrency, 4);
-      expect(resolved.dartExecutable, '/sdk/bin/dart');
-    });
-
     test('command-line flags override the config', () {
-      const config = CiachConfig(
-        path: 'packages/app',
-        public: false,
-        generated: true,
-        format: 'json',
-        color: false,
-        progress: false,
-        concurrency: 4,
-        dart: '/sdk/bin/dart',
-      );
+      final config = ConfigFile.parse('''
+path: packages/app
+public: false
+generated: true
+format: json
+color: false
+progress: false
+concurrency: 4
+dart: /sdk/bin/dart
+''', origin: 'ciach.yaml');
 
       final resolved = resolve(const [
         '--public',
@@ -430,12 +438,15 @@ concurrency: 4
     });
 
     test('a command-line list replaces the config list, not appends', () {
-      const config = CiachConfig(exclude: ['test/**'], kinds: ['class']);
+      final config = ConfigFile.parse(
+        "exclude: ['test/**']\nkinds: [class]",
+        origin: 'ciach.yaml',
+      );
 
       final resolved = resolve(const ['-e', 'tool/**', '-k', 'method'], config);
 
       expect(resolved.excludeGlobs, ['tool/**']);
-      expect(resolved.kinds, {SymbolKind.method});
+      expect(resolved.kinds, <SymbolKind>{.method});
     });
 
     test('repeated command-line values all survive', () {
@@ -459,7 +470,7 @@ concurrency: 4
       // apart from an absent flag — and it has to, to beat `public: false`.
       final resolved = resolve(const [
         '--public',
-      ], const CiachConfig(public: false));
+      ], ConfigFile.parse('public: false', origin: 'ciach.yaml'));
 
       expect(resolved.includePublic, isTrue);
     });
@@ -467,7 +478,7 @@ concurrency: 4
     test('auto-detected color and progress are the last resort', () {
       final auto = resolveOptions(
         parser.parse(const []),
-        const CiachConfig(),
+        const ConfigFile.empty(),
         colorDefault: true,
         progressDefault: true,
       );
@@ -476,7 +487,7 @@ concurrency: 4
 
       final fromConfig = resolveOptions(
         parser.parse(const []),
-        const CiachConfig(color: false, progress: false),
+        ConfigFile.parse('color: false\nprogress: false', origin: 'c.yaml'),
         colorDefault: true,
         progressDefault: true,
       );
@@ -485,7 +496,7 @@ concurrency: 4
 
       final fromArgs = resolveOptions(
         parser.parse(const ['--no-color', '--no-progress']),
-        const CiachConfig(color: true, progress: true),
+        ConfigFile.parse('color: true\nprogress: true', origin: 'c.yaml'),
         colorDefault: true,
         progressDefault: true,
       );
@@ -496,11 +507,11 @@ concurrency: 4
     test('verbose comes from the command line or the config', () {
       expect(resolve(const ['--verbose']).verbose, isTrue);
       expect(resolve(const ['-v']).verbose, isTrue);
-      expect(resolve(const [], const CiachConfig(verbose: true)).verbose, true);
+      expect(resolveFile('verbose: true').verbose, isTrue);
       expect(
         resolve(const [
           '--no-verbose',
-        ], const CiachConfig(verbose: true)).verbose,
+        ], ConfigFile.parse('verbose: true', origin: 'c.yaml')).verbose,
         isFalse,
       );
     });
@@ -512,7 +523,7 @@ concurrency: 4
       expect(
         resolveOptions(
           parser.parse(const ['--verbose', '--progress']),
-          const CiachConfig(),
+          const ConfigFile.empty(),
           colorDefault: false,
           progressDefault: true,
         ).showProgress,
@@ -521,22 +532,22 @@ concurrency: 4
       expect(
         resolveOptions(
           parser.parse(const []),
-          const CiachConfig(verbose: true, progress: true),
+          ConfigFile.parse('verbose: true\nprogress: true', origin: 'c.yaml'),
           colorDefault: false,
           progressDefault: true,
         ).showProgress,
         isFalse,
       );
-      // …but plain progress still works when verbose is off.
       expect(
         resolveOptions(
           parser.parse(const ['--progress']),
-          const CiachConfig(verbose: true),
+          ConfigFile.parse('verbose: true', origin: 'c.yaml'),
           colorDefault: false,
           progressDefault: false,
         ).showProgress,
         isFalse,
       );
+      // …but plain progress still works when verbose is off.
       expect(resolve(const ['--progress']).showProgress, isTrue);
     });
 
@@ -567,6 +578,27 @@ concurrency: 4
           ),
         ),
       );
+    });
+
+    test('hands the finder its share of the settings', () {
+      final resolved = resolve(const [
+        '--no-public',
+        '--overrides',
+        '-e',
+        'test/**',
+        '-j',
+        '4',
+      ]);
+      final options = resolved.finderOptions();
+
+      expect(options.rootPath, p.normalize(p.absolute('.')));
+      expect(options.includePublic, isFalse);
+      // The finder's flag is the inverse of the CLI's.
+      expect(options.skipOverrides, isFalse);
+      expect(options.skipOperators, isTrue);
+      expect(options.excludeGlobs, ['test/**']);
+      expect(options.concurrency, 4);
+      expect(options.onProgress, isNull);
     });
   });
 }

--- a/test/config_test.dart
+++ b/test/config_test.dart
@@ -44,6 +44,7 @@ kinds: [class, function]
 format: github
 color: false
 progress: false
+verbose: true
 concurrency: 4
 dart: /sdk/bin/dart
 ''', origin: 'ciach.yaml');
@@ -65,8 +66,25 @@ dart: /sdk/bin/dart
       expect(config.format, 'github');
       expect(config.color, isFalse);
       expect(config.progress, isFalse);
+      expect(config.verbose, isTrue);
       expect(config.concurrency, 4);
       expect(config.dart, '/sdk/bin/dart');
+      // Every key that was in the file, and nothing else.
+      expect(config.settings.keys, configKeys);
+    });
+
+    test('settings lists only what the file sets', () {
+      final config = CiachConfig.parse('''
+public: false
+exclude: ['test/**']
+concurrency: 4
+''', origin: 'ciach.yaml');
+
+      expect(config.settings, {
+        'public': false,
+        'exclude': ['test/**'],
+        'concurrency': 4,
+      });
     });
 
     test('covers every command-line option', () {
@@ -209,10 +227,11 @@ dart: /sdk/bin/dart
       expect(loaded.config.public, isFalse);
     });
 
-    test('discovers ciach.yml too, preferring ciach.yaml', () {
+    test('discovers ciach.yaml only, not other spellings', () {
       write('ciach.yml', 'format: json');
+      write('.ciach.yaml', 'format: json');
 
-      expect(loadConfig(projectDir: tempDir.path).config.format, 'json');
+      expect(loadConfig(projectDir: tempDir.path).path, isNull);
 
       write('ciach.yaml', 'format: github');
 
@@ -273,13 +292,23 @@ dart: /sdk/bin/dart
       );
     });
 
-    test('ignore skips discovery entirely', () {
-      write('ciach.yaml', 'public: false');
+    test('ignore reads nothing, but still names the file it skipped', () {
+      // Invalid on purpose: with --no-config it is never parsed, so a broken
+      // config file can't fail a run that asked to ignore it.
+      write('ciach.yaml', 'publik: [unclosed');
 
       final loaded = loadConfig(projectDir: tempDir.path, ignore: true);
 
+      expect(loaded.ignored, isTrue);
+      expect(loaded.path, p.join(tempDir.path, 'ciach.yaml'));
+      expect(loaded.config.settings, isEmpty);
+    });
+
+    test('ignore reports no path when there was no config anyway', () {
+      final loaded = loadConfig(projectDir: tempDir.path, ignore: true);
+
+      expect(loaded.ignored, isTrue);
       expect(loaded.path, isNull);
-      expect(loaded.config.public, isNull);
     });
 
     test('ignore skips an explicit path, and its would-be errors', () {
@@ -312,6 +341,7 @@ dart: /sdk/bin/dart
       expect(resolved.additionalGeneratedSuffixes, isEmpty);
       expect(resolved.kinds, FinderOptions.defaultKinds);
       expect(resolved.format, 'text');
+      expect(resolved.verbose, isFalse);
       expect(resolved.concurrency, 16);
       expect(resolved.dartExecutable, isNull);
     });
@@ -461,6 +491,53 @@ dart: /sdk/bin/dart
       );
       expect(fromArgs.useColor, isFalse);
       expect(fromArgs.showProgress, isFalse);
+    });
+
+    test('verbose comes from the command line or the config', () {
+      expect(resolve(const ['--verbose']).verbose, isTrue);
+      expect(resolve(const ['-v']).verbose, isTrue);
+      expect(resolve(const [], const CiachConfig(verbose: true)).verbose, true);
+      expect(
+        resolve(const [
+          '--no-verbose',
+        ], const CiachConfig(verbose: true)).verbose,
+        isFalse,
+      );
+    });
+
+    test('verbose supersedes the progress line', () {
+      // Both would write to stderr, the progress line overwriting itself in
+      // place — so verbose wins and progress is switched off, however it was
+      // asked for.
+      expect(
+        resolveOptions(
+          parser.parse(const ['--verbose', '--progress']),
+          const CiachConfig(),
+          colorDefault: false,
+          progressDefault: true,
+        ).showProgress,
+        isFalse,
+      );
+      expect(
+        resolveOptions(
+          parser.parse(const []),
+          const CiachConfig(verbose: true, progress: true),
+          colorDefault: false,
+          progressDefault: true,
+        ).showProgress,
+        isFalse,
+      );
+      // …but plain progress still works when verbose is off.
+      expect(
+        resolveOptions(
+          parser.parse(const ['--progress']),
+          const CiachConfig(verbose: true),
+          colorDefault: false,
+          progressDefault: false,
+        ).showProgress,
+        isFalse,
+      );
+      expect(resolve(const ['--progress']).showProgress, isTrue);
     });
 
     test('rejects a non-positive --concurrency', () {

--- a/test/config_test.dart
+++ b/test/config_test.dart
@@ -1,0 +1,501 @@
+import 'dart:io';
+
+import 'package:ciach/ciach.dart';
+import 'package:ciach/src/cli/args.dart';
+import 'package:ciach/src/cli/config.dart';
+import 'package:ciach/src/cli/options.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  final parser = buildParser();
+
+  /// Resolves [arguments] against [config] with both auto-detected settings
+  /// off, so only explicit values can turn them on.
+  ResolvedOptions resolve(List<String> arguments, [CiachConfig? config]) =>
+      resolveOptions(
+        parser.parse(arguments),
+        config ?? const CiachConfig(),
+        colorDefault: false,
+        progressDefault: false,
+      );
+
+  group('CiachConfig.parse', () {
+    test('reads every option', () {
+      final config = CiachConfig.parse('''
+path: packages/app
+public: false
+generated: true
+overrides: true
+operators: true
+unused-union-members: true
+report-tojson: true
+set-exit-if-changed: true
+remove: true
+force: true
+exclude:
+  - 'test/**'
+  - 'tool/**'
+include:
+  - 'lib/**'
+generated-suffix:
+  - .gc.dart
+kinds: [class, function]
+format: github
+color: false
+progress: false
+concurrency: 4
+dart: /sdk/bin/dart
+''', origin: 'ciach.yaml');
+
+      expect(config.path, 'packages/app');
+      expect(config.public, isFalse);
+      expect(config.generated, isTrue);
+      expect(config.overrides, isTrue);
+      expect(config.operators, isTrue);
+      expect(config.unusedUnionMembers, isTrue);
+      expect(config.reportToJson, isTrue);
+      expect(config.setExitIfChanged, isTrue);
+      expect(config.remove, isTrue);
+      expect(config.force, isTrue);
+      expect(config.exclude, ['test/**', 'tool/**']);
+      expect(config.include, ['lib/**']);
+      expect(config.generatedSuffix, ['.gc.dart']);
+      expect(config.kinds, ['class', 'function']);
+      expect(config.format, 'github');
+      expect(config.color, isFalse);
+      expect(config.progress, isFalse);
+      expect(config.concurrency, 4);
+      expect(config.dart, '/sdk/bin/dart');
+    });
+
+    test('covers every command-line option', () {
+      // Guards the promise that anything settable on the command line is
+      // settable in the file: every long option name (bar the config-file
+      // plumbing and --help) must be a config key.
+      final cliOnly = {'help', 'config', 'no-config'};
+      final optionNames = parser.options.keys.toSet().difference(cliOnly);
+
+      expect(configKeys.difference({'path'}), optionNames);
+    });
+
+    test('leaves unset options null', () {
+      final config = CiachConfig.parse('public: false', origin: 'ciach.yaml');
+
+      expect(config.public, isFalse);
+      expect(config.format, isNull);
+      expect(config.exclude, isNull);
+      expect(config.concurrency, isNull);
+    });
+
+    test('treats an empty or comment-only file as no settings', () {
+      for (final source in ['', '\n', '# nothing here\n']) {
+        final config = CiachConfig.parse(source, origin: 'ciach.yaml');
+        expect(config.public, isNull, reason: 'for ${source.trim()}');
+      }
+    });
+
+    test('treats a valueless key as unset', () {
+      final config = CiachConfig.parse('public:\n', origin: 'ciach.yaml');
+
+      expect(config.public, isNull);
+    });
+
+    test('accepts a bare string where a list is expected', () {
+      final config = CiachConfig.parse("exclude: 'test/**'", origin: 'c.yaml');
+
+      expect(config.exclude, ['test/**']);
+    });
+
+    test('accepts comma-separated kinds in one string', () {
+      final config = CiachConfig.parse('kinds: class,method', origin: 'c.yaml');
+
+      expect(resolve(const [], config).kinds, <SymbolKind>{.class$, .method});
+    });
+
+    test('rejects an unknown option, naming the file and valid keys', () {
+      expect(
+        () => CiachConfig.parse('publik: false', origin: 'ciach.yaml'),
+        throwsA(
+          isFormatException('ciach.yaml', contains("unknown option 'publik'")),
+        ),
+      );
+    });
+
+    test('rejects a top-level document that is not a map', () {
+      expect(
+        () => CiachConfig.parse('- public', origin: 'ciach.yaml'),
+        throwsA(
+          isFormatException('ciach.yaml', contains('must be a map of options')),
+        ),
+      );
+    });
+
+    test('rejects malformed YAML', () {
+      expect(
+        () => CiachConfig.parse('public: [unclosed', origin: 'ciach.yaml'),
+        throwsA(isFormatException('ciach.yaml', contains('not valid YAML'))),
+      );
+    });
+
+    test('rejects a non-boolean flag', () {
+      expect(
+        () => CiachConfig.parse('public: sometimes', origin: 'ciach.yaml'),
+        throwsA(
+          isFormatException(
+            'ciach.yaml',
+            contains("'public' must be true or false, got a string"),
+          ),
+        ),
+      );
+    });
+
+    test('rejects a non-string in a list', () {
+      expect(
+        () => CiachConfig.parse('exclude: [1]', origin: 'ciach.yaml'),
+        throwsA(isFormatException('ciach.yaml', contains('a list of strings'))),
+      );
+    });
+
+    test('rejects an unknown format', () {
+      expect(
+        () => CiachConfig.parse('format: xml', origin: 'ciach.yaml'),
+        throwsA(
+          isFormatException('ciach.yaml', contains('text, json, github')),
+        ),
+      );
+    });
+
+    test('rejects an unknown kind', () {
+      expect(
+        () => CiachConfig.parse('kinds: [klass]', origin: 'ciach.yaml'),
+        throwsA(
+          isFormatException('ciach.yaml', contains("Unknown kind 'klass'")),
+        ),
+      );
+    });
+
+    test('rejects a non-positive concurrency', () {
+      for (final value in ['0', '-2', 'many', '1.5']) {
+        expect(
+          () => CiachConfig.parse('concurrency: $value', origin: 'c.yaml'),
+          throwsA(isFormatException('c.yaml', contains('positive integer'))),
+          reason: 'for concurrency: $value',
+        );
+      }
+    });
+  });
+
+  group('loadConfig', () {
+    late Directory tempDir;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('ciach_config_test_');
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    void write(String name, String content) =>
+        File(p.join(tempDir.path, name)).writeAsStringSync(content);
+
+    test('discovers ciach.yaml in the project directory', () {
+      write('ciach.yaml', 'public: false');
+
+      final loaded = loadConfig(projectDir: tempDir.path);
+
+      expect(loaded.path, p.join(tempDir.path, 'ciach.yaml'));
+      expect(loaded.config.public, isFalse);
+    });
+
+    test('discovers ciach.yml too, preferring ciach.yaml', () {
+      write('ciach.yml', 'format: json');
+
+      expect(loadConfig(projectDir: tempDir.path).config.format, 'json');
+
+      write('ciach.yaml', 'format: github');
+
+      expect(loadConfig(projectDir: tempDir.path).config.format, 'github');
+    });
+
+    test('returns an empty config when the directory has none', () {
+      final loaded = loadConfig(projectDir: tempDir.path);
+
+      expect(loaded.path, isNull);
+      expect(loaded.config.public, isNull);
+    });
+
+    test('does not look outside the project directory', () {
+      write('ciach.yaml', 'public: false');
+      final nested = Directory(p.join(tempDir.path, 'nested'))..createSync();
+
+      expect(loadConfig(projectDir: nested.path).path, isNull);
+    });
+
+    test('loads an explicit path from outside the project directory', () {
+      write('elsewhere.yaml', 'format: json');
+      final nested = Directory(p.join(tempDir.path, 'nested'))..createSync();
+
+      final loaded = loadConfig(
+        projectDir: nested.path,
+        explicitPath: p.join(tempDir.path, 'elsewhere.yaml'),
+      );
+
+      expect(loaded.config.format, 'json');
+    });
+
+    test('an explicit path wins over a discoverable file', () {
+      write('ciach.yaml', 'format: github');
+      write('other.yaml', 'format: json');
+
+      final loaded = loadConfig(
+        projectDir: tempDir.path,
+        explicitPath: p.join(tempDir.path, 'other.yaml'),
+      );
+
+      expect(loaded.config.format, 'json');
+    });
+
+    test('reports a missing explicit path', () {
+      expect(
+        () => loadConfig(
+          projectDir: tempDir.path,
+          explicitPath: p.join(tempDir.path, 'nope.yaml'),
+        ),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('Config file does not exist'),
+          ),
+        ),
+      );
+    });
+
+    test('ignore skips discovery entirely', () {
+      write('ciach.yaml', 'public: false');
+
+      final loaded = loadConfig(projectDir: tempDir.path, ignore: true);
+
+      expect(loaded.path, isNull);
+      expect(loaded.config.public, isNull);
+    });
+
+    test('ignore skips an explicit path, and its would-be errors', () {
+      final loaded = loadConfig(
+        projectDir: tempDir.path,
+        explicitPath: p.join(tempDir.path, 'nope.yaml'),
+        ignore: true,
+      );
+
+      expect(loaded.path, isNull);
+    });
+  });
+
+  group('resolveOptions', () {
+    test('falls back to the built-in defaults with no config and no args', () {
+      final resolved = resolve(const []);
+
+      expect(resolved.rootPath, '.');
+      expect(resolved.includePublic, isTrue);
+      expect(resolved.includeGenerated, isFalse);
+      expect(resolved.overrides, isFalse);
+      expect(resolved.operators, isFalse);
+      expect(resolved.unusedUnionMembers, isFalse);
+      expect(resolved.reportToJson, isFalse);
+      expect(resolved.setExitIfChanged, isFalse);
+      expect(resolved.remove, isFalse);
+      expect(resolved.force, isFalse);
+      expect(resolved.includeGlobs, isEmpty);
+      expect(resolved.excludeGlobs, isEmpty);
+      expect(resolved.additionalGeneratedSuffixes, isEmpty);
+      expect(resolved.kinds, FinderOptions.defaultKinds);
+      expect(resolved.format, 'text');
+      expect(resolved.concurrency, 16);
+      expect(resolved.dartExecutable, isNull);
+    });
+
+    test('takes config values when the command line is silent', () {
+      final resolved = resolve(
+        const [],
+        const CiachConfig(
+          path: 'packages/app',
+          public: false,
+          generated: true,
+          overrides: true,
+          operators: true,
+          unusedUnionMembers: true,
+          reportToJson: true,
+          setExitIfChanged: true,
+          remove: true,
+          force: true,
+          exclude: ['test/**'],
+          include: ['lib/**'],
+          generatedSuffix: ['.gc.dart'],
+          kinds: ['class'],
+          format: 'json',
+          color: true,
+          progress: true,
+          concurrency: 4,
+          dart: '/sdk/bin/dart',
+        ),
+      );
+
+      expect(resolved.rootPath, 'packages/app');
+      expect(resolved.includePublic, isFalse);
+      expect(resolved.includeGenerated, isTrue);
+      expect(resolved.overrides, isTrue);
+      expect(resolved.operators, isTrue);
+      expect(resolved.unusedUnionMembers, isTrue);
+      expect(resolved.reportToJson, isTrue);
+      expect(resolved.setExitIfChanged, isTrue);
+      expect(resolved.remove, isTrue);
+      expect(resolved.force, isTrue);
+      expect(resolved.excludeGlobs, ['test/**']);
+      expect(resolved.includeGlobs, ['lib/**']);
+      expect(resolved.additionalGeneratedSuffixes, ['.gc.dart']);
+      expect(resolved.kinds, {SymbolKind.class$});
+      expect(resolved.format, 'json');
+      expect(resolved.useColor, isTrue);
+      expect(resolved.showProgress, isTrue);
+      expect(resolved.concurrency, 4);
+      expect(resolved.dartExecutable, '/sdk/bin/dart');
+    });
+
+    test('command-line flags override the config', () {
+      const config = CiachConfig(
+        path: 'packages/app',
+        public: false,
+        generated: true,
+        format: 'json',
+        color: false,
+        progress: false,
+        concurrency: 4,
+        dart: '/sdk/bin/dart',
+      );
+
+      final resolved = resolve(const [
+        '--public',
+        '--no-generated',
+        '--format',
+        'github',
+        '--color',
+        '--progress',
+        '--concurrency',
+        '2',
+        '--dart',
+        '/other/dart',
+        'packages/other',
+      ], config);
+
+      expect(resolved.rootPath, 'packages/other');
+      expect(resolved.includePublic, isTrue);
+      expect(resolved.includeGenerated, isFalse);
+      expect(resolved.format, 'github');
+      expect(resolved.useColor, isTrue);
+      expect(resolved.showProgress, isTrue);
+      expect(resolved.concurrency, 2);
+      expect(resolved.dartExecutable, '/other/dart');
+    });
+
+    test('a command-line list replaces the config list, not appends', () {
+      const config = CiachConfig(exclude: ['test/**'], kinds: ['class']);
+
+      final resolved = resolve(const ['-e', 'tool/**', '-k', 'method'], config);
+
+      expect(resolved.excludeGlobs, ['tool/**']);
+      expect(resolved.kinds, {SymbolKind.method});
+    });
+
+    test('repeated command-line values all survive', () {
+      final resolved = resolve(const [
+        '-e',
+        'test/**',
+        '-e',
+        'tool/**',
+        '--generated-suffix',
+        '.gc.dart',
+        '--generated-suffix',
+        '.pb.dart',
+      ]);
+
+      expect(resolved.excludeGlobs, ['test/**', 'tool/**']);
+      expect(resolved.additionalGeneratedSuffixes, ['.gc.dart', '.pb.dart']);
+    });
+
+    test('explicitly passing a flag at its default value still wins', () {
+      // --public matches the built-in default, so only `wasParsed` can tell it
+      // apart from an absent flag — and it has to, to beat `public: false`.
+      final resolved = resolve(const [
+        '--public',
+      ], const CiachConfig(public: false));
+
+      expect(resolved.includePublic, isTrue);
+    });
+
+    test('auto-detected color and progress are the last resort', () {
+      final auto = resolveOptions(
+        parser.parse(const []),
+        const CiachConfig(),
+        colorDefault: true,
+        progressDefault: true,
+      );
+      expect(auto.useColor, isTrue);
+      expect(auto.showProgress, isTrue);
+
+      final fromConfig = resolveOptions(
+        parser.parse(const []),
+        const CiachConfig(color: false, progress: false),
+        colorDefault: true,
+        progressDefault: true,
+      );
+      expect(fromConfig.useColor, isFalse);
+      expect(fromConfig.showProgress, isFalse);
+
+      final fromArgs = resolveOptions(
+        parser.parse(const ['--no-color', '--no-progress']),
+        const CiachConfig(color: true, progress: true),
+        colorDefault: true,
+        progressDefault: true,
+      );
+      expect(fromArgs.useColor, isFalse);
+      expect(fromArgs.showProgress, isFalse);
+    });
+
+    test('rejects a non-positive --concurrency', () {
+      for (final value in ['0', '-1', 'lots']) {
+        expect(
+          () => resolve(['--concurrency', value]),
+          throwsA(
+            isA<FormatException>().having(
+              (e) => e.message,
+              'message',
+              contains('--concurrency must be a positive integer'),
+            ),
+          ),
+          reason: 'for --concurrency $value',
+        );
+      }
+    });
+
+    test('rejects an unknown --kinds value', () {
+      expect(
+        () => resolve(const ['-k', 'klass']),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains("Unknown kind 'klass'"),
+          ),
+        ),
+      );
+    });
+  });
+}
+
+/// A [FormatException] whose message names [origin] and matches [message].
+Matcher isFormatException(String origin, Matcher message) =>
+    isA<FormatException>()
+        .having((e) => e.message, 'message', startsWith('$origin:'))
+        .having((e) => e.message, 'message', message);

--- a/test/verbose_test.dart
+++ b/test/verbose_test.dart
@@ -1,31 +1,28 @@
+import 'dart:io';
+
 import 'package:ciach/ciach.dart';
 import 'package:ciach/src/cli/args.dart';
 import 'package:ciach/src/cli/config.dart';
 import 'package:ciach/src/cli/options.dart';
 import 'package:ciach/src/cli/verbose.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 void main() {
   final parser = buildParser();
 
-  ResolvedOptions resolve(List<String> arguments, [CiachConfig? config]) =>
-      resolveOptions(
-        parser.parse(arguments),
-        config ?? const CiachConfig(),
-        colorDefault: false,
-        progressDefault: false,
-      );
-
   group('describeConfigSource', () {
     test('names the file it read and every option it set', () {
-      const config = CiachConfig(public: false, exclude: ['test/**']);
       final lines = describeConfigSource(
-        const LoadedConfig(config: config, path: '/pkg/ciach.yaml'),
+        ConfigFile.parse(
+          "public: false\nexclude: ['test/**']",
+          origin: '/c.yaml',
+        ),
         projectDir: '/pkg',
       );
 
       expect(lines, [
-        'Read config from /pkg/ciach.yaml.',
+        'Read config from /c.yaml.',
         '  It sets 2 options:',
         '    public: false',
         '    exclude: test/**',
@@ -34,7 +31,7 @@ void main() {
 
     test('says so when the file it read is empty', () {
       final lines = describeConfigSource(
-        const LoadedConfig(config: CiachConfig(), path: '/pkg/ciach.yaml'),
+        ConfigFile.parse('# nothing\n', origin: '/pkg/ciach.yaml'),
         projectDir: '/pkg',
       );
 
@@ -46,7 +43,7 @@ void main() {
 
     test('names the directory it searched when nothing was found', () {
       final lines = describeConfigSource(
-        const LoadedConfig(config: CiachConfig(), path: null),
+        const ConfigFile.empty(),
         projectDir: 'packages/app',
       );
 
@@ -56,28 +53,35 @@ void main() {
     });
 
     test('names the file it skipped for --no-config', () {
+      final dir = Directory.systemTemp.createTempSync('ciach_verbose_test_');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      File(p.join(dir.path, configFileName)).writeAsStringSync('public: false');
+
       final lines = describeConfigSource(
-        const LoadedConfig(
-          config: CiachConfig(),
-          path: '/pkg/ciach.yaml',
-          ignored: true,
-        ),
-        projectDir: '/pkg',
+        ConfigFile.load(projectDir: dir.path, ignore: true),
+        projectDir: dir.path,
       );
 
-      expect(lines, [
-        'Ignoring the config file /pkg/ciach.yaml (--no-config).',
-      ]);
+      final expected =
+          'Ignoring the config file ${p.join(dir.path, 'ciach.yaml')} '
+          '(--no-config).';
+      expect(lines, [expected]);
     });
 
     test('says --no-config changed nothing when there was no file', () {
+      final dir = Directory.systemTemp.createTempSync('ciach_verbose_test_');
+      addTearDown(() => dir.deleteSync(recursive: true));
+
       final lines = describeConfigSource(
-        const LoadedConfig(config: CiachConfig(), path: null, ignored: true),
-        projectDir: '/pkg',
+        ConfigFile.load(projectDir: dir.path, ignore: true),
+        projectDir: dir.path,
       );
 
       expect(lines, [
-        allOf(contains('--no-config'), contains('no ciach.yaml in /pkg')),
+        allOf(
+          contains('--no-config'),
+          contains('no ciach.yaml in ${dir.path}'),
+        ),
       ]);
     });
   });
@@ -85,8 +89,12 @@ void main() {
   group('describeSettings', () {
     List<String> describe([List<String> arguments = const []]) =>
         describeSettings(
-          resolve(arguments),
-          rootPath: '/pkg',
+          resolveOptions(
+            parser.parse(arguments),
+            const ConfigFile.empty(),
+            colorDefault: false,
+            progressDefault: false,
+          ),
           dartExecutable: '/sdk/bin/dart',
         );
 
@@ -100,7 +108,14 @@ void main() {
     });
 
     test('reports the resolved values, not the raw arguments', () {
-      final lines = describe(const ['--no-public', '-e', 'test/**', '-j', '4']);
+      final lines = describe(const [
+        '--no-public',
+        '-e',
+        'test/**',
+        '-j',
+        '4',
+        '/pkg',
+      ]);
 
       expect(lines, containsAll(<String>['  path: /pkg', '  public: false']));
       expect(lines, contains('  exclude: test/**'));

--- a/test/verbose_test.dart
+++ b/test/verbose_test.dart
@@ -1,0 +1,142 @@
+import 'package:ciach/ciach.dart';
+import 'package:ciach/src/cli/args.dart';
+import 'package:ciach/src/cli/config.dart';
+import 'package:ciach/src/cli/options.dart';
+import 'package:ciach/src/cli/verbose.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final parser = buildParser();
+
+  ResolvedOptions resolve(List<String> arguments, [CiachConfig? config]) =>
+      resolveOptions(
+        parser.parse(arguments),
+        config ?? const CiachConfig(),
+        colorDefault: false,
+        progressDefault: false,
+      );
+
+  group('describeConfigSource', () {
+    test('names the file it read and every option it set', () {
+      const config = CiachConfig(public: false, exclude: ['test/**']);
+      final lines = describeConfigSource(
+        const LoadedConfig(config: config, path: '/pkg/ciach.yaml'),
+        projectDir: '/pkg',
+      );
+
+      expect(lines, [
+        'Read config from /pkg/ciach.yaml.',
+        '  It sets 2 options:',
+        '    public: false',
+        '    exclude: test/**',
+      ]);
+    });
+
+    test('says so when the file it read is empty', () {
+      final lines = describeConfigSource(
+        const LoadedConfig(config: CiachConfig(), path: '/pkg/ciach.yaml'),
+        projectDir: '/pkg',
+      );
+
+      expect(lines, [
+        'Read config from /pkg/ciach.yaml.',
+        contains('It sets nothing'),
+      ]);
+    });
+
+    test('names the directory it searched when nothing was found', () {
+      final lines = describeConfigSource(
+        const LoadedConfig(config: CiachConfig(), path: null),
+        projectDir: 'packages/app',
+      );
+
+      expect(lines, [
+        allOf(contains('No ciach.yaml in packages/app'), contains('defaults')),
+      ]);
+    });
+
+    test('names the file it skipped for --no-config', () {
+      final lines = describeConfigSource(
+        const LoadedConfig(
+          config: CiachConfig(),
+          path: '/pkg/ciach.yaml',
+          ignored: true,
+        ),
+        projectDir: '/pkg',
+      );
+
+      expect(lines, [
+        'Ignoring the config file /pkg/ciach.yaml (--no-config).',
+      ]);
+    });
+
+    test('says --no-config changed nothing when there was no file', () {
+      final lines = describeConfigSource(
+        const LoadedConfig(config: CiachConfig(), path: null, ignored: true),
+        projectDir: '/pkg',
+      );
+
+      expect(lines, [
+        allOf(contains('--no-config'), contains('no ciach.yaml in /pkg')),
+      ]);
+    });
+  });
+
+  group('describeSettings', () {
+    List<String> describe([List<String> arguments = const []]) =>
+        describeSettings(
+          resolve(arguments),
+          rootPath: '/pkg',
+          dartExecutable: '/sdk/bin/dart',
+        );
+
+    test('lists every setting the run uses, under one key per option', () {
+      final lines = describe();
+
+      expect(lines.first, 'Settings for this run:');
+      final keys = lines.skip(1).map((l) => l.trim().split(':').first).toSet();
+      // `path` stands in for the positional argument, as in the config file.
+      expect(keys, configKeys);
+    });
+
+    test('reports the resolved values, not the raw arguments', () {
+      final lines = describe(const ['--no-public', '-e', 'test/**', '-j', '4']);
+
+      expect(lines, containsAll(<String>['  path: /pkg', '  public: false']));
+      expect(lines, contains('  exclude: test/**'));
+      expect(lines, contains('  concurrency: 4'));
+      expect(lines, contains('  dart: /sdk/bin/dart'));
+    });
+
+    test('marks an empty list rather than printing nothing', () {
+      expect(describe(), contains('  exclude: (none)'));
+      expect(describe(), contains('  include: (none)'));
+      expect(describe(), contains('  generated-suffix: (none)'));
+    });
+
+    test('flags the full kind set as such, and lists a restricted one', () {
+      expect(
+        describe().singleWhere((l) => l.startsWith('  kinds:')),
+        allOf(contains('class'), endsWith('(all)')),
+      );
+      expect(
+        describe(const [
+          '-k',
+          'class,method',
+        ]).singleWhere((l) => l.startsWith('  kinds:')),
+        '  kinds: class, method',
+      );
+    });
+
+    test('lists as many kinds as the finder defaults to', () {
+      final kinds = describe()
+          .singleWhere((l) => l.startsWith('  kinds:'))
+          .replaceFirst('  kinds: ', '')
+          .replaceFirst(' (all)', '')
+          .split(', ');
+
+      // Two aliases can map to one symbol kind, so labels can be fewer.
+      expect(kinds, hasLength(FinderOptions.defaultKinds.length));
+    });
+  });
+}

--- a/test/verbose_test.dart
+++ b/test/verbose_test.dart
@@ -86,16 +86,21 @@ void main() {
   });
 
   group('describeSettings', () {
-    List<String> describe([List<String> arguments = const []]) =>
-        describeSettings(
-          resolveOptions(
-            parser.parse(arguments),
-            const ConfigFile.empty(),
-            colorDefault: false,
-            progressDefault: false,
-          ),
-          dartExecutable: '/sdk/bin/dart',
-        );
+    List<String> describe([List<String> arguments = const []]) {
+      final configuration = resolveConfiguration(
+        parser.parse(arguments),
+        const ConfigFile.empty(),
+      );
+      return describeSettings(
+        configuration,
+        resolveOptions(
+          configuration,
+          colorDefault: false,
+          progressDefault: false,
+        ),
+        dartExecutable: '/sdk/bin/dart',
+      );
+    }
 
     test('lists every setting the run uses, under one key per option', () {
       final lines = describe();
@@ -116,41 +121,57 @@ void main() {
         '/pkg',
       ]);
 
-      expect(lines, containsAll(<String>['  path: /pkg', '  public: false']));
-      expect(lines, contains('  exclude: test/**'));
-      expect(lines, contains('  concurrency: 4'));
-      expect(lines, contains('  dart: /sdk/bin/dart'));
+      expect(lines, containsAll(<String>['  path: /pkg (command line)']));
+      expect(lines, contains('  public: false (command line)'));
+      expect(lines, contains('  exclude: test/** (command line)'));
+      expect(lines, contains('  concurrency: 4 (command line)'));
+      expect(lines, contains('  dart: /sdk/bin/dart (auto-detected)'));
+    });
+
+    test('names the layer each value came from', () {
+      final configuration = resolveConfiguration(
+        parser.parse(const ['--no-public']),
+        ConfigFile.parse('format: json\nremove: true', origin: 'c.yaml'),
+      );
+      final lines = describeSettings(
+        configuration,
+        resolveOptions(
+          configuration,
+          colorDefault: false,
+          progressDefault: false,
+        ),
+        dartExecutable: '/sdk/bin/dart',
+      );
+
+      expect(lines, contains('  public: false (command line)'));
+      expect(lines, contains('  format: json (config file)'));
+      expect(lines, contains('  remove: true (config file)'));
+      expect(lines, contains('  concurrency: 16 (default)'));
+      expect(lines, contains('  color: false (auto-detected)'));
     });
 
     test('marks an empty list rather than printing nothing', () {
-      expect(describe(), contains('  exclude: (none)'));
-      expect(describe(), contains('  include: (none)'));
-      expect(describe(), contains('  generated-suffix: (none)'));
+      expect(describe(), contains('  exclude: (none) (default)'));
+      expect(describe(), contains('  include: (none) (default)'));
+      expect(describe(), contains('  generated-suffix: (none) (default)'));
     });
 
-    test('flags the full kind set as such, and lists a restricted one', () {
-      expect(
-        describe().singleWhere((l) => l.startsWith('  kinds:')),
-        allOf(contains('class'), endsWith('(all)')),
-      );
+    test('lists the kinds, all of them by default', () {
+      final kinds = describe()
+          .singleWhere((l) => l.startsWith('  kinds:'))
+          .replaceFirst('  kinds: ', '')
+          .replaceFirst(' (default)', '')
+          .split(', ');
+
+      // Two aliases can map to one symbol kind, so labels can be fewer.
+      expect(kinds, hasLength(FinderOptions.defaultKinds.length));
       expect(
         describe(const [
           '-k',
           'class,method',
         ]).singleWhere((l) => l.startsWith('  kinds:')),
-        '  kinds: class, method',
+        '  kinds: class, method (command line)',
       );
-    });
-
-    test('lists as many kinds as the finder defaults to', () {
-      final kinds = describe()
-          .singleWhere((l) => l.startsWith('  kinds:'))
-          .replaceFirst('  kinds: ', '')
-          .replaceFirst(' (all)', '')
-          .split(', ');
-
-      // Two aliases can map to one symbol kind, so labels can be fewer.
-      expect(kinds, hasLength(FinderOptions.defaultKinds.length));
     });
   });
 }

--- a/test/verbose_test.dart
+++ b/test/verbose_test.dart
@@ -62,10 +62,9 @@ void main() {
         projectDir: dir.path,
       );
 
-      final expected =
-          'Ignoring the config file ${p.join(dir.path, 'ciach.yaml')} '
-          '(--no-config).';
-      expect(lines, [expected]);
+      expect(lines, [
+        'Ignoring the config file ${p.join(dir.path, 'ciach.yaml')} (--no-config).',
+      ]);
     });
 
     test('says --no-config changed nothing when there was no file', () {

--- a/test/verbose_test.dart
+++ b/test/verbose_test.dart
@@ -14,10 +14,7 @@ void main() {
   group('describeConfigSource', () {
     test('names the file it read and every option it set', () {
       final lines = describeConfigSource(
-        ConfigFile.parse(
-          "public: false\nexclude: ['test/**']",
-          origin: '/c.yaml',
-        ),
+        .parse("public: false\nexclude: ['test/**']", origin: '/c.yaml'),
         projectDir: '/pkg',
       );
 
@@ -31,7 +28,7 @@ void main() {
 
     test('says so when the file it read is empty', () {
       final lines = describeConfigSource(
-        ConfigFile.parse('# nothing\n', origin: '/pkg/ciach.yaml'),
+        .parse('# nothing\n', origin: '/pkg/ciach.yaml'),
         projectDir: '/pkg',
       );
 
@@ -43,7 +40,7 @@ void main() {
 
     test('names the directory it searched when nothing was found', () {
       final lines = describeConfigSource(
-        const ConfigFile.empty(),
+        const .empty(),
         projectDir: 'packages/app',
       );
 
@@ -58,7 +55,7 @@ void main() {
       File(p.join(dir.path, configFileName)).writeAsStringSync('public: false');
 
       final lines = describeConfigSource(
-        ConfigFile.load(projectDir: dir.path, ignore: true),
+        .load(projectDir: dir.path, ignore: true),
         projectDir: dir.path,
       );
 
@@ -72,7 +69,7 @@ void main() {
       addTearDown(() => dir.deleteSync(recursive: true));
 
       final lines = describeConfigSource(
-        ConfigFile.load(projectDir: dir.path, ignore: true),
+        .load(projectDir: dir.path, ignore: true),
         projectDir: dir.path,
       );
 
@@ -89,7 +86,7 @@ void main() {
     List<String> describe([List<String> arguments = const []]) {
       final configuration = resolveConfiguration(
         parser.parse(arguments),
-        const ConfigFile.empty(),
+        const .empty(),
       );
       return describeSettings(
         configuration,
@@ -131,7 +128,7 @@ void main() {
     test('names the layer each value came from', () {
       final configuration = resolveConfiguration(
         parser.parse(const ['--no-public']),
-        ConfigFile.parse('format: json\nremove: true', origin: 'c.yaml'),
+        .parse('format: json\nremove: true', origin: 'c.yaml'),
       );
       final lines = describeSettings(
         configuration,
@@ -163,7 +160,7 @@ void main() {
           .replaceFirst(' (default)', '')
           .split(', ');
 
-      // Two aliases can map to one symbol kind, so labels can be fewer.
+      // Two aliases can map to one kind, so labels can be fewer.
       expect(kinds, hasLength(FinderOptions.defaultKinds.length));
       expect(
         describe(const [


### PR DESCRIPTION
Every command-line option can now be set in a `ciach.yaml`, and `-v` explains what a run is doing.

## Config file

`ciach.yaml` in the analyzed package root, discovered automatically. Keys are the long option names minus the `--`, plus `path` for the positional argument:

```yaml
public: false                     # --no-public
exclude: ['test/**', 'tool/**']   # repeatable options take a list, or a bare string
kinds: [class, function, method]
format: github
set-exit-if-changed: true
```

- **Precedence** is command line > config file > built-in default. An explicitly passed flag wins even when its value equals the default (`ciach --public` beats `public: false`), and a repeatable option on the command line *replaces* the config's list rather than appending.
- **Discovery** looks for that one file name in the package root only — no walking up to parents, so each package in a monorepo owns its config. `--config <path>` reads a file from anywhere else; `--no-config` ignores a discovered one (combining the two is a usage error).
- **Errors** name the file and the offending key: unknown keys (with the valid list), wrong-typed values, bad `format`/`kinds`, non-positive `concurrency`. Exit code 2, as with any usage error.
- A test asserts every long option name has a matching config key, so the two can't drift.

## `-v, --verbose`

Narrates the run on stderr with elapsed-time stamps: which config file was read and what it set, the settings the run resolved to, each scan phase, the scan summary, and what `--remove` touches.

```console
$ ciach -v
[  0.0s] Read config from ciach.yaml.
[  0.0s]   It sets 2 options:
[  0.0s]     public: false
[  0.0s]     exclude: test/**
[  0.0s] Settings for this run:
[  0.0s]   path: /home/me/pkg
…
[  0.1s] Starting Dart analysis server…
[  0.3s] Collecting declarations from 13 file(s)…
[  0.5s] Scanned 13 file(s) and checked 44 declaration(s) in 478ms: 4 unused, 1 referenced only from doc comments.
```

Everything goes to stderr, so `ciach -v -f json | jq` still works. It supersedes `--progress`, whose self-overwriting line would fight with it. Settable in the config as `verbose: true`, like everything else.

## Structure

- `lib/src/cli/config.dart` — `ConfigFile`: the validated settings a file holds, where they came from, whether it was skipped, and typed readers that name the file and key on a mismatch. Deliberately not a field per option: the options are declared once in `buildParser`, and `resolveOptions` is the one place that reads them all.
- `lib/src/cli/options.dart` — `ResolvedOptions` + `resolveOptions`, the single place the three layers merge, and the last type that knows where a setting came from. Also owns `finderOptions()`, so mapping to the library's `FinderOptions` lives with the fields rather than in `bin/`.
- `lib/src/cli/verbose.dart` — the two message builders, as pure functions returning lines; `bin/` only owns the stderr printer.
- `FinderOptions` is untouched — it's the public library API, and CLI-only settings don't belong there.

Config values are validated on read, so `resolveOptions` reads every key *before* deciding whether to use it — otherwise a typo would go unreported whenever the command line overrode that same option. A test pins this for all twenty keys; it caught one real hole where `!verbose && flag('progress', …)` short-circuited past the `progress` read.

## Also

- Adds `yaml: ^3.1.3` (SDK `^3.4.0`, so the Dart 3.10 floor check is unaffected).
- README trimmed from 446 lines to 309 while documenting both features — the options table still matches `--help` exactly.

## Testing

`dart analyze`, `dart format --set-exit-if-changed` and `dart test` (131 tests, 47 of them new) all pass. The CLI was also exercised end to end against `example/`: discovery, command-line override, `--no-config`, `path:` from a config, each error message, `-f github` path prefixing, and a config-driven `--remove --force` run in a scratch copy.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P3RUEZG2oA6YmmSLyRrGgC)_