### PR TITLE
Report the pana score as an informational check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,8 @@ jobs:
         id: score
         continue-on-error: true
         run: |
-          pana --json . > "$RUNNER_TEMP/pana.json"
+          set -o pipefail # so tee doesn't mask a pana that fell over
+          pana --json . | tee "$RUNNER_TEMP/pana.json"
 
           granted=$(jq '.scores.grantedPoints' "$RUNNER_TEMP/pana.json")
           max=$(jq '.scores.maxPoints' "$RUNNER_TEMP/pana.json")

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,11 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      id-token: write
+      statuses: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -38,6 +43,79 @@ jobs:
         uses: leancodepl/mobile-tools/.github/actions/pub-release@0bfd6b4b187d1b99fb2cd5e0e6ea4d626837005f # pub-release-v1
         with:
           dry-run: true
+
+      # Informational: keep the `pana` status out of the required checks. It
+      # carries the verdict, so nothing below fails this job.
+      - name: Set up the latest stable Dart for pana
+        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
+        with:
+          sdk: stable # the score has to be the one pub.dev will give
+
+      - name: Install pana
+        run: dart pub global activate pana
+
+      - name: Score the package
+        id: score
+        continue-on-error: true
+        run: |
+          pana --json . > "$RUNNER_TEMP/pana.json"
+
+          granted=$(jq '.scores.grantedPoints' "$RUNNER_TEMP/pana.json")
+          max=$(jq '.scores.maxPoints' "$RUNNER_TEMP/pana.json")
+
+          # Two nulls would compare equal and read as a full score.
+          case "$granted$max" in
+            '' | *[!0-9]*)
+              echo "::error title=pana score::no score in pana's JSON report"
+              exit 1
+              ;;
+          esac
+
+          echo "score=$granted/$max" >> "$GITHUB_OUTPUT"
+          if [ "$granted" = "$max" ]; then
+            echo 'state=success' >> "$GITHUB_OUTPUT"
+          else
+            echo 'state=failure' >> "$GITHUB_OUTPUT"
+          fi
+
+          {
+            echo "## pana score: $granted/$max"
+            echo
+            jq -r '.report.sections[]
+              | "- \(if .grantedPoints == .maxPoints then ":white_check_mark:" else ":x:" end) \(.title): \(.grantedPoints)/\(.maxPoints)"' \
+              "$RUNNER_TEMP/pana.json"
+
+            if [ "$granted" != "$max" ]; then
+              echo
+              echo '<details><summary>Deductions</summary>'
+              echo
+              jq -r '.report.sections[]
+                | select(.grantedPoints < .maxPoints)
+                | .summary' "$RUNNER_TEMP/pana.json"
+              echo
+              echo '</details>'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report the score
+        continue-on-error: true
+        # A fork's token can't write statuses.
+        if: |
+          always() && (github.event_name != 'pull_request' ||
+            github.event.pull_request.head.repo.full_name == github.repository)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # The pull request head, not the merge commit `github.sha` names.
+          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          STATE: ${{ steps.score.outputs.state || 'error' }}
+          SCORE: ${{ steps.score.outputs.score || 'pana produced no score' }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/statuses/$SHA" \
+            --silent \
+            -f state="$STATE" \
+            -f context='pana' \
+            -f description="$SCORE" \
+            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
   verify-sdk-floor:
     name: Verify Dart 3.10 floor

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,8 +58,8 @@ jobs:
         id: score
         continue-on-error: true
         run: |
-          set -o pipefail # so tee doesn't mask a pana that fell over
-          pana --json . | tee "$RUNNER_TEMP/pana.json"
+          set -euo pipefail # so tee doesn't mask a pana that fell over
+          pana --json . | tee "$RUNNER_TEMP/pana.json" || true
 
           granted=$(jq '.scores.grantedPoints' "$RUNNER_TEMP/pana.json")
           max=$(jq '.scores.maxPoints' "$RUNNER_TEMP/pana.json")

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 .dart_tool/
 .idea/
 pubspec.lock
+
+# FVM Version Cache
+.fvm/
+
+.DS_Store


### PR DESCRIPTION
Split out of #27, where this started life.

Runs pana at the end of the `test` job and publishes the score as a `pana` commit status, so a pull request lists it among its checks:

```
✓ pana — 160/160
```

The status is `success` only at full points, `failure` on anything less, and `error` if pana produced no score at all. The run's step summary lists every section's points, with pana's own explanation for any that were docked folded underneath:

```
## pana score: 150/160

- ✅ Follow Dart file conventions: 30/30
- ❌ Provide documentation: 0/10
- ✅ Platform support: 20/20
- ✅ Pass static analysis: 50/50
- ✅ Support up-to-date dependencies: 40/40

<details><summary>Deductions</summary>
### [x] 0/10 points: 20% or more of the public API has dartdoc comments
…
</details>
```

## Informational

**Leave `pana` out of the branch protection required checks.** Nothing about the score can fail the `test` job — both steps are `continue-on-error`, and the status is what carries the verdict. That way a dropped score is visible on the pull request without standing in the way of it.

It lives in the `test` job rather than one of its own because every job mints its own check row, which would list the same thing twice.

## Notes

- pana is unpinned and gets `stable` rather than the `3.12` the job pins: it is the same tool pub.dev scores with, so the number has to be the one the package will be given. The cost is that a new pana or SDK release can turn the status red on an unrelated pull request — which is the news this check exists to deliver.
- The `test` job needed a `permissions` block for the status write. Since declaring one resets everything unlisted to `none`, it also spells out what the existing steps had implicitly: `contents: read` for the checkout and `id-token: write` for the publish dry run. **Worth a look** — if that action needs more than I assumed, the dry-run step is what will say so.
- The status attaches to the pull request's head rather than the merge commit `github.sha` names, and is skipped for a fork's read-only token.
- pana adds roughly 2–3 minutes to the job, dartdoc included.

## Testing

The scoring script was run against real `pana --json` output for three cases — full score, a synthesized 150/160, and a report with no `scores` field — checking the step outputs, the summary, and the exit status each time. That last case is why the guard is there: `granted` and `max` would both be `null`, compare equal, and report a false full score.

The `gh api` call gets its first real run on this pull request.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P3RUEZG2oA6YmmSLyRrGgC)_