### PR TITLE
Add YAML config file support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     tags-ignore: ['v*']
   pull_request:
-    branches: [main]
 
 jobs:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Add config file support: any option can be set in a `ciach.yaml` in the
+  package root, and the command line overrides it. `--config <path>` reads one
+  from elsewhere, `--no-config` ignores it.
 - Fix a comment mentioning `@override` or `vm:entry-point` skipping the declaration below it. ([#29](https://github.com/leancodepl/ciach/pull/29))
 - Add a secondary `textDocument/definition` check for zero-reference
   declarations, so valid uses the reference search misses no longer produce

--- a/README.md
+++ b/README.md
@@ -20,64 +20,39 @@ AI-Provenance:
 [![Test status][test-badge]][test-badge-link]
 [![License: Apache 2.0][license-badge]][license-badge-link]
 
-**Dead code detector and unused code finder for Dart and Flutter.** Finds
-**unused (never-referenced) declarations** — classes, functions, methods,
-fields, constants, enum values, and so on — in a Dart or Flutter package, and
+**Dead code detector for Dart and Flutter.** Finds declarations that are never
+referenced — classes, functions, methods, fields, constants, enum values — and
 can remove them for you.
 
-### About the name
-
 *"Ciach!"* — pronounced **/t͡ɕax/** — is Polish for the sound of a clean chop,
-the noise a knife makes right before something falls off. Fitting, since
-that's exactly what this tool finds for you: dead code, waiting to be cut.
+the noise a knife makes right before something falls off.
 
 ## Installation
 
-There are two ways to get the `ciach` command, depending on how you want to
-run it:
+Install it globally for a `ciach` command everywhere, in `~/.pub-cache/bin`:
 
-- **Global activation** — a single `ciach` command available everywhere,
-  independent of any particular project:
+```bash
+dart pub global activate ciach
+```
 
-  ```bash
-  dart pub global activate ciach
-  ciach
-  ```
+Or add it as a dev dependency, which pins the version for the team and CI:
 
-  This puts `ciach` in `~/.pub-cache/bin`; add that to your `PATH` if
-  `dart pub global activate` warns that it isn't there already.
+```bash
+dart pub add --dev ciach
+dart run ciach
+```
 
-- **As a dev dependency** — pinned per-project, so everyone on the team (and
-  CI) uses the same version:
-
-  ```bash
-  dart pub add --dev ciach
-  dart run ciach
-  ```
-
-The rest of this README shows bare `ciach …` commands; prefix them with
-`dart run` if you installed it as a dev dependency instead of globally.
+Examples below show bare `ciach …`; prefix them with `dart run` for the second.
 
 ## Usage
 
 ```bash
-# Scan the current package
-ciach
-
-# Scan a specific package
-ciach path/to/package
-
-# Only the highest-confidence dead code (private, never-referenced), as JSON
-ciach --no-public -f json
-
-# GitHub Actions annotations; fail the job if anything is found
-ciach -f github --set-exit-if-changed
-
-# Remove what's found, after confirming
-ciach --remove
-
-# Remove without asking (e.g. from a script)
-ciach --remove --force
+ciach                                  # scan the current package
+ciach path/to/package                  # scan another package
+ciach --no-public -f json              # private-only (highest confidence), as JSON
+ciach -f github --set-exit-if-changed  # CI: annotations, non-zero if anything is found
+ciach --remove                         # delete the findings, after confirming
+ciach --remove --force                 # …without asking
 ```
 
 ### Options
@@ -86,6 +61,8 @@ ciach --remove --force
 | --- | --- | --- |
 | `[path]` | `.` | Package root to analyze. |
 | `-h, --help` | — | Print usage information. |
+| `--config <path>` | auto | Read settings from this YAML file instead of the auto-discovered one. See [Configuration file](#configuration-file). |
+| `--no-config` | off | Ignore the config file, even if one is found. |
 | `--[no-]public` | on | Report unused public declarations too. Disable to report only private (`_`-prefixed) ones. |
 | `--[no-]generated` | off | Scan generated files (`*.g.dart`, `*.freezed.dart`, `*.mocks.dart`, …). |
 | `--[no-]overrides` | off | Report `@override` members too. Off by default — see limitations. |
@@ -108,170 +85,135 @@ ciach --remove --force
 Exit codes: `0` success, `1` unused found with `--set-exit-if-changed`, `2`
 usage or analysis error.
 
+### Configuration file
+
+Every option above can live in a `ciach.yaml` in the package root, keyed by its
+long name minus the `--`, plus `path` for the positional argument:
+
+```yaml
+public: false                     # --no-public
+exclude: ['test/**', 'tool/**']   # repeatable options take a list, or a bare string
+kinds: [class, function, method]
+format: github
+set-exit-if-changed: true
+```
+
+Command line beats config file beats default, even when the flag matches the
+default (`ciach --public` overrides `public: false`), and a repeatable option on
+the command line replaces the config's list rather than adding to it. Unknown
+keys and wrong-typed values are usage errors naming the file and the key.
+
+Discovery looks for that one file name in the analyzed package root, never in a
+parent, so each package in a monorepo owns its config. `--config <path>` reads
+one from elsewhere; `--no-config` ignores a discovered one; the two can't be
+combined.
+
 ### Doc-only findings
 
-A dartdoc `[Xxx]` comment link resolves to a real declaration, so the
-analysis server counts it as a reference — but "someone linked to this in a
-comment" isn't the same confidence level as "something actually calls this".
-Declarations with no *code* references, only a comment link, are reported
-separately as **doc-only**, in every format:
+A dartdoc `[Xxx]` link resolves to a real declaration, so the analysis server
+counts it as a reference — but a comment mentioning something isn't the same as
+code calling it. Declarations with no *code* references are reported separately,
+in every format:
 
 ```
-$ ciach
 lib/greeting.dart
   15:6  function  danglingFunction  (public)
 
 Referenced only from doc comments — not counted as unused, never removed:
 lib/greeting.dart
   40:6  function  docOnlyMentioned  (public)
-
-Found 1 unused declaration in 1 file (scanned 6 files, 44 declarations, 0.5s). 1 more referenced only from doc comments.
 ```
 
-Doc-only findings are informational: they never count toward
-`--set-exit-if-changed`, are never touched by `--remove`, and get a `::notice`
-(not `::warning`) in `-f github` output. If one really is dead code, remove
-its doc comment link (or the comment itself) and re-run to have it reported
-as properly unused.
+These never count toward `--set-exit-if-changed`, are never touched by
+`--remove`, and get a `::notice` rather than a `::warning` in `-f github`. Drop
+the doc link to have one reported as properly unused.
 
 ### GitHub Actions
-
-Add `ciach` as a dev dependency (see [Installation](#installation)) so the
-version is pinned and `dart pub get` is all the setup CI needs:
 
 ```yaml
 - run: dart pub get
 - run: dart run ciach -f github --set-exit-if-changed
 ```
 
-Each finding becomes a `::warning` annotation shown inline on the PR diff. Run
-it from the repository root so annotation paths resolve; when scanning a
-sub-package (e.g. `ciach -f github app`), the scan path is
-prepended automatically so annotations still point at the right files.
+Each finding becomes a `::warning` annotation inline on the PR diff. Run it from
+the repository root so paths resolve; when scanning a sub-package (`ciach -f
+github app`), the scan path is prepended automatically.
 
 ### Removing declarations
 
-`--remove` deletes every reported declaration from source — its doc comment
-and annotations included — after showing what it's about to remove and asking
-for confirmation:
+`--remove` deletes every reported declaration — doc comment and annotations
+included — after showing what it is about to remove and asking:
 
 ```
-$ ciach --remove
-lib/greeting.dart
-  15:6  function  danglingFunction  (public)
-...
 Found 4 unused declarations in 2 files (scanned 6 files, 44 declarations, 0.5s).
 Remove 4 unused declarations? [y/N] y
 Removed 4 unused declarations from 2 files.
 ```
 
-`--remove --force` skips the prompt; use it in a script once you're confident
-in the results (`--force` on its own, without `--remove`, is a usage error).
-Without a terminal to confirm on (e.g. piped into another program) and
-without `--force`, nothing is removed.
+`--force` skips the prompt (and is a usage error on its own); with no terminal to
+confirm on and no `--force`, nothing is removed. Run `dart format` afterward:
+removal is conservative about *what* it deletes — an ambiguous `int a = 1, b = 2;`
+is left alone unless every declarator is unused — but not about spacing.
 
-Run `dart format` afterward — removal is conservative about *what* to delete
-(it leaves ambiguous multi-variable statements like `int a = 1, b = 2;`
-alone unless every declarator in them is unused) but not about spacing, so
-expect the odd extra blank line.
-
-Because removal acts on whatever the finder reports, it inherits the same
-false-positive risk as the report itself (see [What it skips by
-default](#what-it-skips-by-default) and [Limitations](#limitations) below) —
-enabling `--overrides` or `--operators` widens that risk considerably.
-[Doc-only findings](#doc-only-findings) are never included, regardless of
-those flags. Review the diff (or your test suite) after removing, the same as
+Removal acts on whatever the finder reports, so it inherits the same
+false-positive risk, which `--overrides` and `--operators` widen considerably.
+[Doc-only findings](#doc-only-findings) are never included. Review the diff, as
 you would after any automated refactor.
 
 ## What it skips by default
 
-These are all off by default because they're known sources of false
-positives — a used declaration reported as unused. Each has a flag to opt
-back in, at the cost of reintroducing that risk:
+Each of these is a known source of false positives; the flag opts back in at
+that cost.
 
-- **`main`** — the program entry point. Always skipped; there's no flag for
-  this one.
-- **`@override` members** — they are frequently reached polymorphically or by a
-  framework (Flutter's `build`, `initState`, `dispose`, `toString`, `==`, …),
-  which a name-based reference search can miss. Use `--overrides` to include
-  them.
-- **Operator overloads** (`operator +`, `operator ==`, …) — the analysis
-  server's reference search does not resolve infix operator syntax (`a + b`)
-  back to the operator's declaration, so a used operator is reported as
-  unused every time. See `example/lib/extensions.dart`. Use `--operators` to
-  include them.
-- **`call` methods** — a `call` method makes its object callable via
-  implicit-call syntax (`obj(...)`), which the reference search can't resolve
-  back to the declaration, the same way it can't resolve infix operators. A
-  used `call` method would be reported as unused every time. Always skipped;
-  there's no flag for this one. See `example/lib/callables.dart`.
-- **`@pragma('vm:entry-point')`** — reachable from native code / reflection.
-- **Generated files** — by filename convention and the
-  `GENERATED CODE - DO NOT MODIFY BY HAND` banner. Use `--generated` to include.
-  Even when excluded from the scan, they are still opened while analyzing, so a
-  declaration referenced *only* from generated code (e.g. a `toJson` called
-  from a `.g.dart` part) is not misreported as unused.
-- **`type parameters`** and non-declaration symbols.
+| Skipped | Why | Flag |
+| --- | --- | --- |
+| `main` | the entry point is never unused | — |
+| `@override` members | often reached polymorphically or by a framework (`build`, `initState`, `==`, …), which a name-based search misses | `--overrides` |
+| Operator overloads | the server doesn't resolve `a + b` back to the declaration, so a used operator is flagged every time | `--operators` |
+| `call` methods | implicit-call syntax (`obj(…)`) is unresolvable the same way | — |
+| `@pragma('vm:entry-point')` | reachable from native code or reflection | — |
+| Generated files | by filename convention and the `GENERATED CODE - DO NOT MODIFY BY HAND` banner. Still opened during analysis, so a declaration used only from a `.g.dart` isn't misreported | `--generated` |
+| `toJson()` | `jsonEncode(obj)` calls it by dynamic dispatch, leaving no source-level reference | `--report-tojson` |
+| Type parameters | always "used" within their scope | — |
+| dartdoc `[Xxx]` links | not a code reference; reported as [doc-only](#doc-only-findings) instead of hidden | — |
 
-**Private constructors are *not* skipped.** An unused `ClassName._` is dead code
-like any other and is reported (and removed by `--remove`). When it's the sole,
-zero-parameter `ClassName._()` — the classic prevent-instantiation marker — the
-finding carries a hint suggesting `abstract final class`, the idiomatic way to
-make a static-only class non-instantiable. See `example/lib/private_ctors.dart`.
-
-**dartdoc `[Xxx]` reference links** are a related wrinkle, handled a bit
-differently: a link resolves to a real declaration, so the analysis server
-counts it as a reference, which would otherwise hide genuinely dead code
-(e.g. `/// See [Dog.sound]` would keep `Dog.sound` looking used). Rather than
-a flag, these get their own always-on category — see [Doc-only
-findings](#doc-only-findings).
+Private constructors are **not** skipped: an unused `ClassName._` is dead code
+like any other. A sole zero-parameter `ClassName._()` — the classic
+prevent-instantiation marker — is reported with a hint suggesting `abstract final
+class` instead. See [example/](example) for a runnable demonstration of each case.
 
 ## Limitations
 
-This is a static, reference-based heuristic. Expect to review its output rather
-than delete blindly:
+This is a static, reference-based heuristic, so review its output rather than
+deleting blindly:
 
-- **Public API of a library package** is legitimately "unused" from the
-  package's own perspective. Prefer `--no-public` for library packages, or treat
-  public findings as advisory.
-- **Reflection / dynamic invocation / serialization** (e.g. `dart:mirrors`,
-  code that is only referenced by name in generated code you excluded) is not
-  visible to a reference search.
-- **Entry points beyond `main`** (isolate entry points, plugin registrants) may
-  need excluding or annotating with `@pragma('vm:entry-point')`.
-- Results are only as good as the analysis: a package that does not analyze
-  cleanly (missing `pub get`, errors) may yield incomplete references.
+- **A library package's public API** is legitimately unused from inside the
+  package. Prefer `--no-public` there, or treat public findings as advisory.
+- **Reflection, dynamic invocation, and names referenced only from generated
+  code you excluded** are invisible to a reference search.
+- **Entry points other than `main`** (isolate entry points, plugin registrants)
+  need excluding or `@pragma('vm:entry-point')`.
+- A package that doesn't analyze cleanly (missing `pub get`, errors) yields
+  incomplete references.
 
 ## Performance
 
-Runtime is dominated by the analysis server, not the tool. Two phases matter:
+Runtime is the analysis server's, not the tool's. It analyzes the whole package
+once per run — tens of seconds for a large Flutter app, and unskippable, since
+incomplete analysis means wrong reference counts — then answers one
+`textDocument/references` per declaration through a pool of `-j` (default 16),
+with scanned files kept open so its resolved-unit cache stays warm.
 
-1. **Initial analysis** — the server analyzes the whole package (and, for a
-   Flutter app, the SDK/dependencies) once before any query. This is a fixed
-   per-run cost (tens of seconds for a large app) and cannot be skipped:
-   incomplete analysis would produce wrong reference counts.
-2. **Reference queries** — one `textDocument/references` per declaration.
-   Requests run through a global pool (`-j/--concurrency`, default 16) and the
-   scanned files are kept open so the server's resolved-unit cache stays warm.
-
-The biggest lever is **how much you ask**:
-
-- **`--no-public`** is by far the cheapest mode. Private declarations are
-  library-scoped, so the server only searches one library per query instead of
-  the whole workspace — often several times faster, and it surfaces the
-  highest-confidence dead code.
-- **`--include` / `--exclude`** to scan only the part of the tree you care
-  about — references are still counted from everywhere, so results stay correct.
-- **`-j`** to tune concurrency; the default (16) is near the point of
-  diminishing returns for the analysis server's internal parallelism.
-
-For repeated runs, compile once to skip the JIT warmup:
-`dart compile exe bin/ciach.dart -o ciach` — `dart pub global activate` already
-does this for you.
+The lever is how much you ask for. `--no-public` is by far the cheapest mode:
+private declarations are library-scoped, so each query searches one library
+instead of the whole workspace, and it surfaces the highest-confidence dead code
+anyway. `--include`/`--exclude` narrow the scan while still counting references
+from everywhere. `dart pub global activate` compiles ahead of time, so there's no
+JIT warmup per run.
 
 ## Library usage
 
-The tool also exposes a public API for running the finder programmatically:
+The finder is also available programmatically:
 
 ```dart
 import 'package:ciach/ciach.dart';
@@ -292,8 +234,7 @@ dart analyze
 dart test          # spins up a real analysis server against the example/ package
 ```
 
-The implementation lives under `lib/src/`; the CLI entry point is `bin/`. See
-[example/](example) for a runnable demonstration.
+The implementation lives under `lib/src/`; the CLI entry point is `bin/`.
 
 ## License
 

--- a/bin/ciach.dart
+++ b/bin/ciach.dart
@@ -13,7 +13,10 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:ciach/ciach.dart';
 import 'package:ciach/src/cli/args.dart';
+import 'package:ciach/src/cli/config.dart';
+import 'package:ciach/src/cli/options.dart';
 import 'package:ciach/src/reporter.dart';
+import 'package:config/config.dart';
 import 'package:path/path.dart' as p;
 
 Future<void> main(List<String> arguments) async {
@@ -41,75 +44,64 @@ Future<int> _run(List<String> arguments) async {
     return 0;
   }
 
-  final rest = args.rest;
-  if (rest.length > 1) {
-    stderr.writeln(
-      'Expected at most one path argument, got: ${rest.join(', ')}',
-    );
-    return 2;
-  }
-  final rootPath = rest.isEmpty ? '.' : rest.first;
-  final rootDir = Directory(rootPath);
-  if (!rootDir.existsSync()) {
-    stderr.writeln('Path does not exist: $rootPath');
+  final ignoreConfig = args.flag('no-config');
+  final explicitConfig = args.option('config');
+  if (ignoreConfig && explicitConfig != null) {
+    stderr.writeln('--config cannot be combined with --no-config.');
     return 2;
   }
 
-  if (args.flag('force') && !args.flag('remove')) {
-    stderr.writeln('--force requires --remove.');
-    return 2;
-  }
+  // The root named on the command line: a config file's own `path` can't decide
+  // where that file is read from.
+  final projectDir = args.rest.isEmpty ? '.' : args.rest.first;
 
-  final Set<SymbolKind> kinds;
+  final ResolvedOptions resolved;
   try {
-    kinds = parseKinds(args.multiOption('kinds'));
+    final config = ConfigFile.load(
+      projectDir: projectDir,
+      explicitPath: explicitConfig,
+      ignore: ignoreConfig,
+    );
+    final configuration = resolveConfiguration(args, config);
+    resolved = resolveOptions(
+      configuration,
+      colorDefault: stdout.supportsAnsiEscapes,
+      // Progress goes to stderr, so default it on only for a terminal.
+      progressDefault: stderr.hasTerminal,
+    );
+  } on UsageException catch (e) {
+    stderr.writeln(e.message);
+    return 2;
   } on FormatException catch (e) {
     stderr.writeln(e.message);
     return 2;
   }
 
-  // `allowed` on the option already rejects unknown values during parsing.
-  final format = args.option('format')!;
-
-  final useColor = args.wasParsed('color')
-      ? args.flag('color')
-      : stdout.supportsAnsiEscapes;
-  // Progress goes to stderr; default on only when it won't clutter a pipe.
-  final showProgress = args.wasParsed('progress')
-      ? args.flag('progress')
-      : stderr.hasTerminal;
-
-  final int concurrency;
-  try {
-    concurrency = int.parse(args.option('concurrency')!);
-    if (concurrency < 1) {
-      throw const FormatException();
-    }
-  } on FormatException {
-    stderr.writeln('--concurrency must be a positive integer.');
+  final rootDir = Directory(resolved.rootPath);
+  if (!rootDir.existsSync()) {
+    stderr.writeln('Path does not exist: ${resolved.rootPath}');
     return 2;
   }
 
-  final options = FinderOptions(
-    rootPath: rootDir.absolute.path,
-    includeGlobs: args.multiOption('include'),
-    excludeGlobs: args.multiOption('exclude'),
-    kinds: kinds,
-    includePublic: args.flag('public'),
-    includeGenerated: args.flag('generated'),
-    additionalGeneratedSuffixes: args.multiOption('generated-suffix'),
-    skipOverrides: !args.flag('overrides'),
-    skipOperators: !args.flag('operators'),
-    unusedUnionMembers: args.flag('unused-union-members'),
-    reportToJson: args.flag('report-tojson'),
-    concurrency: concurrency,
-    dartExecutable: args.option('dart'),
-    onProgress: showProgress ? _ProgressPrinter().update : null,
-  );
+  if (resolved.force && !resolved.remove) {
+    stderr.writeln(
+      'Skipping the removal prompt only makes sense when removing: --force (or `force: true`) requires --remove (or `remove: true`).',
+    );
+    return 2;
+  }
+
+  final format = resolved.format;
+  final useColor = resolved.useColor;
+  final showProgress = resolved.showProgress;
+  final rootPath = resolved.absoluteRootPath;
 
   final FinderResult result;
   try {
-    result = await Ciach(options).run();
+    result = await Ciach(
+      resolved.finderOptions(
+        onProgress: showProgress ? _ProgressPrinter().update : null,
+      ),
+    ).run();
   } on Object catch (e, st) {
     if (showProgress) {
       stderr.writeln();
@@ -128,12 +120,10 @@ Future<int> _run(List<String> arguments) async {
     case 'json':
       stdout.writeln(Reporter.json(result));
     case 'github':
-      // GitHub resolves annotation paths from the repo root; make the finding
-      // paths root-relative by prepending the scan root's path from here.
+      // GitHub resolves annotation paths from the repo root, so prepend the
+      // scan root's path from here.
       final prefix = p
-          .split(
-            p.relative(rootDir.absolute.path, from: Directory.current.path),
-          )
+          .split(p.relative(rootPath, from: Directory.current.path))
           .join('/');
       stdout.write(Reporter.github(result, pathPrefix: prefix));
     case _:
@@ -143,29 +133,29 @@ Future<int> _run(List<String> arguments) async {
       stderr.write(Reporter.warningsText(result));
   }
 
-  if (result.unused.isNotEmpty && args.flag('remove')) {
-    await _removeUnused(result, rootDir.absolute.path, args, format, useColor);
+  if (result.unused.isNotEmpty && resolved.remove) {
+    await _removeUnused(result, rootPath, resolved, format, useColor);
   }
 
-  if (result.unused.isNotEmpty && args.flag('set-exit-if-changed')) {
+  if (result.unused.isNotEmpty && resolved.setExitIfChanged) {
     return 1;
   }
   return 0;
 }
 
-/// Reports what would be removed, confirms unless [ArgResults.flag]
-/// `'force'` is set, and deletes the unused declarations from disk.
+/// Reports what would be removed, confirms unless [ResolvedOptions.force], and
+/// deletes the declarations from disk.
 Future<void> _removeUnused(
   FinderResult result,
   String rootPath,
-  ArgResults args,
+  ResolvedOptions resolved,
   String format,
   bool useColor,
 ) async {
   final count = result.unused.length;
   final plural = count == 1 ? '' : 's';
 
-  var proceed = args.flag('force');
+  var proceed = resolved.force;
   if (!proceed) {
     // The chosen --format may not be human-readable; show the findings
     // again so the confirmation prompt is never a shot in the dark.
@@ -174,8 +164,7 @@ Future<void> _removeUnused(
     }
     if (!stdin.hasTerminal) {
       stdout.writeln(
-        'Refusing to remove declarations without a terminal to confirm on; '
-        'pass --force to remove without asking.',
+        'Refusing to remove declarations without a terminal to confirm on; pass --force to remove without asking.',
       );
       return;
     }
@@ -193,12 +182,10 @@ Future<void> _removeUnused(
 
   final filesChanged = removeDeclarations(result.unused, rootPath);
   stdout.writeln(
-    'Removed $count unused declaration$plural from $filesChanged '
-    "file${filesChanged == 1 ? '' : 's'}. Run 'dart format' to tidy up spacing.",
+    "Removed $count unused declaration$plural from $filesChanged file${filesChanged == 1 ? '' : 's'}. Run 'dart format' to tidy up spacing.",
   );
-  // Surface any advisory hints (e.g. a removed prevent-instantiation
-  // constructor) once more, since removing the declaration also removes the
-  // reported line that carried the hint.
+  // Repeat any advisory hints: removing a declaration takes the reported line
+  // that carried its hint with it.
   final removedHints = result.unused
       .where((d) => !d.removalBlocked && d.hint != null)
       .map((d) => '${d.qualifiedName}: ${d.hint}')

--- a/lib/src/cli/args.dart
+++ b/lib/src/cli/args.dart
@@ -11,6 +11,7 @@
 import 'package:args/args.dart';
 import 'package:ciach/ciach.dart';
 import 'package:collection/collection.dart';
+import 'package:config/config.dart';
 
 /// Friendly `--kinds` names mapped to LSP symbol kinds.
 const kindAliases = <String, SymbolKind>{
@@ -34,6 +35,9 @@ const kindAliases = <String, SymbolKind>{
 /// The `--kinds` alias names, sorted, for help text and error messages.
 String get kindNames => kindAliases.keys.sorted().join(', ');
 
+/// The accepted `--format` values; the first one is the default.
+const formatNames = ['text', 'json', 'github'];
+
 /// Parses the `--kinds` values (comma-separated, repeatable) into symbol kinds,
 /// falling back to [FinderOptions.defaultKinds] when none are given.
 ///
@@ -54,144 +58,277 @@ Set<SymbolKind> parseKinds(List<String> raw) {
   };
 }
 
-/// Builds the CLI argument parser. Every flag and option ciach accepts is
-/// declared here, so adding one is a single-file change.
-ArgParser buildParser() => .new()
-  ..addFlag(
-    'help',
-    abbr: 'h',
-    negatable: false,
-    help: 'Print this usage information.',
-  )
-  ..addFlag(
-    'public',
-    defaultsTo: true,
-    help:
-        'Report unused public declarations too. Disable to report only\n'
-        'private (underscore-prefixed) declarations, which are the\n'
-        'highest-confidence dead code.',
-  )
-  ..addFlag(
-    'generated',
-    help: 'Scan generated files (*.g.dart, *.freezed.dart, …). Off by default.',
-  )
-  ..addFlag(
-    'overrides',
-    help:
-        'Report members annotated with @override too. Off by default,\n'
-        'since overrides are often reached polymorphically and a plain\n'
-        'reference search can miss those uses.',
-  )
-  ..addFlag(
-    'operators',
-    help:
-        'Report operator overloads (operator +, operator ==, …) too. Off\n'
-        'by default: the analysis server never resolves infix operator\n'
-        "syntax (a + b) back to the operator's declaration, so a used\n"
-        'operator is reported as unused every time.',
-  )
-  ..addFlag(
-    'unused-union-members',
-    help:
-        'Also flag a class whose only references are type patterns over its\n'
-        '(sealed) supertype — matched but never constructed. Off by default:\n'
-        'a `case Foo():` arm otherwise counts as a use. Report-only: these\n'
-        'findings are surfaced but --remove never deletes them or their\n'
-        'pattern arms (removing a sealed member and rewriting its switches\n'
-        'is left to a human). Conservative: any reference that is not clearly\n'
-        'a type pattern keeps the class alive.',
-  )
-  ..addFlag(
-    'report-tojson',
-    help:
-        'Report a `toJson()` serialization hook as unused too. Off by\n'
-        'default: `jsonEncode(obj)` calls `obj.toJson()` by dynamic dispatch\n'
-        'with no source-level `.toJson()` reference for the search to see, so\n'
-        'a live serializer would be flagged. Enable to audit dead `toJson`s.',
-  )
-  ..addFlag(
-    'set-exit-if-changed',
-    help:
-        'Exit with a non-zero status when any unused declaration is found\n'
-        '(useful in CI).',
-  )
-  ..addFlag(
-    'remove',
-    help:
-        'Remove unused declarations from source after reporting them.\n'
-        'Prompts for confirmation first, unless --force is also given.',
-  )
-  ..addFlag(
-    'force',
-    help: 'Skip the confirmation prompt for --remove. Requires --remove.',
-  )
-  ..addMultiOption(
-    'exclude',
-    abbr: 'e',
-    help: 'Glob(s), relative to the root, of files to skip. Repeatable.',
-    valueHelp: 'glob',
-  )
-  ..addMultiOption(
-    'include',
-    abbr: 'i',
-    help: 'If given, only scan files matching these glob(s). Repeatable.',
-    valueHelp: 'glob',
-  )
-  ..addMultiOption(
-    'generated-suffix',
-    help:
-        'Additional filename suffix to treat as generated (and so\n'
-        'exclude from the scan), on top of the built-in set (*.g.dart,\n'
-        '*.freezed.dart, …). Use for custom code generators, e.g.\n'
-        '--generated-suffix .gc.dart. Include the leading dot. Repeatable.\n'
-        'Ignored when --generated is set.',
-    valueHelp: 'suffix',
-  )
-  ..addMultiOption(
-    'kinds',
-    abbr: 'k',
-    help:
-        'Restrict to these declaration kinds (comma-separated).\n'
-        'Valid: $kindNames.',
-    valueHelp: 'kind,kind',
-  )
-  ..addOption(
-    'format',
-    abbr: 'f',
-    allowed: ['text', 'json', 'github'],
-    defaultsTo: 'text',
-    help: 'Output format.',
-    allowedHelp: {
-      'text': 'Human-readable, grouped by file.',
-      'json': 'Machine-readable JSON.',
-      'github': 'GitHub Actions `::warning` annotations.',
-    },
-  )
-  ..addFlag(
-    'color',
-    help: 'Colorize text output. Defaults to auto-detecting the terminal.',
-  )
-  ..addFlag(
-    'progress',
-    help: 'Show scan progress on stderr. Defaults to on for a terminal.',
-  )
-  ..addOption(
-    'concurrency',
-    abbr: 'j',
-    defaultsTo: '16',
-    help:
-        'How many reference queries to run against the analysis server at\n'
-        'once. Higher can be faster on large projects, up to the limit of\n'
-        'the analysis server parallelism.',
-    valueHelp: 'n',
-  )
-  ..addOption(
-    'dart',
-    help:
-        'Path to the dart executable used to launch the analysis server.\n'
-        'Defaults to the SDK running this tool.',
-    valueHelp: 'path',
+/// Every setting ciach accepts, declared once for the command line, the config
+/// file (`configKey`) and its default.
+///
+/// [help], [config] and [noConfig] have no `configKey`: a config file doesn't
+/// get to decide whether it is read.
+enum CiachOption<V> implements OptionDefinition<V> {
+  help(
+    FlagOption(
+      argName: 'help',
+      argAbbrev: 'h',
+      negatable: false,
+      defaultsTo: false,
+      helpText: 'Print this usage information.',
+    ),
+  ),
+  config(
+    StringOption(
+      argName: 'config',
+      valueHelp: 'path',
+      helpText:
+          'Path to a YAML config file. Defaults to $configFileName in the\n'
+          'analyzed package root, when present.',
+    ),
+  ),
+  // A flag of its own, not a negated `config` — that name is the option above.
+  noConfig(
+    FlagOption(
+      argName: 'no-config',
+      negatable: false,
+      defaultsTo: false,
+      helpText:
+          'Ignore any config file, including one that would be discovered\n'
+          'automatically. Cannot be combined with --config.',
+    ),
+  ),
+  path(
+    StringOption(
+      argPos: 0,
+      configKey: '/path',
+      defaultsTo: '.',
+      helpText: 'Package root to analyze.',
+    ),
+  ),
+  public(
+    FlagOption(
+      argName: 'public',
+      configKey: '/public',
+      defaultsTo: true,
+      helpText:
+          'Report unused public declarations too. Disable to report only\n'
+          'private (underscore-prefixed) declarations, which are the\n'
+          'highest-confidence dead code.',
+    ),
+  ),
+  generated(
+    FlagOption(
+      argName: 'generated',
+      configKey: '/generated',
+      defaultsTo: false,
+      helpText:
+          'Scan generated files (*.g.dart, *.freezed.dart, …). Off by default.',
+    ),
+  ),
+  overrides(
+    FlagOption(
+      argName: 'overrides',
+      configKey: '/overrides',
+      defaultsTo: false,
+      helpText:
+          'Report members annotated with @override too. Off by default,\n'
+          'since overrides are often reached polymorphically and a plain\n'
+          'reference search can miss those uses.',
+    ),
+  ),
+  operators(
+    FlagOption(
+      argName: 'operators',
+      configKey: '/operators',
+      defaultsTo: false,
+      helpText:
+          'Report operator overloads (operator +, operator ==, …) too. Off\n'
+          'by default: the analysis server never resolves infix operator\n'
+          "syntax (a + b) back to the operator's declaration, so a used\n"
+          'operator is reported as unused every time.',
+    ),
+  ),
+  unusedUnionMembers(
+    FlagOption(
+      argName: 'unused-union-members',
+      configKey: '/unused-union-members',
+      defaultsTo: false,
+      helpText:
+          'Also flag a class whose only references are type patterns over its\n'
+          '(sealed) supertype — matched but never constructed. Off by default:\n'
+          'a `case Foo():` arm otherwise counts as a use. Report-only: these\n'
+          'findings are surfaced but --remove never deletes them or their\n'
+          'pattern arms (removing a sealed member and rewriting its switches\n'
+          'is left to a human). Conservative: any reference that is not clearly\n'
+          'a type pattern keeps the class alive.',
+    ),
+  ),
+  reportToJson(
+    FlagOption(
+      argName: 'report-tojson',
+      configKey: '/report-tojson',
+      defaultsTo: false,
+      helpText:
+          'Report a `toJson()` serialization hook as unused too. Off by\n'
+          'default: `jsonEncode(obj)` calls `obj.toJson()` by dynamic dispatch\n'
+          'with no source-level `.toJson()` reference for the search to see, so\n'
+          'a live serializer would be flagged. Enable to audit dead `toJson`s.',
+    ),
+  ),
+  setExitIfChanged(
+    FlagOption(
+      argName: 'set-exit-if-changed',
+      configKey: '/set-exit-if-changed',
+      negatable: false,
+      defaultsTo: false,
+      helpText:
+          'Exit with a non-zero status when any unused declaration is found\n'
+          '(useful in CI).',
+    ),
+  ),
+  remove(
+    FlagOption(
+      argName: 'remove',
+      configKey: '/remove',
+      negatable: false,
+      defaultsTo: false,
+      helpText:
+          'Remove unused declarations from source after reporting them.\n'
+          'Prompts for confirmation first, unless --force is also given.',
+    ),
+  ),
+  force(
+    FlagOption(
+      argName: 'force',
+      configKey: '/force',
+      negatable: false,
+      defaultsTo: false,
+      helpText: 'Skip the confirmation prompt for --remove. Requires --remove.',
+    ),
+  ),
+  exclude(
+    MultiStringOption.noSplit(
+      argName: 'exclude',
+      argAbbrev: 'e',
+      configKey: '/exclude',
+      defaultsTo: [],
+      valueHelp: 'glob',
+      helpText: 'Glob(s), relative to the root, of files to skip. Repeatable.',
+    ),
+  ),
+  include(
+    MultiStringOption.noSplit(
+      argName: 'include',
+      argAbbrev: 'i',
+      configKey: '/include',
+      defaultsTo: [],
+      valueHelp: 'glob',
+      helpText: 'If given, only scan files matching these glob(s). Repeatable.',
+    ),
+  ),
+  generatedSuffix(
+    MultiStringOption.noSplit(
+      argName: 'generated-suffix',
+      configKey: '/generated-suffix',
+      defaultsTo: [],
+      valueHelp: 'suffix',
+      helpText:
+          'Additional filename suffix to treat as generated (and so\n'
+          'exclude from the scan), on top of the built-in set (*.g.dart,\n'
+          '*.freezed.dart, …). Use for custom code generators, e.g.\n'
+          '--generated-suffix .gc.dart. Include the leading dot. Repeatable.\n'
+          'Ignored when --generated is set.',
+    ),
+  ),
+  kinds(
+    MultiStringOption(
+      argName: 'kinds',
+      argAbbrev: 'k',
+      configKey: '/kinds',
+      defaultsTo: [],
+      valueHelp: 'kind,kind',
+      // Rejects an unknown kind wherever it came from; the conversion to
+      // symbol kinds happens later.
+      customValidator: parseKinds,
+      // Listed in `usage`, which can read them off kindAliases.
+      helpText:
+          'Restrict to these declaration kinds (comma-separated).\n'
+          'The kinds are listed at the end of this help.',
+    ),
+  ),
+  format(
+    StringOption(
+      argName: 'format',
+      argAbbrev: 'f',
+      configKey: '/format',
+      allowedValues: formatNames,
+      defaultsTo: 'text',
+      helpText: 'Output format.',
+      allowedHelp: {
+        'text': 'Human-readable, grouped by file.',
+        'json': 'Machine-readable JSON.',
+        'github': 'GitHub Actions `::warning` annotations.',
+      },
+    ),
+  ),
+  color(
+    FlagOption(
+      argName: 'color',
+      configKey: '/color',
+      helpText:
+          'Colorize text output. Defaults to auto-detecting the terminal.',
+    ),
+  ),
+  progress(
+    FlagOption(
+      argName: 'progress',
+      configKey: '/progress',
+      helpText: 'Show scan progress on stderr. Defaults to on for a terminal.',
+    ),
+  ),
+  concurrency(
+    IntOption(
+      argName: 'concurrency',
+      argAbbrev: 'j',
+      configKey: '/concurrency',
+      valueHelp: 'n',
+      defaultsTo: 16,
+      min: 1,
+      helpText:
+          'How many reference queries to run against the analysis server at\n'
+          'once. Higher can be faster on large projects, up to the limit of\n'
+          'the analysis server parallelism.',
+    ),
+  ),
+  dart(
+    StringOption(
+      argName: 'dart',
+      configKey: '/dart',
+      valueHelp: 'path',
+      helpText:
+          'Path to the dart executable used to launch the analysis server.\n'
+          'Defaults to the SDK running this tool.',
+    ),
   );
+
+  const CiachOption(this.option);
+
+  @override
+  final ConfigOptionBase<V> option;
+
+  /// The `ciach.yaml` key for this option, its JSON pointer without the `/`.
+  String? get configKey => option.configKey?.substring(1);
+}
+
+/// Ciach's resolved options, named so the enum's `dynamic` argument is written
+/// once.
+typedef CiachConfiguration = Configuration<CiachOption<dynamic>>;
+
+/// The file name config discovery looks for in the project directory.
+const configFileName = 'ciach.yaml';
+
+/// The argument parser for [CiachOption.values].
+ArgParser buildParser() {
+  final parser = ArgParser();
+  prepareOptionsForParsing(CiachOption.values, parser);
+  return parser;
+}
 
 /// The full `--help` text, wrapping [parser]'s generated option list.
 String usage(ArgParser parser) =>
@@ -204,12 +341,33 @@ Usage: ciach [options] [path]
 
 ${parser.usage}
 
+Declaration kinds (-k, --kinds):
+${_wrapped(kindNames, indent: '  ')}
+
+Config file:
+  Every option above can also be set in $configFileName in the package root,
+  keyed by its long name, plus `path` for the positional argument. The command
+  line wins over the file; --no-config ignores the file.
+
+    # $configFileName
+    public: false
+    exclude:
+      - 'test/**'
+    kinds: [class, function]
+    format: json
+
 Examples:
   # Scan the current package
   ciach
 
   # Only private declarations, excluding tests, as JSON
   ciach --no-public -e 'test/**' -f json lib/
+
+  # Read settings from a config file elsewhere
+  ciach --config tool/ciach.yaml
+
+  # Ignore the package's config file for one run
+  ciach --no-config
 
   # GitHub Actions annotations, fail the job if anything is found
   ciach -f github --set-exit-if-changed
@@ -219,3 +377,16 @@ Examples:
 
   # Remove without asking (e.g. in a script)
   ciach --remove --force''';
+
+/// [text] as [indent]-prefixed lines of at most [width] characters.
+String _wrapped(String text, {String indent = '', int width = 76}) {
+  final lines = <String>[];
+  for (final word in text.split(' ')) {
+    if (lines.isEmpty || '${lines.last} $word'.length > width) {
+      lines.add('$indent$word');
+    } else {
+      lines[lines.length - 1] = '${lines.last} $word';
+    }
+  }
+  return lines.join('\n');
+}

--- a/lib/src/cli/config.dart
+++ b/lib/src/cli/config.dart
@@ -1,0 +1,227 @@
+import 'dart:io';
+
+import 'package:ciach/src/cli/args.dart';
+import 'package:collection/collection.dart';
+import 'package:config/config.dart';
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+/// Every key a config file may contain, following [CiachOption].
+final configKeys = {for (final option in CiachOption.values) ?option.configKey};
+
+/// The config-file layer of option resolution: a [ConfigurationBroker] over the
+/// settings of a `ciach.yaml`.
+///
+/// Where to look for that file, whether to read it at all, and reporting a
+/// malformed one against its path stay ciach's own business; the command line
+/// beating it, and its defaults, are `package:config`'s.
+class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
+  const ConfigFile._({
+    required this.settings,
+    required this.path,
+    required this.ignored,
+  });
+
+  /// Creates a config that sets nothing, from nowhere.
+  const ConfigFile.empty() : settings = const {}, path = null, ignored = false;
+
+  /// Parses [source], read from the file [origin], which names it in errors.
+  ///
+  /// Throws a [FormatException] on anything but a map of known keys with values
+  /// their options accept.
+  factory ConfigFile.parse(String source, {required String origin}) {
+    final Object? document;
+    try {
+      document = loadYaml(source, sourceUrl: Uri.file(origin));
+    } on YamlException catch (e) {
+      throw FormatException('$origin: not valid YAML: ${e.message}');
+    }
+
+    // An empty file parses to null; that is no settings, not an error.
+    if (document == null) {
+      return ._(settings: const {}, path: origin, ignored: false);
+    }
+    if (document is! Map) {
+      throw FormatException('$origin: the top level must be a map of options.');
+    }
+
+    final unknown = document.keys
+        .map((key) => '$key')
+        .whereNot(configKeys.contains)
+        .toList();
+    if (unknown.isNotEmpty) {
+      final valid = (configKeys.toList()..sort()).join(', ');
+      throw FormatException(
+        '$origin: unknown option${unknown.length == 1 ? '' : 's'} ${unknown.map((key) => "'$key'").join(', ')}. Valid options: $valid.',
+      );
+    }
+
+    final file = ConfigFile._(
+      settings: {
+        for (final entry in document.entries)
+          // A valueless key (`public:`) counts as unset, and YAML collections
+          // are unwrapped to plain Dart ones.
+          if (entry.value case final value?)
+            '${entry.key}': value is Iterable ? value.toList() : value,
+      },
+      path: origin,
+      ignored: false,
+    );
+
+    // Resolution only asks for the keys it needs, so without checking the whole
+    // file here, a bad value under an overridden option would go unreported.
+    file.settings.keys.forEach(file._typedValue);
+    return file;
+  }
+
+  /// Finds and reads the config file for a run: [explicitPath] from `--config`
+  /// if given, else [configFileName] in [projectDir].
+  ///
+  /// With [ignore] the file is located but never read, so a caller can still
+  /// name what `--no-config` skipped, and an unparseable file is no error.
+  ///
+  /// Throws a [FormatException] if [explicitPath] is missing or the file cannot
+  /// be read or parsed.
+  static ConfigFile load({
+    required String projectDir,
+    String? explicitPath,
+    bool ignore = false,
+  }) {
+    final discovered = File(p.join(projectDir, configFileName));
+    if (ignore) {
+      return ._(
+        settings: const {},
+        path: discovered.existsSync() ? discovered.path : null,
+        ignored: true,
+      );
+    }
+
+    final File file;
+    if (explicitPath != null) {
+      file = File(explicitPath);
+      if (!file.existsSync()) {
+        throw FormatException('Config file does not exist: $explicitPath');
+      }
+    } else {
+      if (!discovered.existsSync()) {
+        return const .empty();
+      }
+      file = discovered;
+    }
+
+    try {
+      return .parse(file.readAsStringSync(), origin: file.path);
+    } on FileSystemException catch (e) {
+      throw FormatException(
+        'Cannot read config file ${file.path}: ${e.message}',
+      );
+    }
+  }
+
+  /// What the file sets, keyed by config key, in the order it set them.
+  final Map<String, Object?> settings;
+
+  /// The file the [settings] came from, or that [ignored] skipped; `null` when
+  /// there was no config file at all.
+  final String? path;
+
+  /// Whether `--no-config` skipped a file, leaving it unread.
+  final bool ignored;
+
+  /// The value for [key], a JSON pointer such as `/public`.
+  @override
+  Object? valueOrNull(String key, CiachConfiguration cfg) =>
+      _typedValue(key.startsWith('/') ? key.substring(1) : key);
+
+  /// The value under [key], as the type its option takes.
+  ///
+  /// The type comes from the option, not the value, so that `exclude: ['a']`
+  /// arrives as the `List<String>` the option needs rather than a
+  /// `List<dynamic>`, and a mismatch names the file and the key.
+  ///
+  /// The first three accept less than their type allows, and `package:config`
+  /// keeps its own validators internal, so they reuse what the options declare.
+  Object? _typedValue(String key) => switch (_optionFor(key)) {
+    .format => _oneOf(key, formatNames),
+    .kinds => _kinds(key),
+    .concurrency => _positiveInt(key),
+    final option => switch (option.option) {
+      FlagOption() => _boolean(key),
+      IntOption() => _positiveInt(key),
+      MultiOption() => _strings(key),
+      _ => _string(key),
+    },
+  };
+
+  CiachOption<dynamic> _optionFor(String key) =>
+      .values.firstWhere((option) => option.configKey == key);
+
+  bool? _boolean(String key) => switch (settings[key]) {
+    null => null,
+    final bool value => value,
+    final other => _wrong(key, 'true or false', other),
+  };
+
+  String? _string(String key) => switch (settings[key]) {
+    null => null,
+    final String value => value,
+    final other => _wrong(key, 'a string', other),
+  };
+
+  /// The strings under [key], accepting a bare string as a one-element list.
+  List<String>? _strings(String key) => switch (settings[key]) {
+    null => null,
+    final String value => [value],
+    final Iterable<Object?> values => [
+      for (final value in values)
+        if (value is String) value else _wrong(key, 'a list of strings', value),
+    ],
+    final other => _wrong(key, 'a list of strings', other),
+  };
+
+  /// The string under [key], which has to be one of [allowed].
+  String? _oneOf(String key, List<String> allowed) {
+    final value = _string(key);
+    if (value != null && !allowed.contains(value)) {
+      throw FormatException(
+        "$path: '$key' must be one of ${allowed.join(', ')}, got '$value'.",
+      );
+    }
+    return value;
+  }
+
+  /// The kind names under [key], validated but not yet converted.
+  List<String>? _kinds(String key) {
+    final values = _strings(key);
+    if (values != null) {
+      try {
+        parseKinds(values);
+      } on FormatException catch (e) {
+        throw FormatException("$path: '$key': ${e.message}");
+      }
+    }
+    return values;
+  }
+
+  int? _positiveInt(String key) => switch (settings[key]) {
+    null => null,
+    final int value && > 0 => value,
+    final other => _wrong(key, 'a positive integer', other),
+  };
+
+  /// Reports the wrong type, naming the file and the key.
+  Never _wrong(String key, String expected, Object? value) =>
+      throw FormatException(
+        "$path: '$key' must be $expected, got ${_describe(value)}.",
+      );
+
+  static String _describe(Object? value) => switch (value) {
+    null => 'null',
+    String() => 'a string',
+    bool() => 'a boolean',
+    num() => 'a number',
+    Iterable() => 'a list',
+    Map() => 'a map',
+    _ => '$value',
+  };
+}

--- a/lib/src/cli/config.dart
+++ b/lib/src/cli/config.dart
@@ -87,6 +87,14 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
     String? explicitPath,
     bool ignore = false,
   }) {
+    if (explicitPath != null && !ignore) {
+      final file = File(explicitPath);
+      if (!file.existsSync()) {
+        throw FormatException('Config file does not exist: $explicitPath');
+      }
+      return _read(file);
+    }
+
     final discovered = File(p.join(projectDir, configFileName));
     if (ignore) {
       return ._(
@@ -96,19 +104,11 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
       );
     }
 
-    final File file;
-    if (explicitPath != null) {
-      file = File(explicitPath);
-      if (!file.existsSync()) {
-        throw FormatException('Config file does not exist: $explicitPath');
-      }
-    } else {
-      if (!discovered.existsSync()) {
-        return const .empty();
-      }
-      file = discovered;
-    }
+    return discovered.existsSync() ? _read(discovered) : const .empty();
+  }
 
+  /// Parses [file], naming it in a read or parse failure.
+  static ConfigFile _read(File file) {
     try {
       return .parse(file.readAsStringSync(), origin: file.path);
     } on FileSystemException catch (e) {

--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -1,0 +1,128 @@
+import 'package:args/args.dart';
+import 'package:ciach/ciach.dart';
+import 'package:ciach/src/cli/args.dart';
+import 'package:ciach/src/cli/config.dart';
+import 'package:config/config.dart';
+import 'package:path/path.dart' as p;
+
+/// A resolved [Configuration] in the types the rest of the tool works in: kind
+/// names converted, the inverted flags flipped, the auto-detected ones settled.
+class ResolvedOptions {
+  const ResolvedOptions({
+    required this.rootPath,
+    required this.includeGlobs,
+    required this.excludeGlobs,
+    required this.additionalGeneratedSuffixes,
+    required this.kinds,
+    required this.includePublic,
+    required this.includeGenerated,
+    required this.overrides,
+    required this.operators,
+    required this.unusedUnionMembers,
+    required this.reportToJson,
+    required this.setExitIfChanged,
+    required this.remove,
+    required this.force,
+    required this.format,
+    required this.useColor,
+    required this.showProgress,
+    required this.concurrency,
+    required this.dartExecutable,
+  });
+
+  /// Package root to analyze, as written; see [absoluteRootPath].
+  final String rootPath;
+  final List<String> includeGlobs;
+  final List<String> excludeGlobs;
+  final List<String> additionalGeneratedSuffixes;
+  final Set<SymbolKind> kinds;
+  final bool includePublic;
+  final bool includeGenerated;
+
+  /// Whether to report `@override` members — inverted for the finder.
+  final bool overrides;
+
+  /// Whether to report operator overloads — inverted for the finder.
+  final bool operators;
+  final bool unusedUnionMembers;
+  final bool reportToJson;
+  final bool setExitIfChanged;
+  final bool remove;
+  final bool force;
+  final String format;
+  final bool useColor;
+
+  /// Whether to show scan progress.
+  final bool showProgress;
+  final int concurrency;
+  final String? dartExecutable;
+
+  /// [rootPath] resolved against the current directory.
+  String get absoluteRootPath => p.normalize(p.absolute(rootPath));
+
+  /// The finder's share of these settings, reporting progress to [onProgress].
+  FinderOptions finderOptions({void Function(String message)? onProgress}) =>
+      .new(
+        rootPath: absoluteRootPath,
+        includeGlobs: includeGlobs,
+        excludeGlobs: excludeGlobs,
+        additionalGeneratedSuffixes: additionalGeneratedSuffixes,
+        kinds: kinds,
+        includePublic: includePublic,
+        includeGenerated: includeGenerated,
+        skipOverrides: !overrides,
+        skipOperators: !operators,
+        unusedUnionMembers: unusedUnionMembers,
+        reportToJson: reportToJson,
+        concurrency: concurrency,
+        dartExecutable: dartExecutable,
+        onProgress: onProgress,
+      );
+}
+
+/// Resolves every [CiachOption] from [args] and [config], the command line
+/// winning over the file and the file over the default.
+///
+/// Throws a [UsageException] listing every malformed value, from either layer.
+CiachConfiguration resolveConfiguration(ArgResults args, ConfigFile config) =>
+    .resolve(
+      options: CiachOption.values,
+      argResults: args,
+      configBroker: config,
+    );
+
+/// The settings of [configuration], with [colorDefault] and [progressDefault]
+/// standing in for the two nobody asked for either way.
+ResolvedOptions resolveOptions(
+  CiachConfiguration configuration, {
+  required bool colorDefault,
+  required bool progressDefault,
+}) {
+  final progress =
+      configuration.optionalValue(CiachOption.progress) ?? progressDefault;
+
+  return .new(
+    rootPath: configuration.value(CiachOption.path),
+    includeGlobs: configuration.value(CiachOption.include),
+    excludeGlobs: configuration.value(CiachOption.exclude),
+    additionalGeneratedSuffixes: configuration.value(
+      CiachOption.generatedSuffix,
+    ),
+    // Already validated by the option; this only converts the names.
+    kinds: parseKinds(configuration.value(CiachOption.kinds)),
+    includePublic: configuration.value(CiachOption.public),
+    includeGenerated: configuration.value(CiachOption.generated),
+    overrides: configuration.value(CiachOption.overrides),
+    operators: configuration.value(CiachOption.operators),
+    unusedUnionMembers: configuration.value(CiachOption.unusedUnionMembers),
+    reportToJson: configuration.value(CiachOption.reportToJson),
+    setExitIfChanged: configuration.value(CiachOption.setExitIfChanged),
+    remove: configuration.value(CiachOption.remove),
+    force: configuration.value(CiachOption.force),
+    format: configuration.value(CiachOption.format),
+    useColor: configuration.optionalValue(CiachOption.color) ?? colorDefault,
+    showProgress: progress,
+    concurrency: configuration.value(CiachOption.concurrency),
+    dartExecutable: configuration.optionalValue(CiachOption.dart),
+  );
+}

--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -97,32 +97,26 @@ ResolvedOptions resolveOptions(
   CiachConfiguration configuration, {
   required bool colorDefault,
   required bool progressDefault,
-}) {
-  final progress =
-      configuration.optionalValue(CiachOption.progress) ?? progressDefault;
-
-  return .new(
-    rootPath: configuration.value(CiachOption.path),
-    includeGlobs: configuration.value(CiachOption.include),
-    excludeGlobs: configuration.value(CiachOption.exclude),
-    additionalGeneratedSuffixes: configuration.value(
-      CiachOption.generatedSuffix,
-    ),
-    // Already validated by the option; this only converts the names.
-    kinds: parseKinds(configuration.value(CiachOption.kinds)),
-    includePublic: configuration.value(CiachOption.public),
-    includeGenerated: configuration.value(CiachOption.generated),
-    overrides: configuration.value(CiachOption.overrides),
-    operators: configuration.value(CiachOption.operators),
-    unusedUnionMembers: configuration.value(CiachOption.unusedUnionMembers),
-    reportToJson: configuration.value(CiachOption.reportToJson),
-    setExitIfChanged: configuration.value(CiachOption.setExitIfChanged),
-    remove: configuration.value(CiachOption.remove),
-    force: configuration.value(CiachOption.force),
-    format: configuration.value(CiachOption.format),
-    useColor: configuration.optionalValue(CiachOption.color) ?? colorDefault,
-    showProgress: progress,
-    concurrency: configuration.value(CiachOption.concurrency),
-    dartExecutable: configuration.optionalValue(CiachOption.dart),
-  );
-}
+}) => .new(
+  rootPath: configuration.value(CiachOption.path),
+  includeGlobs: configuration.value(CiachOption.include),
+  excludeGlobs: configuration.value(CiachOption.exclude),
+  additionalGeneratedSuffixes: configuration.value(CiachOption.generatedSuffix),
+  // Already validated by the option; this only converts the names.
+  kinds: parseKinds(configuration.value(CiachOption.kinds)),
+  includePublic: configuration.value(CiachOption.public),
+  includeGenerated: configuration.value(CiachOption.generated),
+  overrides: configuration.value(CiachOption.overrides),
+  operators: configuration.value(CiachOption.operators),
+  unusedUnionMembers: configuration.value(CiachOption.unusedUnionMembers),
+  reportToJson: configuration.value(CiachOption.reportToJson),
+  setExitIfChanged: configuration.value(CiachOption.setExitIfChanged),
+  remove: configuration.value(CiachOption.remove),
+  force: configuration.value(CiachOption.force),
+  format: configuration.value(CiachOption.format),
+  useColor: configuration.optionalValue(CiachOption.color) ?? colorDefault,
+  showProgress:
+      configuration.optionalValue(CiachOption.progress) ?? progressDefault,
+  concurrency: configuration.value(CiachOption.concurrency),
+  dartExecutable: configuration.optionalValue(CiachOption.dart),
+);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,10 +19,12 @@ environment:
 dependencies:
   args: ^2.7.0
   collection: ^1.19.0
+  config: ^0.9.0
   glob: ^2.1.3
   path: ^1.9.1
   pro_lsp: ^0.3.0
   stream_channel: ^2.1.4
+  yaml: ^3.1.3
 
 dev_dependencies:
   leancode_lint: ^24.0.0

--- a/test/config_test.dart
+++ b/test/config_test.dart
@@ -1,0 +1,576 @@
+import 'dart:io';
+
+import 'package:ciach/ciach.dart';
+import 'package:ciach/src/cli/args.dart';
+import 'package:ciach/src/cli/config.dart';
+import 'package:ciach/src/cli/options.dart';
+import 'package:config/config.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  final parser = buildParser();
+
+  /// Resolves [arguments] against [config], the terminal-probed defaults given
+  /// explicitly so no test depends on the terminal it runs in.
+  ResolvedOptions resolveWith(
+    List<String> arguments,
+    ConfigFile config, {
+    required bool colorDefault,
+    required bool progressDefault,
+  }) => resolveOptions(
+    resolveConfiguration(parser.parse(arguments), config),
+    colorDefault: colorDefault,
+    progressDefault: progressDefault,
+  );
+
+  /// As above, with both auto-detected settings off.
+  ResolvedOptions resolve(List<String> arguments, [ConfigFile? config]) =>
+      resolveWith(
+        arguments,
+        config ?? const .empty(),
+        colorDefault: false,
+        progressDefault: false,
+      );
+
+  /// What a config [source] alone resolves to.
+  ResolvedOptions resolveFile(String source) =>
+      resolve(const [], .parse(source, origin: 'ciach.yaml'));
+
+  group('ConfigFile.parse', () {
+    test('reads every option', () {
+      // Checked through the merge, which is what the CLI does with them.
+      final resolved = resolveFile('''
+path: packages/app
+public: false
+generated: true
+overrides: true
+operators: true
+unused-union-members: true
+report-tojson: true
+set-exit-if-changed: true
+remove: true
+force: true
+exclude:
+  - 'test/**'
+  - 'tool/**'
+include:
+  - 'lib/**'
+generated-suffix:
+  - .gc.dart
+kinds: [class, function]
+format: github
+color: true
+progress: true
+concurrency: 4
+dart: /sdk/bin/dart
+''');
+
+      expect(resolved.rootPath, 'packages/app');
+      expect(resolved.includePublic, isFalse);
+      expect(resolved.includeGenerated, isTrue);
+      expect(resolved.overrides, isTrue);
+      expect(resolved.operators, isTrue);
+      expect(resolved.unusedUnionMembers, isTrue);
+      expect(resolved.reportToJson, isTrue);
+      expect(resolved.setExitIfChanged, isTrue);
+      expect(resolved.remove, isTrue);
+      expect(resolved.force, isTrue);
+      expect(resolved.excludeGlobs, ['test/**', 'tool/**']);
+      expect(resolved.includeGlobs, ['lib/**']);
+      expect(resolved.additionalGeneratedSuffixes, ['.gc.dart']);
+      expect(resolved.kinds, <SymbolKind>{.class$, .function});
+      expect(resolved.format, 'github');
+      expect(resolved.useColor, isTrue);
+      expect(resolved.showProgress, isTrue);
+      expect(resolved.concurrency, 4);
+      expect(resolved.dartExecutable, '/sdk/bin/dart');
+    });
+
+    test('covers every command-line option', () {
+      // Anything settable on the command line is settable in the file.
+      final cliOnly = {'help', 'config', 'no-config'};
+      final optionNames = parser.options.keys.toSet().difference(cliOnly);
+
+      expect(configKeys.difference({'path'}), optionNames);
+    });
+
+    test('settings lists what the file sets, and only that', () {
+      final config = ConfigFile.parse('''
+public: false
+exclude: ['test/**']
+concurrency: 4
+''', origin: 'ciach.yaml');
+
+      expect(config.settings, {
+        'public': false,
+        'exclude': ['test/**'],
+        'concurrency': 4,
+      });
+      expect(config.path, 'ciach.yaml');
+      expect(config.ignored, isFalse);
+    });
+
+    test('treats an empty or comment-only file as no settings', () {
+      for (final source in ['', '\n', '# nothing here\n']) {
+        expect(
+          ConfigFile.parse(source, origin: 'ciach.yaml').settings,
+          isEmpty,
+          reason: 'for ${source.trim()}',
+        );
+      }
+    });
+
+    test('treats a valueless key as unset', () {
+      final config = ConfigFile.parse('public:\n', origin: 'ciach.yaml');
+
+      expect(config.settings, isEmpty);
+      expect(resolve(const [], config).includePublic, isTrue);
+    });
+
+    test('accepts a bare string where a list is expected', () {
+      expect(resolveFile("exclude: 'test/**'").excludeGlobs, ['test/**']);
+    });
+
+    test('accepts comma-separated kinds in one string', () {
+      expect(resolveFile('kinds: class,method').kinds, <SymbolKind>{
+        .class$,
+        .method,
+      });
+    });
+
+    test('rejects an unknown option, naming the file and valid keys', () {
+      expect(
+        () => ConfigFile.parse('publik: false', origin: 'ciach.yaml'),
+        throwsA(
+          isFormatException('ciach.yaml', contains("unknown option 'publik'")),
+        ),
+      );
+    });
+
+    test('rejects a top-level document that is not a map', () {
+      expect(
+        () => ConfigFile.parse('- public', origin: 'ciach.yaml'),
+        throwsA(
+          isFormatException('ciach.yaml', contains('must be a map of options')),
+        ),
+      );
+    });
+
+    test('rejects malformed YAML', () {
+      expect(
+        () => ConfigFile.parse('public: [unclosed', origin: 'ciach.yaml'),
+        throwsA(isFormatException('ciach.yaml', contains('not valid YAML'))),
+      );
+    });
+
+    test('rejects a non-boolean flag', () {
+      expect(
+        () => resolveFile('public: sometimes'),
+        throwsA(
+          isFormatException(
+            'ciach.yaml',
+            contains("'public' must be true or false, got a string"),
+          ),
+        ),
+      );
+    });
+
+    test('rejects a non-string in a list', () {
+      expect(
+        () => resolveFile('exclude: [1]'),
+        throwsA(isFormatException('ciach.yaml', contains('a list of strings'))),
+      );
+    });
+
+    test('rejects an unknown format', () {
+      expect(
+        () => resolveFile('format: xml'),
+        throwsA(
+          isFormatException('ciach.yaml', contains('text, json, github')),
+        ),
+      );
+    });
+
+    test('rejects an unknown kind', () {
+      expect(
+        () => resolveFile('kinds: [klass]'),
+        throwsA(
+          isFormatException('ciach.yaml', contains("Unknown kind 'klass'")),
+        ),
+      );
+    });
+
+    test('rejects a non-positive concurrency', () {
+      for (final value in ['0', '-2', 'many', '1.5']) {
+        expect(
+          () => resolveFile('concurrency: $value'),
+          throwsA(
+            isFormatException('ciach.yaml', contains('positive integer')),
+          ),
+          reason: 'for concurrency: $value',
+        );
+      }
+    });
+
+    test('checks the type of every key, even one the argv overrides', () {
+      // Every option is given on the command line below, so only the eager
+      // check when the file is parsed can still catch the bad value. A map fits
+      // no setting, so it is the one wrong value that works for every key.
+      const everyOption = [
+        '--public',
+        '--generated',
+        '--overrides',
+        '--operators',
+        '--unused-union-members',
+        '--report-tojson',
+        '--set-exit-if-changed',
+        '--remove',
+        '--force',
+        '-e',
+        'test/**',
+        '-i',
+        'lib/**',
+        '--generated-suffix',
+        '.gc.dart',
+        '-k',
+        'class',
+        '-f',
+        'json',
+        '--color',
+        '--progress',
+        '-j',
+        '2',
+        '--dart',
+        '/sdk/bin/dart',
+        'lib',
+      ];
+
+      for (final key in configKeys) {
+        expect(
+          () => resolve(
+            everyOption,
+            .parse('$key: {a: b}', origin: 'ciach.yaml'),
+          ),
+          throwsA(isFormatException('ciach.yaml', contains("'$key'"))),
+          reason: 'for a map under $key',
+        );
+      }
+    });
+  });
+
+  group('ConfigFile.load', () {
+    late Directory tempDir;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('ciach_config_test_');
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    void write(String name, String content) =>
+        File(p.join(tempDir.path, name)).writeAsStringSync(content);
+
+    test('discovers ciach.yaml in the project directory', () {
+      write('ciach.yaml', 'public: false');
+
+      final config = ConfigFile.load(projectDir: tempDir.path);
+
+      expect(config.path, p.join(tempDir.path, 'ciach.yaml'));
+      expect(config.settings['public'], isFalse);
+    });
+
+    test('discovers ciach.yaml only, not other spellings', () {
+      write('ciach.yml', 'format: json');
+      write('.ciach.yaml', 'format: json');
+
+      expect(ConfigFile.load(projectDir: tempDir.path).path, isNull);
+
+      write('ciach.yaml', 'format: github');
+
+      expect(
+        ConfigFile.load(projectDir: tempDir.path).settings['format'],
+        'github',
+      );
+    });
+
+    test('returns an empty config when the directory has none', () {
+      final config = ConfigFile.load(projectDir: tempDir.path);
+
+      expect(config.path, isNull);
+      expect(config.settings, isEmpty);
+    });
+
+    test('does not look outside the project directory', () {
+      write('ciach.yaml', 'public: false');
+      final nested = Directory(p.join(tempDir.path, 'nested'))..createSync();
+
+      expect(ConfigFile.load(projectDir: nested.path).path, isNull);
+    });
+
+    test('loads an explicit path from outside the project directory', () {
+      write('elsewhere.yaml', 'format: json');
+      final nested = Directory(p.join(tempDir.path, 'nested'))..createSync();
+
+      final config = ConfigFile.load(
+        projectDir: nested.path,
+        explicitPath: p.join(tempDir.path, 'elsewhere.yaml'),
+      );
+
+      expect(config.settings['format'], 'json');
+    });
+
+    test('an explicit path wins over a discoverable file', () {
+      write('ciach.yaml', 'format: github');
+      write('other.yaml', 'format: json');
+
+      final config = ConfigFile.load(
+        projectDir: tempDir.path,
+        explicitPath: p.join(tempDir.path, 'other.yaml'),
+      );
+
+      expect(config.settings['format'], 'json');
+    });
+
+    test('reports a missing explicit path', () {
+      expect(
+        () => ConfigFile.load(
+          projectDir: tempDir.path,
+          explicitPath: p.join(tempDir.path, 'nope.yaml'),
+        ),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('Config file does not exist'),
+          ),
+        ),
+      );
+    });
+
+    test('ignore reads nothing, but still names the file it skipped', () {
+      // Invalid on purpose: --no-config never parses it, so it can't fail.
+      write('ciach.yaml', 'publik: [unclosed');
+
+      final config = ConfigFile.load(projectDir: tempDir.path, ignore: true);
+
+      expect(config.ignored, isTrue);
+      expect(config.path, p.join(tempDir.path, 'ciach.yaml'));
+      expect(config.settings, isEmpty);
+    });
+
+    test('ignore reports no path when there was no config anyway', () {
+      final config = ConfigFile.load(projectDir: tempDir.path, ignore: true);
+
+      expect(config.ignored, isTrue);
+      expect(config.path, isNull);
+    });
+
+    test('ignore skips an explicit path, and its would-be errors', () {
+      final config = ConfigFile.load(
+        projectDir: tempDir.path,
+        explicitPath: p.join(tempDir.path, 'nope.yaml'),
+        ignore: true,
+      );
+
+      expect(config.path, isNull);
+    });
+  });
+
+  group('resolveOptions', () {
+    test('falls back to the built-in defaults with no config and no args', () {
+      final resolved = resolve(const []);
+
+      expect(resolved.rootPath, '.');
+      expect(resolved.includePublic, isTrue);
+      expect(resolved.includeGenerated, isFalse);
+      expect(resolved.overrides, isFalse);
+      expect(resolved.operators, isFalse);
+      expect(resolved.unusedUnionMembers, isFalse);
+      expect(resolved.reportToJson, isFalse);
+      expect(resolved.setExitIfChanged, isFalse);
+      expect(resolved.remove, isFalse);
+      expect(resolved.force, isFalse);
+      expect(resolved.includeGlobs, isEmpty);
+      expect(resolved.excludeGlobs, isEmpty);
+      expect(resolved.additionalGeneratedSuffixes, isEmpty);
+      expect(resolved.kinds, FinderOptions.defaultKinds);
+      expect(resolved.format, 'text');
+      expect(resolved.concurrency, 16);
+      expect(resolved.dartExecutable, isNull);
+    });
+
+    test('command-line flags override the config', () {
+      final config = ConfigFile.parse('''
+path: packages/app
+public: false
+generated: true
+format: json
+color: false
+progress: false
+concurrency: 4
+dart: /sdk/bin/dart
+''', origin: 'ciach.yaml');
+
+      final resolved = resolve(const [
+        '--public',
+        '--no-generated',
+        '--format',
+        'github',
+        '--color',
+        '--progress',
+        '--concurrency',
+        '2',
+        '--dart',
+        '/other/dart',
+        'packages/other',
+      ], config);
+
+      expect(resolved.rootPath, 'packages/other');
+      expect(resolved.includePublic, isTrue);
+      expect(resolved.includeGenerated, isFalse);
+      expect(resolved.format, 'github');
+      expect(resolved.useColor, isTrue);
+      expect(resolved.showProgress, isTrue);
+      expect(resolved.concurrency, 2);
+      expect(resolved.dartExecutable, '/other/dart');
+    });
+
+    test('a command-line list replaces the config list, not appends', () {
+      final config = ConfigFile.parse(
+        "exclude: ['test/**']\nkinds: [class]",
+        origin: 'ciach.yaml',
+      );
+
+      final resolved = resolve(const ['-e', 'tool/**', '-k', 'method'], config);
+
+      expect(resolved.excludeGlobs, ['tool/**']);
+      expect(resolved.kinds, <SymbolKind>{.method});
+    });
+
+    test('repeated command-line values all survive', () {
+      final resolved = resolve(const [
+        '-e',
+        'test/**',
+        '-e',
+        'tool/**',
+        '--generated-suffix',
+        '.gc.dart',
+        '--generated-suffix',
+        '.pb.dart',
+      ]);
+
+      expect(resolved.excludeGlobs, ['test/**', 'tool/**']);
+      expect(resolved.additionalGeneratedSuffixes, ['.gc.dart', '.pb.dart']);
+    });
+
+    test('explicitly passing a flag at its default value still wins', () {
+      // --public matches the default, so only the layer it came from tells it
+      // apart from an absent flag — and it has to, to beat `public: false`.
+      final resolved = resolve(const [
+        '--public',
+      ], .parse('public: false', origin: 'ciach.yaml'));
+
+      expect(resolved.includePublic, isTrue);
+    });
+
+    test('auto-detected color and progress are the last resort', () {
+      final auto = resolveWith(
+        const [],
+        const .empty(),
+        colorDefault: true,
+        progressDefault: true,
+      );
+      expect(auto.useColor, isTrue);
+      expect(auto.showProgress, isTrue);
+
+      final fromConfig = resolveWith(
+        const [],
+        .parse('color: false\nprogress: false', origin: 'c.yaml'),
+        colorDefault: true,
+        progressDefault: true,
+      );
+      expect(fromConfig.useColor, isFalse);
+      expect(fromConfig.showProgress, isFalse);
+
+      final fromArgs = resolveWith(
+        const ['--no-color', '--no-progress'],
+        .parse('color: true\nprogress: true', origin: 'c.yaml'),
+        colorDefault: true,
+        progressDefault: true,
+      );
+      expect(fromArgs.useColor, isFalse);
+      expect(fromArgs.showProgress, isFalse);
+    });
+
+    test('rejects a non-positive --concurrency', () {
+      for (final value in ['0', '-1']) {
+        expect(
+          () => resolve(['--concurrency', value]),
+          throwsA(isUsageException(contains('below the minimum (1)'))),
+          reason: 'for --concurrency $value',
+        );
+      }
+      expect(
+        () => resolve(const ['--concurrency', 'lots']),
+        throwsA(isUsageException(contains('lots'))),
+      );
+    });
+
+    test('rejects an unknown --kinds value', () {
+      expect(
+        () => resolve(const ['-k', 'klass']),
+        throwsA(isUsageException(contains("Unknown kind 'klass'"))),
+      );
+    });
+
+    test('reports every problem at once, not just the first', () {
+      // An out-of-range `--format` is not among them: an option's `allowed`
+      // list is the arg parser's business, so that fails before resolution.
+      expect(
+        () => resolve(const ['-k', 'klass', '-j', '0']),
+        throwsA(
+          isUsageException(
+            allOf(
+              contains("Unknown kind 'klass'"),
+              contains('below the minimum (1)'),
+            ),
+          ),
+        ),
+      );
+    });
+
+    test('hands the finder its share of the settings', () {
+      final resolved = resolve(const [
+        '--no-public',
+        '--overrides',
+        '-e',
+        'test/**',
+        '-j',
+        '4',
+      ]);
+      final options = resolved.finderOptions();
+
+      expect(options.rootPath, p.normalize(p.absolute('.')));
+      expect(options.includePublic, isFalse);
+      // Inverted for the finder.
+      expect(options.skipOverrides, isFalse);
+      expect(options.skipOperators, isTrue);
+      expect(options.excludeGlobs, ['test/**']);
+      expect(options.concurrency, 4);
+      expect(options.onProgress, isNull);
+    });
+  });
+}
+
+/// A [UsageException] whose message matches [message].
+Matcher isUsageException(Matcher message) =>
+    isA<UsageException>().having((e) => e.message, 'message', message);
+
+/// A [FormatException] whose message names [origin] and matches [message].
+Matcher isFormatException(String origin, Matcher message) =>
+    isA<FormatException>()
+        .having((e) => e.message, 'message', startsWith('$origin:'))
+        .having((e) => e.message, 'message', message);


### PR DESCRIPTION
Every command-line option can now be set in a `ciach.yaml`, discovered automatically in the analyzed package root.

```yaml
public: false                     # --no-public
exclude: ['test/**', 'tool/**']   # repeatable options take a list, or a bare string
kinds: [class, function, method]
format: github
set-exit-if-changed: true
```

- **Precedence** is command line > config file > built-in default. An explicitly passed flag wins even when its value equals the default (`ciach --public` beats `public: false`), and a repeatable option on the command line *replaces* the config's list rather than appending.
- **Discovery** looks for that one file name in the package root only — no walking up to parents, so each package in a monorepo owns its config. `--config <path>` reads a file from anywhere else; `--no-config` ignores a discovered one (combining the two is a usage error).
- **Errors** name the file and the offending key: unknown keys (with the valid list), wrong-typed values, bad `format`/`kinds`, non-positive `concurrency`. Exit code 2, as with any usage error.
- A test asserts every long option name has a matching config key, so the two can't drift.

## Structure

- `lib/src/cli/config.dart` — `ConfigFile`: the validated settings a file holds, where they came from, whether it was skipped, and typed readers that name the file and key on a mismatch.
- `lib/src/cli/options.dart` — `ResolvedOptions` + `resolveOptions`/`resolveConfiguration`, the single place the three layers merge (via `package:config`), and the last type that knows where a setting came from. Also owns `finderOptions()`.
- Each option is declared once, as a `CiachOption` enum entry carrying its command-line spelling, help text, default, constraints, and the `configKey` a `ciach.yaml` entry is read from.
- `FinderOptions` is untouched — it's the public library API, and CLI-only settings don't belong there.

Config values are validated on read, so `resolveOptions` reads every key *before* deciding whether to use it — otherwise a typo would go unreported whenever the command line overrode that same option.

Adds `yaml: ^3.1.3` and `config: ^0.9.0`.

## Testing

`dart analyze`, `dart format --set-exit-if-changed` and `dart test` (153 tests) all pass.

## Split from #27

This is the first of two stacked PRs splitting #27, which bundled the config file with `--verbose`. This PR contains only the config-file feature; verbose mode follows as a second PR stacked on top.

---
_Generated by [Claude Code](https://claude.ai/code)_