### PR TITLE
Add a --verbose mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Add config file support: any option can be set in a `ciach.yaml` in the
   package root, and the command line overrides it. `--config <path>` reads one
   from elsewhere, `--no-config` ignores it.
+- Add `-v`, `--verbose` to narrate a run on stderr: config used, every setting
+  and the layer it came from, scan phases, what `--remove` touches. Supersedes
+  `--progress`.
 - Fix a comment mentioning `@override` or `vm:entry-point` skipping the declaration below it. ([#29](https://github.com/leancodepl/ciach/pull/29))
 - Add a secondary `textDocument/definition` check for zero-reference
   declarations, so valid uses the reference search misses no longer produce

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ ciach --no-public -f json              # private-only (highest confidence), as J
 ciach -f github --set-exit-if-changed  # CI: annotations, non-zero if anything is found
 ciach --remove                         # delete the findings, after confirming
 ciach --remove --force                 # …without asking
+ciach --verbose                        # explain what's happening
 ```
 
 ### Options
@@ -80,6 +81,7 @@ ciach --remove --force                 # …without asking
 | `-j, --concurrency <n>` | `16` | Reference queries kept in flight against the analysis server. |
 | `--[no-]color` | auto | Colorize text output. |
 | `--[no-]progress` | auto | Show scan progress on stderr. |
+| `-v, --verbose` | off | Explain what's happening on stderr. See [Verbose mode](#verbose-mode). |
 | `--dart <path>` | current SDK | Path to the `dart` executable to launch the server with. |
 
 Exit codes: `0` success, `1` unused found with `--set-exit-if-changed`, `2`
@@ -107,6 +109,34 @@ Discovery looks for that one file name in the analyzed package root, never in a
 parent, so each package in a monorepo owns its config. `--config <path>` reads
 one from elsewhere; `--no-config` ignores a discovered one; the two can't be
 combined.
+
+### Verbose mode
+
+`-v` narrates the run on stderr, with elapsed times: the config file read and
+what it set, every setting and the layer it came from, each scan phase, anything
+the definition check rescued, and what `--remove` touches.
+
+```console
+$ ciach -v
+[  0.0s] Read config from ciach.yaml.
+[  0.0s]   It sets 2 options:
+[  0.0s]     public: false
+[  0.0s]     exclude: test/**
+[  0.0s] Settings for this run:
+[  0.0s]   path: /home/me/pkg (command line)
+[  0.0s]   public: false (config file)
+[  0.0s]   exclude: test/** (config file)
+[  0.0s]   concurrency: 16 (default)
+[  0.0s]   color: true (auto-detected)
+…
+[  0.1s] Starting Dart analysis server…
+[  0.3s] Collecting declarations from 13 file(s)…
+[  0.5s] Scanned 13 file(s) and checked 44 declaration(s) in 478ms: 4 unused, 1 referenced only from doc comments.
+```
+
+It all goes to stderr, so `ciach -v -f json | jq` still works. Reach for it when
+a config file seems not to apply, or to find the phase eating the time. It
+supersedes `--progress`, whose self-overwriting line would fight with it.
 
 ### Doc-only findings
 

--- a/bin/ciach.dart
+++ b/bin/ciach.dart
@@ -15,7 +15,9 @@ import 'package:ciach/ciach.dart';
 import 'package:ciach/src/cli/args.dart';
 import 'package:ciach/src/cli/config.dart';
 import 'package:ciach/src/cli/options.dart';
+import 'package:ciach/src/cli/verbose.dart';
 import 'package:ciach/src/reporter.dart';
+import 'package:collection/collection.dart';
 import 'package:config/config.dart';
 import 'package:path/path.dart' as p;
 
@@ -56,13 +58,15 @@ Future<int> _run(List<String> arguments) async {
   final projectDir = args.rest.isEmpty ? '.' : args.rest.first;
 
   final ResolvedOptions resolved;
+  final ConfigFile config;
+  final CiachConfiguration configuration;
   try {
-    final config = ConfigFile.load(
+    config = .load(
       projectDir: projectDir,
       explicitPath: explicitConfig,
       ignore: ignoreConfig,
     );
-    final configuration = resolveConfiguration(args, config);
+    configuration = resolveConfiguration(args, config);
     resolved = resolveOptions(
       configuration,
       colorDefault: stdout.supportsAnsiEscapes,
@@ -76,6 +80,9 @@ Future<int> _run(List<String> arguments) async {
     stderr.writeln(e.message);
     return 2;
   }
+
+  final log = resolved.verbose ? _VerboseLog() : null;
+  log?.writeAll(describeConfigSource(config, projectDir: projectDir));
 
   final rootDir = Directory(resolved.rootPath);
   if (!rootDir.existsSync()) {
@@ -95,11 +102,21 @@ Future<int> _run(List<String> arguments) async {
   final showProgress = resolved.showProgress;
   final rootPath = resolved.absoluteRootPath;
 
+  log?.writeAll(
+    describeSettings(
+      configuration,
+      resolved,
+      dartExecutable: resolved.dartExecutable ?? Platform.resolvedExecutable,
+    ),
+  );
+
   final FinderResult result;
   try {
     result = await Ciach(
       resolved.finderOptions(
-        onProgress: showProgress ? _ProgressPrinter().update : null,
+        // Verbose keeps every phase line; progress overwrites one in place.
+        onProgress:
+            log?.write ?? (showProgress ? _ProgressPrinter().update : null),
       ),
     ).run();
   } on Object catch (e, st) {
@@ -116,6 +133,15 @@ Future<int> _run(List<String> arguments) async {
     stderr.writeln();
   }
 
+  log?.write(
+    'Scanned ${result.filesScanned} file(s) and checked ${result.declarationsChecked} declaration(s) in ${result.elapsed.inMilliseconds}ms: ${result.unused.length} unused, ${result.docOnly.length} referenced only from doc comments.',
+  );
+  if (result.recoveredReferences.isNotEmpty) {
+    log?.write(
+      'Kept ${result.recoveredReferences.length} declaration(s) the reference search called unused: the definition check found a use for each. Reported as warnings.',
+    );
+  }
+
   switch (format) {
     case 'json':
       stdout.writeln(Reporter.json(result));
@@ -125,6 +151,7 @@ Future<int> _run(List<String> arguments) async {
       final prefix = p
           .split(p.relative(rootPath, from: Directory.current.path))
           .join('/');
+      log?.write("Prefixing annotation paths with '$prefix/'.");
       stdout.write(Reporter.github(result, pathPrefix: prefix));
     case _:
       stdout.writeln(Reporter.text(result, useColor: useColor));
@@ -134,7 +161,9 @@ Future<int> _run(List<String> arguments) async {
   }
 
   if (result.unused.isNotEmpty && resolved.remove) {
-    await _removeUnused(result, rootPath, resolved, format, useColor);
+    await _removeUnused(result, rootPath, resolved, format, useColor, log);
+  } else if (result.unused.isNotEmpty) {
+    log?.write('Leaving the findings in place; --remove was not given.');
   }
 
   if (result.unused.isNotEmpty && resolved.setExitIfChanged) {
@@ -151,12 +180,21 @@ Future<void> _removeUnused(
   ResolvedOptions resolved,
   String format,
   bool useColor,
+  _VerboseLog? log,
 ) async {
   final count = result.unused.length;
   final plural = count == 1 ? '' : 's';
 
+  final blocked = result.unused.where((d) => d.removalBlocked).length;
+  if (blocked > 0) {
+    log?.write(
+      'Skipping $blocked of $count finding$plural: removing them safely would need a source rewrite (see --unused-union-members and remove safety).',
+    );
+  }
+
   var proceed = resolved.force;
   if (!proceed) {
+    log?.write('Asking for confirmation; pass --force to skip the prompt.');
     // The chosen --format may not be human-readable; show the findings
     // again so the confirmation prompt is never a shot in the dark.
     if (format != 'text') {
@@ -180,6 +218,15 @@ Future<void> _removeUnused(
     return;
   }
 
+  if (log != null) {
+    final byFile = result.unused
+        .whereNot((d) => d.removalBlocked)
+        .groupFoldBy<String, int>((d) => d.filePath, (n, _) => (n ?? 0) + 1);
+    for (final entry in byFile.entries) {
+      log.write('Rewriting ${entry.key} (${entry.value} declaration(s)).');
+    }
+  }
+
   final filesChanged = removeDeclarations(result.unused, rootPath);
   stdout.writeln(
     "Removed $count unused declaration$plural from $filesChanged file${filesChanged == 1 ? '' : 's'}. Run 'dart format' to tidy up spacing.",
@@ -193,6 +240,21 @@ Future<void> _removeUnused(
   for (final note in removedHints) {
     stdout.writeln('Note: $note');
   }
+}
+
+/// Prints `--verbose` narration to stderr — not stdout, so `-f json` stays
+/// machine-readable — one line per message, stamped with the elapsed time.
+class _VerboseLog {
+  final _stopwatch = Stopwatch()..start();
+
+  /// Writes one stamped line.
+  void write(String message) {
+    final seconds = (_stopwatch.elapsedMilliseconds / 1000).toStringAsFixed(1);
+    stderr.writeln('[${seconds.padLeft(5)}s] $message');
+  }
+
+  /// Writes a line per message.
+  void writeAll(Iterable<String> messages) => messages.forEach(write);
 }
 
 /// Prints single-line, overwriting progress to stderr.

--- a/bin/ciach.dart
+++ b/bin/ciach.dart
@@ -138,7 +138,7 @@ Future<int> _run(List<String> arguments) async {
   );
   if (result.recoveredReferences.isNotEmpty) {
     log?.write(
-      'Kept ${result.recoveredReferences.length} declaration(s) the reference search called unused: the definition check found a use for each. Reported as warnings.',
+      'Kept ${result.recoveredReferences.length} declaration(s) the reference search called unused: the definition check found a use for each.',
     );
   }
 

--- a/lib/src/cli/args.dart
+++ b/lib/src/cli/args.dart
@@ -282,6 +282,19 @@ enum CiachOption<V> implements OptionDefinition<V> {
       helpText: 'Show scan progress on stderr. Defaults to on for a terminal.',
     ),
   ),
+  verbose(
+    FlagOption(
+      argName: 'verbose',
+      argAbbrev: 'v',
+      configKey: '/verbose',
+      defaultsTo: false,
+      helpText:
+          'Explain what is happening on stderr: which config file was used and\n'
+          'what it set, the settings the run ended up with, each scan phase as\n'
+          'it starts, and what --remove touches. Supersedes --progress, whose\n'
+          'single overwriting line would fight with it.',
+    ),
+  ),
   concurrency(
     IntOption(
       argName: 'concurrency',
@@ -347,7 +360,8 @@ ${_wrapped(kindNames, indent: '  ')}
 Config file:
   Every option above can also be set in $configFileName in the package root,
   keyed by its long name, plus `path` for the positional argument. The command
-  line wins over the file; --no-config ignores the file.
+  line wins over the file; --no-config ignores the file; --verbose says which
+  file was read and what it set.
 
     # $configFileName
     public: false

--- a/lib/src/cli/config.dart
+++ b/lib/src/cli/config.dart
@@ -77,8 +77,8 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
   /// Finds and reads the config file for a run: [explicitPath] from `--config`
   /// if given, else [configFileName] in [projectDir].
   ///
-  /// With [ignore] the file is located but never read, so a caller can still
-  /// name what `--no-config` skipped, and an unparseable file is no error.
+  /// With [ignore] the file is located but never read, so `--verbose` can name
+  /// what `--no-config` skipped and an unparseable file is no error.
   ///
   /// Throws a [FormatException] if [explicitPath] is missing or the file cannot
   /// be read or parsed.

--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -26,6 +26,7 @@ class ResolvedOptions {
     required this.format,
     required this.useColor,
     required this.showProgress,
+    required this.verbose,
     required this.concurrency,
     required this.dartExecutable,
   });
@@ -52,8 +53,10 @@ class ResolvedOptions {
   final String format;
   final bool useColor;
 
-  /// Whether to show scan progress.
+  /// Whether to show scan progress. Always `false` when [verbose] is set, whose
+  /// durable lines the overwriting progress line would fight with.
   final bool showProgress;
+  final bool verbose;
   final int concurrency;
   final String? dartExecutable;
 
@@ -97,26 +100,35 @@ ResolvedOptions resolveOptions(
   CiachConfiguration configuration, {
   required bool colorDefault,
   required bool progressDefault,
-}) => .new(
-  rootPath: configuration.value(CiachOption.path),
-  includeGlobs: configuration.value(CiachOption.include),
-  excludeGlobs: configuration.value(CiachOption.exclude),
-  additionalGeneratedSuffixes: configuration.value(CiachOption.generatedSuffix),
-  // Already validated by the option; this only converts the names.
-  kinds: parseKinds(configuration.value(CiachOption.kinds)),
-  includePublic: configuration.value(CiachOption.public),
-  includeGenerated: configuration.value(CiachOption.generated),
-  overrides: configuration.value(CiachOption.overrides),
-  operators: configuration.value(CiachOption.operators),
-  unusedUnionMembers: configuration.value(CiachOption.unusedUnionMembers),
-  reportToJson: configuration.value(CiachOption.reportToJson),
-  setExitIfChanged: configuration.value(CiachOption.setExitIfChanged),
-  remove: configuration.value(CiachOption.remove),
-  force: configuration.value(CiachOption.force),
-  format: configuration.value(CiachOption.format),
-  useColor: configuration.optionalValue(CiachOption.color) ?? colorDefault,
-  showProgress:
-      configuration.optionalValue(CiachOption.progress) ?? progressDefault,
-  concurrency: configuration.value(CiachOption.concurrency),
-  dartExecutable: configuration.optionalValue(CiachOption.dart),
-);
+}) {
+  final verbose = configuration.value(CiachOption.verbose);
+
+  return .new(
+    rootPath: configuration.value(CiachOption.path),
+    includeGlobs: configuration.value(CiachOption.include),
+    excludeGlobs: configuration.value(CiachOption.exclude),
+    additionalGeneratedSuffixes: configuration.value(
+      CiachOption.generatedSuffix,
+    ),
+    // Already validated by the option; this only converts the names.
+    kinds: parseKinds(configuration.value(CiachOption.kinds)),
+    includePublic: configuration.value(CiachOption.public),
+    includeGenerated: configuration.value(CiachOption.generated),
+    overrides: configuration.value(CiachOption.overrides),
+    operators: configuration.value(CiachOption.operators),
+    unusedUnionMembers: configuration.value(CiachOption.unusedUnionMembers),
+    reportToJson: configuration.value(CiachOption.reportToJson),
+    setExitIfChanged: configuration.value(CiachOption.setExitIfChanged),
+    remove: configuration.value(CiachOption.remove),
+    force: configuration.value(CiachOption.force),
+    format: configuration.value(CiachOption.format),
+    useColor: configuration.optionalValue(CiachOption.color) ?? colorDefault,
+    showProgress:
+        (configuration.optionalValue(CiachOption.progress) ??
+            progressDefault) &&
+        !verbose,
+    verbose: verbose,
+    concurrency: configuration.value(CiachOption.concurrency),
+    dartExecutable: configuration.optionalValue(CiachOption.dart),
+  );
+}

--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -124,9 +124,8 @@ ResolvedOptions resolveOptions(
     format: configuration.value(CiachOption.format),
     useColor: configuration.optionalValue(CiachOption.color) ?? colorDefault,
     showProgress:
-        (configuration.optionalValue(CiachOption.progress) ??
-            progressDefault) &&
-        !verbose,
+        !verbose &&
+        (configuration.optionalValue(CiachOption.progress) ?? progressDefault),
     verbose: verbose,
     concurrency: configuration.value(CiachOption.concurrency),
     dartExecutable: configuration.optionalValue(CiachOption.dart),

--- a/lib/src/cli/verbose.dart
+++ b/lib/src/cli/verbose.dart
@@ -1,0 +1,113 @@
+import 'package:ciach/src/cli/args.dart';
+import 'package:ciach/src/cli/config.dart';
+import 'package:ciach/src/cli/options.dart';
+import 'package:ciach/src/models.dart';
+import 'package:collection/collection.dart';
+import 'package:config/config.dart';
+import 'package:pro_lsp/pro_lsp.dart' show SymbolKind;
+
+/// The `--verbose` account of the config file: read (and what it set), skipped,
+/// or missing from [projectDir], which is named so a file that sits elsewhere
+/// and silently didn't apply is obvious.
+List<String> describeConfigSource(
+  ConfigFile config, {
+  required String projectDir,
+}) {
+  final path = config.path;
+
+  if (config.ignored) {
+    return [
+      if (path != null)
+        'Ignoring the config file $path (--no-config).'
+      else
+        'Ignoring any config file (--no-config); there is no $configFileName in $projectDir anyway.',
+    ];
+  }
+
+  if (path == null) {
+    return [
+      'No $configFileName in $projectDir; using command-line arguments and built-in defaults.',
+    ];
+  }
+
+  final settings = config.settings;
+  return [
+    'Read config from $path.',
+    if (settings.isEmpty)
+      '  It sets nothing; using command-line arguments and built-in defaults.'
+    else ...[
+      '  It sets ${settings.length} option${settings.length == 1 ? '' : 's'}:',
+      for (final entry in settings.entries)
+        '    ${entry.key}: ${_value(entry.value)}',
+    ],
+  ];
+}
+
+/// The `--verbose` rundown of the run's settings: one line per config key, each
+/// naming the layer its value came from.
+///
+/// [resolved] supplies the values, [configuration] their layers, and
+/// [dartExecutable] the `dart` only the caller can resolve.
+List<String> describeSettings(
+  CiachConfiguration configuration,
+  ResolvedOptions resolved, {
+  required String dartExecutable,
+}) => [
+  'Settings for this run:',
+  for (final option in CiachOption.values)
+    if (option.configKey case final key?)
+      '  $key: ${_setting(option, resolved, dartExecutable)} (${_source(configuration.valueSourceType(option))})',
+];
+
+/// The value of [option] as the run uses it, with the root made absolute, the
+/// kinds as labels, and the auto-detected flags as they settled.
+String _setting(
+  CiachOption<dynamic> option,
+  ResolvedOptions resolved,
+  String dartExecutable,
+) => switch (option) {
+  .path => resolved.absoluteRootPath,
+  .public => '${resolved.includePublic}',
+  .generated => '${resolved.includeGenerated}',
+  .overrides => '${resolved.overrides}',
+  .operators => '${resolved.operators}',
+  .unusedUnionMembers => '${resolved.unusedUnionMembers}',
+  .reportToJson => '${resolved.reportToJson}',
+  .setExitIfChanged => '${resolved.setExitIfChanged}',
+  .remove => '${resolved.remove}',
+  .force => '${resolved.force}',
+  .exclude => _value(resolved.excludeGlobs),
+  .include => _value(resolved.includeGlobs),
+  .generatedSuffix => _value(resolved.additionalGeneratedSuffixes),
+  .kinds => _kinds(resolved.kinds),
+  .format => resolved.format,
+  .color => '${resolved.useColor}',
+  .progress => '${resolved.showProgress}',
+  .verbose => '${resolved.verbose}',
+  .concurrency => '${resolved.concurrency}',
+  .dart => dartExecutable,
+  // No config key, so never listed; spelled out so a new option must be too.
+  .help || .config || .noConfig => '',
+};
+
+/// Where a value came from, in the user's words.
+String _source(ValueSourceType source) => switch (source) {
+  .arg => 'command line',
+  .config => 'config file',
+  .envVar => 'environment',
+  .preset || .custom => 'preset',
+  .defaultValue => 'default',
+  .noValue => 'auto-detected',
+};
+
+/// A value as the log reads it: an empty list is `(none)`, a full one is
+/// comma-separated.
+String _value(Object? value) => switch (value) {
+  [] => '(none)',
+  List() => value.join(', '),
+  _ => '$value',
+};
+
+/// The kind labels, sorted.
+String _kinds(Set<SymbolKind> kinds) =>
+    kinds.map((kind) => kind.label).sorted().join(', ');

--- a/test/config_test.dart
+++ b/test/config_test.dart
@@ -85,6 +85,8 @@ dart: /sdk/bin/dart
       expect(resolved.showProgress, isTrue);
       expect(resolved.concurrency, 4);
       expect(resolved.dartExecutable, '/sdk/bin/dart');
+      // On its own, since it forces `progress` off.
+      expect(resolveFile('verbose: true').verbose, isTrue);
     });
 
     test('covers every command-line option', () {
@@ -239,6 +241,7 @@ concurrency: 4
         'json',
         '--color',
         '--progress',
+        '--verbose',
         '-j',
         '2',
         '--dart',
@@ -398,6 +401,7 @@ concurrency: 4
       expect(resolved.additionalGeneratedSuffixes, isEmpty);
       expect(resolved.kinds, FinderOptions.defaultKinds);
       expect(resolved.format, 'text');
+      expect(resolved.verbose, isFalse);
       expect(resolved.concurrency, 16);
       expect(resolved.dartExecutable, isNull);
     });
@@ -503,6 +507,51 @@ dart: /sdk/bin/dart
       );
       expect(fromArgs.useColor, isFalse);
       expect(fromArgs.showProgress, isFalse);
+    });
+
+    test('verbose comes from the command line or the config', () {
+      expect(resolve(const ['--verbose']).verbose, isTrue);
+      expect(resolve(const ['-v']).verbose, isTrue);
+      expect(resolveFile('verbose: true').verbose, isTrue);
+      expect(
+        resolve(const [
+          '--no-verbose',
+        ], .parse('verbose: true', origin: 'c.yaml')).verbose,
+        isFalse,
+      );
+    });
+
+    test('verbose supersedes the progress line', () {
+      // Both write to stderr, so verbose wins however progress was asked for.
+      expect(
+        resolveWith(
+          const ['--verbose', '--progress'],
+          const .empty(),
+          colorDefault: false,
+          progressDefault: true,
+        ).showProgress,
+        isFalse,
+      );
+      expect(
+        resolveWith(
+          const [],
+          .parse('verbose: true\nprogress: true', origin: 'c.yaml'),
+          colorDefault: false,
+          progressDefault: true,
+        ).showProgress,
+        isFalse,
+      );
+      expect(
+        resolveWith(
+          const ['--progress'],
+          .parse('verbose: true', origin: 'c.yaml'),
+          colorDefault: false,
+          progressDefault: false,
+        ).showProgress,
+        isFalse,
+      );
+      // …but progress still works when verbose is off.
+      expect(resolve(const ['--progress']).showProgress, isTrue);
     });
 
     test('rejects a non-positive --concurrency', () {

--- a/test/verbose_test.dart
+++ b/test/verbose_test.dart
@@ -1,0 +1,174 @@
+import 'dart:io';
+
+import 'package:ciach/ciach.dart';
+import 'package:ciach/src/cli/args.dart';
+import 'package:ciach/src/cli/config.dart';
+import 'package:ciach/src/cli/options.dart';
+import 'package:ciach/src/cli/verbose.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  final parser = buildParser();
+
+  group('describeConfigSource', () {
+    test('names the file it read and every option it set', () {
+      final lines = describeConfigSource(
+        .parse("public: false\nexclude: ['test/**']", origin: '/c.yaml'),
+        projectDir: '/pkg',
+      );
+
+      expect(lines, [
+        'Read config from /c.yaml.',
+        '  It sets 2 options:',
+        '    public: false',
+        '    exclude: test/**',
+      ]);
+    });
+
+    test('says so when the file it read is empty', () {
+      final lines = describeConfigSource(
+        .parse('# nothing\n', origin: '/pkg/ciach.yaml'),
+        projectDir: '/pkg',
+      );
+
+      expect(lines, [
+        'Read config from /pkg/ciach.yaml.',
+        contains('It sets nothing'),
+      ]);
+    });
+
+    test('names the directory it searched when nothing was found', () {
+      final lines = describeConfigSource(
+        const .empty(),
+        projectDir: 'packages/app',
+      );
+
+      expect(lines, [
+        allOf(contains('No ciach.yaml in packages/app'), contains('defaults')),
+      ]);
+    });
+
+    test('names the file it skipped for --no-config', () {
+      final dir = Directory.systemTemp.createTempSync('ciach_verbose_test_');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      File(p.join(dir.path, configFileName)).writeAsStringSync('public: false');
+
+      final lines = describeConfigSource(
+        .load(projectDir: dir.path, ignore: true),
+        projectDir: dir.path,
+      );
+
+      expect(lines, [
+        'Ignoring the config file ${p.join(dir.path, 'ciach.yaml')} (--no-config).',
+      ]);
+    });
+
+    test('says --no-config changed nothing when there was no file', () {
+      final dir = Directory.systemTemp.createTempSync('ciach_verbose_test_');
+      addTearDown(() => dir.deleteSync(recursive: true));
+
+      final lines = describeConfigSource(
+        .load(projectDir: dir.path, ignore: true),
+        projectDir: dir.path,
+      );
+
+      expect(lines, [
+        allOf(
+          contains('--no-config'),
+          contains('no ciach.yaml in ${dir.path}'),
+        ),
+      ]);
+    });
+  });
+
+  group('describeSettings', () {
+    List<String> describe([List<String> arguments = const []]) {
+      final configuration = resolveConfiguration(
+        parser.parse(arguments),
+        const .empty(),
+      );
+      return describeSettings(
+        configuration,
+        resolveOptions(
+          configuration,
+          colorDefault: false,
+          progressDefault: false,
+        ),
+        dartExecutable: '/sdk/bin/dart',
+      );
+    }
+
+    test('lists every setting the run uses, under one key per option', () {
+      final lines = describe();
+
+      expect(lines.first, 'Settings for this run:');
+      final keys = lines.skip(1).map((l) => l.trim().split(':').first).toSet();
+      // `path` stands in for the positional argument, as in the config file.
+      expect(keys, configKeys);
+    });
+
+    test('reports the resolved values, not the raw arguments', () {
+      final lines = describe(const [
+        '--no-public',
+        '-e',
+        'test/**',
+        '-j',
+        '4',
+        '/pkg',
+      ]);
+
+      expect(lines, containsAll(<String>['  path: /pkg (command line)']));
+      expect(lines, contains('  public: false (command line)'));
+      expect(lines, contains('  exclude: test/** (command line)'));
+      expect(lines, contains('  concurrency: 4 (command line)'));
+      expect(lines, contains('  dart: /sdk/bin/dart (auto-detected)'));
+    });
+
+    test('names the layer each value came from', () {
+      final configuration = resolveConfiguration(
+        parser.parse(const ['--no-public']),
+        .parse('format: json\nremove: true', origin: 'c.yaml'),
+      );
+      final lines = describeSettings(
+        configuration,
+        resolveOptions(
+          configuration,
+          colorDefault: false,
+          progressDefault: false,
+        ),
+        dartExecutable: '/sdk/bin/dart',
+      );
+
+      expect(lines, contains('  public: false (command line)'));
+      expect(lines, contains('  format: json (config file)'));
+      expect(lines, contains('  remove: true (config file)'));
+      expect(lines, contains('  concurrency: 16 (default)'));
+      expect(lines, contains('  color: false (auto-detected)'));
+    });
+
+    test('marks an empty list rather than printing nothing', () {
+      expect(describe(), contains('  exclude: (none) (default)'));
+      expect(describe(), contains('  include: (none) (default)'));
+      expect(describe(), contains('  generated-suffix: (none) (default)'));
+    });
+
+    test('lists the kinds, all of them by default', () {
+      final kinds = describe()
+          .singleWhere((l) => l.startsWith('  kinds:'))
+          .replaceFirst('  kinds: ', '')
+          .replaceFirst(' (default)', '')
+          .split(', ');
+
+      // Two aliases can map to one kind, so labels can be fewer.
+      expect(kinds, hasLength(FinderOptions.defaultKinds.length));
+      expect(
+        describe(const [
+          '-k',
+          'class,method',
+        ]).singleWhere((l) => l.startsWith('  kinds:')),
+        '  kinds: class, method (command line)',
+      );
+    });
+  });
+}

--- a/test/verbose_test.dart
+++ b/test/verbose_test.dart
@@ -148,9 +148,11 @@ void main() {
     });
 
     test('marks an empty list rather than printing nothing', () {
-      expect(describe(), contains('  exclude: (none) (default)'));
-      expect(describe(), contains('  include: (none) (default)'));
-      expect(describe(), contains('  generated-suffix: (none) (default)'));
+      final lines = describe();
+
+      expect(lines, contains('  exclude: (none) (default)'));
+      expect(lines, contains('  include: (none) (default)'));
+      expect(lines, contains('  generated-suffix: (none) (default)'));
     });
 
     test('lists the kinds, all of them by default', () {


### PR DESCRIPTION
Stacked on #32. Adds `-v, --verbose`, which narrates a run on stderr with elapsed-time stamps: which config file was read and what it set, the settings the run resolved to, each scan phase, the scan summary, and what `--remove` touches.

```console
$ ciach -v
[  0.0s] Read config from ciach.yaml.
[  0.0s]   It sets 2 options:
[  0.0s]     public: false
[  0.0s]     exclude: test/**
[  0.0s] Settings for this run:
[  0.0s]   path: /home/me/pkg
…
[  0.1s] Starting Dart analysis server…
[  0.3s] Collecting declarations from 13 file(s)…
[  0.5s] Scanned 13 file(s) and checked 44 declaration(s) in 478ms: 4 unused, 1 referenced only from doc comments.
```

Everything goes to stderr, so `ciach -v -f json | jq` still works. It supersedes `--progress`, whose self-overwriting line would fight with it. Settable in the config as `verbose: true`, like everything else.

## Structure

- `lib/src/cli/verbose.dart` — the two message builders (`describeConfigSource`, `describeSettings`), as pure functions returning lines; `bin/` only owns the stderr printer (`_VerboseLog`).

## Testing

`dart analyze`, `dart format --set-exit-if-changed` and `dart test` (165 tests, 12 of them new) all pass.

## Split from #27

Second of two stacked PRs splitting #27 (see #32 for the first). Diffed against #27's final state — this branch's tree is byte-identical to it once merged, aside from unrelated files that changed on `main` since #27 branched.

---
_Generated by [Claude Code](https://claude.ai/code)_