### PR TITLE
Support Dart 3.13 primary constructors

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Dart
         uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
-          sdk: '3.12'
+          sdk: '3.13'
 
       - name: Download pub dependencies
         run: dart pub get

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Dart
         uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
-          sdk: '3.12'
+          sdk: '3.13'
 
       - name: Download pub dependencies
         run: dart pub get

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,15 @@
 ## Unreleased
 
-- Support Dart 3.13 primary constructors. A declaration in a class *header* —
-  the primary constructor itself, or a `var`/`final` declaring parameter — is
-  reported when dead but never auto-removed: deleting the constructor alone left
-  a `class ;` fragment, and deleting a declaring parameter silently changed the
-  constructor's signature. Both now carry a hint explaining why.
+- Support Dart 3.13 primary constructors. A dead declaration in a class *header*
+  — the primary constructor, or a `var`/`final` declaring parameter — is now
+  report-only: `--remove` used to delete it, leaving a `class ;` fragment or
+  silently changing the constructor's signature.
 - Stop reporting a primary constructor's `this : …` body part as a bogus
-  `Class.this` finding; it is the tail of the constructor declared in the
-  header, not a declaration of its own.
-- Stop reporting a dead class's declaring parameters separately: they are part
-  of the class declaration and go with it, like its constructors.
-- Count only what `--remove` actually deletes in its summary, and name how many
-  findings were left in place as report-only.
+  `Class.this` finding.
+- Stop reporting a dead class's declaring parameters separately; they go with
+  the class, like its constructors.
+- Count only what `--remove` actually deletes in its summary, and say how many
+  findings it left in place.
 
 ## 0.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,11 @@
 ## Unreleased
 
 - Support Dart 3.13 primary constructors. A dead declaration in a class *header*
-  — the primary constructor, or a `var`/`final` declaring parameter — is now
+  — the constructor, or a `var`/`final` declaring parameter — is now
   report-only: `--remove` used to delete it, leaving a `class ;` fragment or
-  silently changing the constructor's signature.
-- Stop reporting a primary constructor's `this : …` body part as a bogus
-  `Class.this` finding.
-- Stop reporting a dead class's declaring parameters separately; they go with
-  the class, like its constructors.
+  silently changing the constructor's signature. A dead class's declaring
+  parameters go with the class rather than being reported separately, and the
+  `this : …` body part is no longer reported as a bogus `Class.this` finding.
 - Count only what `--remove` actually deletes in its summary, and say how many
   findings it left in place.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## Unreleased
+
+- Support Dart 3.13 primary constructors. A declaration in a class *header* —
+  the primary constructor itself, or a `var`/`final` declaring parameter — is
+  reported when dead but never auto-removed: deleting the constructor alone left
+  a `class ;` fragment, and deleting a declaring parameter silently changed the
+  constructor's signature. Both now carry a hint explaining why.
+- Stop reporting a primary constructor's `this : …` body part as a bogus
+  `Class.this` finding; it is the tail of the constructor declared in the
+  header, not a declaration of its own.
+- Stop reporting a dead class's declaring parameters separately: they are part
+  of the class declaration and go with it, like its constructors.
+- Count only what `--remove` actually deletes in its summary, and name how many
+  findings were left in place as report-only.
+
 ## 0.4.1
 
 - Fix a constructor reached only through a dot shorthand (`.new(…)`), from a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,11 @@
 ## Unreleased
 
-- Support Dart 3.13 primary constructors. A dead declaration in a class *header*
-  — the constructor, or a `var`/`final` declaring parameter — is now
-  report-only: `--remove` used to delete it, leaving a `class ;` fragment or
-  silently changing the constructor's signature. A dead class's declaring
-  parameters go with the class rather than being reported separately, and the
-  `this : …` body part is no longer reported as a bogus `Class.this` finding.
-- Count only what `--remove` actually deletes in its summary, and say how many
-  findings it left in place.
+- Support Dart 3.13 primary constructors: a dead constructor or declaring
+  parameter in a class header is report-only, since `--remove` cannot delete
+  part of a header.
+- Stop reporting a primary constructor's `this : …` body part as a `Class.this`
+  finding, and a dead class's declaring parameters separately from the class.
+- Count only what `--remove` actually deletes in its summary.
 
 ## 0.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.4.2
 
 - Support Dart 3.13 primary constructors: a dead constructor or declaring
   parameter in a class header is report-only, since `--remove` cannot delete

--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ dart run ciach
 Examples below show bare `ciach …`; prefix them with `dart run` for the second.
 
 ciach runs on Dart 3.10 and up, but analyzes with the SDK it is invoked with, so
-scanning code that uses newer syntax needs an SDK that can parse it — 3.13 or
-later for [primary constructors](#primary-constructors).
+scanning code needs an SDK new enough to parse it.
 
 ## Usage
 
@@ -205,11 +204,13 @@ you would after any automated refactor.
 
 Findings whose removal wouldn't compile are **report-only**: marked `unsafe to
 auto-remove — remove manually` and skipped, along with anything coupled to them.
-Those are a sealed member kept dead only by type patterns
-(`--unused-union-members`), an enum value whose removal would empty a
-still-referenced enum, the sole constructor of a live class with `final` fields
-or super-constructor forwarding, and anything declared in a class *header*
-(see [Primary constructors](#primary-constructors)).
+
+| Report-only finding | Why |
+| --- | --- |
+| A sealed member matched only by type patterns (`--unused-union-members`) | its `case` arms would need rewriting |
+| Every value of a still-referenced enum | `enum E {}` doesn't compile |
+| The sole constructor of a live class with `final` fields or `super` forwarding | the implicit default constructor can't replace it |
+| [Anything in a class header](#primary-constructors) | only part of a declaration |
 
 ### Primary constructors
 
@@ -217,12 +218,11 @@ or super-constructor forwarding, and anything declared in a class *header*
 class const Endpoint.of(final String host, final int port);
 ```
 
-A dead class is removed in one piece, `;` body and all, but a *part* of a header
-never is: removing the constructor would leave `class ;`, and removing a
-declaring parameter would change the signature at every call site, so both are
-report-only. Abbreviated in-body headers (`new named()`, `factory fact()`) are
-ordinary body members and stay removable, and the `this : …` body part is not
-reported at all — it belongs to the constructor in the header.
+- A dead class goes whole, `;` body and all.
+- Its constructor and declaring parameters are report-only: deleting one would
+  leave `class ;` or change the signature at every call site.
+- Body members (`new named()`, `factory fact()`) stay removable; the `this : …`
+  body part is never reported.
 
 ## What it skips by default
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,9 @@ dart run ciach
 
 Examples below show bare `ciach …`; prefix them with `dart run` for the second.
 
-ciach runs on Dart 3.10 and up, but analyzes with the SDK it is invoked with (or
-the one `--dart` points at), so scanning code that uses newer syntax needs an SDK
-that can parse it — 3.13 or later for
-[primary constructors](#primary-constructors).
+ciach runs on Dart 3.10 and up, but analyzes with the SDK it is invoked with, so
+scanning code that uses newer syntax needs an SDK that can parse it — 3.13 or
+later for [primary constructors](#primary-constructors).
 
 ## Usage
 
@@ -205,7 +204,7 @@ false-positive risk, which `--overrides` and `--operators` widen considerably.
 you would after any automated refactor.
 
 Findings whose removal wouldn't compile are **report-only**: marked `unsafe to
-auto-remove — remove manually`, and skipped along with anything coupled to them.
+auto-remove — remove manually` and skipped, along with anything coupled to them.
 Those are a sealed member kept dead only by type patterns
 (`--unused-union-members`), an enum value whose removal would empty a
 still-referenced enum, the sole constructor of a live class with `final` fields
@@ -214,24 +213,16 @@ or super-constructor forwarding, and anything declared in a class *header*
 
 ### Primary constructors
 
-Dart 3.13 lets a class declare its constructor, and the instance variables its
-`var`/`final` parameters induce, in the header:
-
 ```dart
 class const Endpoint.of(final String host, final int port);
 ```
 
-A dead one is reported, and a class dead as a whole is removed in one piece, `;`
-body and all — but a *part* of a header is never deleted: removing the
-constructor would leave `class ;`, and removing a declaring parameter would
-change the signature at every call site, so both are report-only. The
-abbreviated in-body headers from the same feature (`new named()`,
-`factory fact()`, `const factory redir() = C;`) are ordinary body members and
-stay removable. The `this : …` body part is the header constructor's tail, not a
-declaration, so it is never reported separately.
-
-[example/lib/scenarios/primary_constructors.dart](example/lib/scenarios/primary_constructors.dart)
-covers each shape.
+A dead class is removed in one piece, `;` body and all, but a *part* of a header
+never is: removing the constructor would leave `class ;`, and removing a
+declaring parameter would change the signature at every call site, so both are
+report-only. Abbreviated in-body headers (`new named()`, `factory fact()`) are
+ordinary body members and stay removable, and the `this : …` body part is not
+reported at all — it belongs to the constructor in the header.
 
 ## What it skips by default
 

--- a/README.md
+++ b/README.md
@@ -210,19 +210,7 @@ auto-remove — remove manually` and skipped, along with anything coupled to the
 | A sealed member matched only by type patterns (`--unused-union-members`) | its `case` arms would need rewriting |
 | Every value of a still-referenced enum | `enum E {}` doesn't compile |
 | The sole constructor of a live class with `final` fields or `super` forwarding | the implicit default constructor can't replace it |
-| [Anything in a class header](#primary-constructors) | only part of a declaration |
-
-### Primary constructors
-
-```dart
-class const Endpoint.of(final String host, final int port);
-```
-
-- A dead class goes whole, `;` body and all.
-- Its constructor and declaring parameters are report-only: deleting one would
-  leave `class ;` or change the signature at every call site.
-- Body members (`new named()`, `factory fact()`) stay removable; the `this : …`
-  body part is never reported.
+| A primary constructor or its declaring parameters | only part of the class header |
 
 ## What it skips by default
 
@@ -257,9 +245,9 @@ deleting blindly:
   code you excluded** are invisible to a reference search.
 - **Entry points other than `main`** (isolate entry points, plugin registrants)
   need excluding or `@pragma('vm:entry-point')`.
-- **A [primary constructor](#primary-constructors) shares its class's
-  references**, since a query at the header resolves to the class: a
-  never-invoked one only surfaces once the class itself is dead.
+- **A primary constructor shares its class's references**, since a query at the
+  header resolves to the class: a never-invoked one only surfaces once the class
+  itself is dead.
 - A package that doesn't analyze cleanly (missing `pub get`, errors) yields
   incomplete references.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ dart run ciach
 
 Examples below show bare `ciach …`; prefix them with `dart run` for the second.
 
+ciach itself runs on Dart 3.10 and up, but it analyzes with the SDK you invoke
+it with — it launches that SDK's analysis server (or the one `--dart` points
+at). Scanning a package that uses newer syntax therefore means running ciach on
+an SDK new enough to parse it: Dart 3.13 or later for
+[primary constructors](#primary-constructors), for instance.
+
 ## Usage
 
 ```bash
@@ -199,6 +205,40 @@ false-positive risk, which `--overrides` and `--operators` widen considerably.
 [Doc-only findings](#doc-only-findings) are never included. Review the diff, as
 you would after any automated refactor.
 
+Some findings are **report-only**: real dead code, but deleting the node would
+not compile, so `--remove` leaves them (and anything coupled to them) in place
+and says so, marking each `unsafe to auto-remove — remove manually`. That covers
+a member of a sealed union kept dead only by type patterns
+(`--unused-union-members`), an enum value whose removal would empty a
+still-referenced enum, the sole constructor of a live class with `final` fields
+or super-constructor forwarding, and everything declared in a class *header*
+(see [Primary constructors](#primary-constructors)).
+
+### Primary constructors
+
+Dart 3.13 lets a class declare its constructor — and the instance variables its
+`var`/`final` parameters induce — in the header:
+
+```dart
+class const Endpoint.of(final String host, final int port);
+```
+
+ciach reads these like any other declaration: a dead one is reported, and a
+class that is dead as a whole is removed in one piece, `;` body and all. What it
+never does is delete a *part* of a header. Removing the constructor alone would
+leave a `class ;` fragment, and removing a declaring parameter would silently
+change the constructor's signature at every call site — so both are reported as
+report-only, with a hint saying which. The abbreviated in-body constructor
+headers that ship with the same feature (`new named()`, `factory fact()`, `const
+factory redir() = C;`) are ordinary body members and stay fully removable.
+
+The `this : …` body part that completes a primary constructor is not a
+declaration of its own — it is the tail of the one in the header — so it is
+never reported separately.
+
+See [example/lib/scenarios/primary_constructors.dart](example/lib/scenarios/primary_constructors.dart)
+for a runnable fixture covering each shape.
+
 ## What it skips by default
 
 Each of these is a known source of false positives; the flag opts back in at
@@ -232,6 +272,12 @@ deleting blindly:
   code you excluded** are invisible to a reference search.
 - **Entry points other than `main`** (isolate entry points, plugin registrants)
   need excluding or `@pragma('vm:entry-point')`.
+- **A [primary constructor](#primary-constructors) shares its class's
+  references**: a reference query at the header resolves to the class, so a
+  never-invoked primary constructor of a class that is still used as a type
+  reads as used. The class being dead is what surfaces it — deliberately, since
+  the failure mode is missing a dead constructor rather than deleting a live
+  one.
 - A package that doesn't analyze cleanly (missing `pub get`, errors) yields
   incomplete references.
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,10 @@ dart run ciach
 
 Examples below show bare `ciach …`; prefix them with `dart run` for the second.
 
-ciach itself runs on Dart 3.10 and up, but it analyzes with the SDK you invoke
-it with — it launches that SDK's analysis server (or the one `--dart` points
-at). Scanning a package that uses newer syntax therefore means running ciach on
-an SDK new enough to parse it: Dart 3.13 or later for
-[primary constructors](#primary-constructors), for instance.
+ciach runs on Dart 3.10 and up, but analyzes with the SDK it is invoked with (or
+the one `--dart` points at), so scanning code that uses newer syntax needs an SDK
+that can parse it — 3.13 or later for
+[primary constructors](#primary-constructors).
 
 ## Usage
 
@@ -205,39 +204,34 @@ false-positive risk, which `--overrides` and `--operators` widen considerably.
 [Doc-only findings](#doc-only-findings) are never included. Review the diff, as
 you would after any automated refactor.
 
-Some findings are **report-only**: real dead code, but deleting the node would
-not compile, so `--remove` leaves them (and anything coupled to them) in place
-and says so, marking each `unsafe to auto-remove — remove manually`. That covers
-a member of a sealed union kept dead only by type patterns
+Findings whose removal wouldn't compile are **report-only**: marked `unsafe to
+auto-remove — remove manually`, and skipped along with anything coupled to them.
+Those are a sealed member kept dead only by type patterns
 (`--unused-union-members`), an enum value whose removal would empty a
 still-referenced enum, the sole constructor of a live class with `final` fields
-or super-constructor forwarding, and everything declared in a class *header*
+or super-constructor forwarding, and anything declared in a class *header*
 (see [Primary constructors](#primary-constructors)).
 
 ### Primary constructors
 
-Dart 3.13 lets a class declare its constructor — and the instance variables its
-`var`/`final` parameters induce — in the header:
+Dart 3.13 lets a class declare its constructor, and the instance variables its
+`var`/`final` parameters induce, in the header:
 
 ```dart
 class const Endpoint.of(final String host, final int port);
 ```
 
-ciach reads these like any other declaration: a dead one is reported, and a
-class that is dead as a whole is removed in one piece, `;` body and all. What it
-never does is delete a *part* of a header. Removing the constructor alone would
-leave a `class ;` fragment, and removing a declaring parameter would silently
-change the constructor's signature at every call site — so both are reported as
-report-only, with a hint saying which. The abbreviated in-body constructor
-headers that ship with the same feature (`new named()`, `factory fact()`, `const
-factory redir() = C;`) are ordinary body members and stay fully removable.
+A dead one is reported, and a class dead as a whole is removed in one piece, `;`
+body and all — but a *part* of a header is never deleted: removing the
+constructor would leave `class ;`, and removing a declaring parameter would
+change the signature at every call site, so both are report-only. The
+abbreviated in-body headers from the same feature (`new named()`,
+`factory fact()`, `const factory redir() = C;`) are ordinary body members and
+stay removable. The `this : …` body part is the header constructor's tail, not a
+declaration, so it is never reported separately.
 
-The `this : …` body part that completes a primary constructor is not a
-declaration of its own — it is the tail of the one in the header — so it is
-never reported separately.
-
-See [example/lib/scenarios/primary_constructors.dart](example/lib/scenarios/primary_constructors.dart)
-for a runnable fixture covering each shape.
+[example/lib/scenarios/primary_constructors.dart](example/lib/scenarios/primary_constructors.dart)
+covers each shape.
 
 ## What it skips by default
 
@@ -273,11 +267,8 @@ deleting blindly:
 - **Entry points other than `main`** (isolate entry points, plugin registrants)
   need excluding or `@pragma('vm:entry-point')`.
 - **A [primary constructor](#primary-constructors) shares its class's
-  references**: a reference query at the header resolves to the class, so a
-  never-invoked primary constructor of a class that is still used as a type
-  reads as used. The class being dead is what surfaces it — deliberately, since
-  the failure mode is missing a dead constructor rather than deleting a live
-  one.
+  references**, since a query at the header resolves to the class: a
+  never-invoked one only surfaces once the class itself is dead.
 - A package that doesn't analyze cleanly (missing `pub get`, errors) yields
   incomplete references.
 

--- a/bin/ciach.dart
+++ b/bin/ciach.dart
@@ -188,9 +188,8 @@ Future<void> _removeUnused(
   bool useColor,
   _VerboseLog? log,
 ) async {
-  // Only findings the remover will actually touch are counted: a report-only
-  // one is left in place, so counting it would promise an edit that never
-  // happens.
+  // Report-only findings are left in place, so counting them would promise an
+  // edit that never happens.
   final count = result.unused.whereNot((d) => d.removalBlocked).length;
   final plural = count == 1 ? '' : 's';
 

--- a/bin/ciach.dart
+++ b/bin/ciach.dart
@@ -188,14 +188,24 @@ Future<void> _removeUnused(
   bool useColor,
   _VerboseLog? log,
 ) async {
-  final count = result.unused.length;
+  // Only findings the remover will actually touch are counted: a report-only
+  // one is left in place, so counting it would promise an edit that never
+  // happens.
+  final count = result.unused.whereNot((d) => d.removalBlocked).length;
   final plural = count == 1 ? '' : 's';
 
-  final blocked = result.unused.where((d) => d.removalBlocked).length;
+  final blocked = result.unused.length - count;
   if (blocked > 0) {
     log?.write(
-      'Skipping $blocked of $count finding$plural: removing them safely would need a source rewrite (see --unused-union-members and remove safety).',
+      'Skipping $blocked of ${result.unused.length} finding(s): removing them safely would need a source rewrite (see --unused-union-members and remove safety).',
     );
+  }
+  if (count == 0) {
+    stdout.writeln(
+      'Nothing removed: all $blocked finding${blocked == 1 ? ' is' : 's are'} '
+      'unsafe to auto-remove — remove them manually.',
+    );
+    return;
   }
 
   var proceed = resolved.force;
@@ -234,8 +244,11 @@ Future<void> _removeUnused(
   }
 
   final filesChanged = removeDeclarations(result.unused, rootPath);
+  final left = blocked > 0
+      ? ' $blocked left in place — unsafe to auto-remove.'
+      : '';
   stdout.writeln(
-    "Removed $count unused declaration$plural from $filesChanged file${filesChanged == 1 ? '' : 's'}. Run 'dart format' to tidy up spacing.",
+    "Removed $count unused declaration$plural from $filesChanged file${filesChanged == 1 ? '' : 's'}.$left Run 'dart format' to tidy up spacing.",
   );
   // Repeat any advisory hints: removing a declaration takes the reported line
   // that carried its hint with it.

--- a/example/README.md
+++ b/example/README.md
@@ -4,8 +4,7 @@ This directory is a small, self-contained Dart package (`sample_pkg`) with a
 deliberate mix of **used** and **unused** declarations, spread across several
 files so the report's per-file grouping actually has something to group. It
 doubles as the integration-test fixture, so it is a real, runnable
-demonstration of the tool. It needs Dart 3.13 or later: one scenario fixture is
-written with primary constructors.
+demonstration of the tool.
 
 It comes in two tiers. The files directly under `lib/` are the **demo**: the
 everyday declaration kinds, referenced (or not) from `bin/app.dart`.

--- a/example/README.md
+++ b/example/README.md
@@ -4,8 +4,8 @@ This directory is a small, self-contained Dart package (`sample_pkg`) with a
 deliberate mix of **used** and **unused** declarations, spread across several
 files so the report's per-file grouping actually has something to group. It
 doubles as the integration-test fixture, so it is a real, runnable
-demonstration of the tool. It needs Dart 3.13 or later — one scenario fixture is
-written with primary constructors, which older SDKs cannot parse.
+demonstration of the tool. It needs Dart 3.13 or later: one scenario fixture is
+written with primary constructors.
 
 It comes in two tiers. The files directly under `lib/` are the **demo**: the
 everyday declaration kinds, referenced (or not) from `bin/app.dart`.
@@ -35,7 +35,7 @@ expected; each is scanned only by its own test, never by the demo run above.
 | `serialization.dart` | the `toJson`/`fromJson` conventions, and `--report-tojson` |
 | `comment_annotations.dart` | a comment mentioning `@override` or `vm:entry-point` does not skip the declaration below it |
 | `dot_shorthands.dart`, `dot_shorthand_uses.dart` | every context a `.name` dot shorthand is allowed in, including nested constructor shorthands |
-| `primary_constructors.dart` | Dart 3.13 primary constructors: a dead one is reported but never partly removed, while the abbreviated `new`/`factory` body headers stay removable |
+| `primary_constructors.dart` | primary constructors: a dead declaration in the class header is report-only, while the class body stays removable |
 | `xref_*.dart` | the cross-library reference recovery, and telling same-named members apart |
 
 Run the finder against the demo tier from the repository root:

--- a/example/README.md
+++ b/example/README.md
@@ -4,7 +4,8 @@ This directory is a small, self-contained Dart package (`sample_pkg`) with a
 deliberate mix of **used** and **unused** declarations, spread across several
 files so the report's per-file grouping actually has something to group. It
 doubles as the integration-test fixture, so it is a real, runnable
-demonstration of the tool.
+demonstration of the tool. It needs Dart 3.13 or later — one scenario fixture is
+written with primary constructors, which older SDKs cannot parse.
 
 It comes in two tiers. The files directly under `lib/` are the **demo**: the
 everyday declaration kinds, referenced (or not) from `bin/app.dart`.
@@ -34,6 +35,7 @@ expected; each is scanned only by its own test, never by the demo run above.
 | `serialization.dart` | the `toJson`/`fromJson` conventions, and `--report-tojson` |
 | `comment_annotations.dart` | a comment mentioning `@override` or `vm:entry-point` does not skip the declaration below it |
 | `dot_shorthands.dart`, `dot_shorthand_uses.dart` | every context a `.name` dot shorthand is allowed in, including nested constructor shorthands |
+| `primary_constructors.dart` | Dart 3.13 primary constructors: a dead one is reported but never partly removed, while the abbreviated `new`/`factory` body headers stay removable |
 | `xref_*.dart` | the cross-library reference recovery, and telling same-named members apart |
 
 Run the finder against the demo tier from the repository root:

--- a/example/lib/scenarios/primary_constructors.dart
+++ b/example/lib/scenarios/primary_constructors.dart
@@ -1,0 +1,123 @@
+// Fixtures for Dart 3.13 primary constructors: a constructor (and, for the
+// parameters marked `var`/`final`, the instance variables it initializes)
+// declared in the type's *header* instead of its body, the `this : …` body part
+// that completes it, and the abbreviated `new`/`factory` constructor headers
+// that ship with the same feature. Scanned only by the dedicated
+// primary-constructor tests; see test/finder_test.dart.
+//
+// The rule this file pins down: anything declared in the header is reported
+// when dead, but never auto-removed. Deleting the constructor alone would leave
+// a `class ;` fragment, and deleting a declaring parameter would silently
+// change the constructor's signature at every call site. Declarations in the
+// *body* of the same class — including the abbreviated constructors — stay
+// removable like any other dead code.
+
+// --- Live: nothing here may be reported ---
+
+/// Header form with a `;` body, constructed below, both declaring parameters
+/// read.
+class Point(var int x, var int y);
+
+/// A `const`, named primary constructor. Invoked below, so neither the class
+/// nor the constructor is dead.
+class const Money.cents(final int amount);
+
+/// A primary constructor with a plain (non-declaring) parameter, an instance
+/// variable initialized from it, and a body part carrying the initializer list.
+/// The body part is the tail of the header's constructor, not a declaration of
+/// its own: it must never surface as a `Delta.this` finding.
+class Delta(final int from, int step) {
+  this : assert(step > 0);
+
+  final int to = from + step;
+}
+
+/// A super parameter forwarded through a primary constructor.
+class Origin(final int at);
+
+class Shifted(super.at) extends Origin;
+
+/// An enum with a primary constructor; `hearts` is named below.
+enum Suit(final String glyph) {
+  hearts('♥'),
+  spades('♠');
+}
+
+/// An empty body written as `;`.
+mixin Marker;
+
+class Marked with Marker;
+
+// --- Dead, and removable: the class body is ordinary ground ---
+
+/// Never referenced at all. Reported as the whole CLASS — its declaring
+/// parameters go with it, so they are not reported separately — and removed as
+/// one node, `;` body and all.
+class DeadPoint(var int x, var int y);
+
+/// A live class (constructed below) whose *body* declarations are dead. The
+/// abbreviated `new`/`factory` headers are the second half of the primary
+/// constructors feature: they name no class, but they are ordinary body members
+/// and stay removable.
+class Registry {
+  new() : tag = null;
+
+  new tagged(this.tag);
+
+  new deadNamed() : tag = null;
+
+  factory deadFactory() => .new();
+
+  factory deadRedirect() = Registry;
+
+  final String? tag;
+
+  /// A plain body field that is dead: still removable, unlike a declaring
+  /// parameter.
+  int deadCounter = 0;
+}
+
+// --- Dead, but report-only: declared in the header ---
+
+/// A live class (constructed below) whose second declaring parameter is never
+/// read. It is a real finding — nothing reads `port` — but removing it would
+/// change `Endpoint`'s signature, so it is reported and left in place.
+class Endpoint(final String host, final int port);
+
+/// Named declaring parameters, one of them dead. They sit inside the parameter
+/// list's own `{…}` group, which must not be mistaken for the start of the
+/// class body when placing them in the header.
+class Chip({required var String label, var int badge = 0}) {
+  String get short => label;
+}
+
+/// An optional positional declaring parameter, also dead.
+class Ranged(var int low, [var int high = 10]);
+
+/// A live class whose *private* primary constructor is never invoked: the class
+/// is only ever used as a type. It is *not* reported — a references query at the
+/// header resolves to the class, whose type use keeps it alive — but its dead
+/// declaring parameter is. Were the class dead too, the constructor would
+/// surface (under `-k constructor`) as report-only: the header is the class
+/// declaration itself.
+class const Secret._(final int seed);
+
+// --- Uses ---
+
+void usePrimaryConstructors() {
+  final p = Point(1, 2);
+  print(p.x + p.y);
+  print(const Money.cents(500).amount);
+  print(Delta(1, 2).to);
+  print(Shifted(3).at);
+  print(Suit.hearts.glyph);
+  print(Marked());
+  print(Registry().tag);
+  print(Registry.tagged('t'));
+  print(Endpoint('localhost', 8080).host);
+  print(Chip(label: 'draft').short);
+  print(Ranged(1).low);
+}
+
+/// Keeps [Secret] alive as a type without ever invoking its constructor.
+void useSecretType(Secret? secret) => print(secret);

--- a/example/lib/scenarios/primary_constructors.dart
+++ b/example/lib/scenarios/primary_constructors.dart
@@ -1,31 +1,23 @@
-// Fixtures for Dart 3.13 primary constructors: a constructor (and, for the
-// parameters marked `var`/`final`, the instance variables it initializes)
-// declared in the type's *header* instead of its body, the `this : …` body part
-// that completes it, and the abbreviated `new`/`factory` constructor headers
-// that ship with the same feature. Scanned only by the dedicated
+// Fixture for Dart 3.13 primary constructors: a constructor, and the instance
+// variables its `var`/`final` parameters induce, declared in the type's header;
+// the `this : …` body part completing it; and the abbreviated `new`/`factory`
+// headers that ship with the same feature. Scanned only by the dedicated
 // primary-constructor tests; see test/finder_test.dart.
 //
-// The rule this file pins down: anything declared in the header is reported
-// when dead, but never auto-removed. Deleting the constructor alone would leave
-// a `class ;` fragment, and deleting a declaring parameter would silently
-// change the constructor's signature at every call site. Declarations in the
-// *body* of the same class — including the abbreviated constructors — stay
-// removable like any other dead code.
+// The rule it pins down: a dead declaration in the HEADER is reported but never
+// auto-removed, while the BODY of the same class stays ordinary ground.
 
 // --- Live: nothing here may be reported ---
 
-/// Header form with a `;` body, constructed below, both declaring parameters
-/// read.
+/// Header form with a `;` body.
 class Point(var int x, var int y);
 
-/// A `const`, named primary constructor. Invoked below, so neither the class
-/// nor the constructor is dead.
+/// A `const`, named primary constructor.
 class const Money.cents(final int amount);
 
-/// A primary constructor with a plain (non-declaring) parameter, an instance
-/// variable initialized from it, and a body part carrying the initializer list.
-/// The body part is the tail of the header's constructor, not a declaration of
-/// its own: it must never surface as a `Delta.this` finding.
+/// A plain (non-declaring) parameter, an instance variable initialized from it,
+/// and a body part carrying the initializer list. The body part must never
+/// surface as a `Delta.this` finding.
 class Delta(final int from, int step) {
   this : assert(step > 0);
 
@@ -37,28 +29,24 @@ class Origin(final int at);
 
 class Shifted(super.at) extends Origin;
 
-/// An enum with a primary constructor; `hearts` is named below.
 enum Suit(final String glyph) {
   hearts('♥'),
   spades('♠');
 }
 
-/// An empty body written as `;`.
+/// Empty bodies written as `;`.
 mixin Marker;
 
 class Marked with Marker;
 
-// --- Dead, and removable: the class body is ordinary ground ---
+// --- Dead, and removable: declared in the body ---
 
-/// Never referenced at all. Reported as the whole CLASS — its declaring
-/// parameters go with it, so they are not reported separately — and removed as
-/// one node, `;` body and all.
+/// Reported as the whole CLASS — its declaring parameters go with it — and
+/// removed as one node, `;` body and all.
 class DeadPoint(var int x, var int y);
 
-/// A live class (constructed below) whose *body* declarations are dead. The
-/// abbreviated `new`/`factory` headers are the second half of the primary
-/// constructors feature: they name no class, but they are ordinary body members
-/// and stay removable.
+/// A live class whose dead *body* members stay removable, the abbreviated
+/// `new`/`factory` headers included.
 class Registry {
   new() : tag = null;
 
@@ -72,21 +60,16 @@ class Registry {
 
   final String? tag;
 
-  /// A plain body field that is dead: still removable, unlike a declaring
-  /// parameter.
   int deadCounter = 0;
 }
 
 // --- Dead, but report-only: declared in the header ---
 
-/// A live class (constructed below) whose second declaring parameter is never
-/// read. It is a real finding — nothing reads `port` — but removing it would
-/// change `Endpoint`'s signature, so it is reported and left in place.
+/// Nothing reads `port`, but removing it would change `Endpoint`'s signature.
 class Endpoint(final String host, final int port);
 
 /// Named declaring parameters, one of them dead. They sit inside the parameter
-/// list's own `{…}` group, which must not be mistaken for the start of the
-/// class body when placing them in the header.
+/// list's own `{…}`, which must not be taken for the start of the class body.
 class Chip({required var String label, var int badge = 0}) {
   String get short => label;
 }
@@ -94,12 +77,10 @@ class Chip({required var String label, var int badge = 0}) {
 /// An optional positional declaring parameter, also dead.
 class Ranged(var int low, [var int high = 10]);
 
-/// A live class whose *private* primary constructor is never invoked: the class
-/// is only ever used as a type. It is *not* reported — a references query at the
-/// header resolves to the class, whose type use keeps it alive — but its dead
-/// declaring parameter is. Were the class dead too, the constructor would
-/// surface (under `-k constructor`) as report-only: the header is the class
-/// declaration itself.
+/// A private primary constructor that is never invoked. It is *not* reported —
+/// a query at the header resolves to the class, which is used as a type below —
+/// but its dead declaring parameter is. Were the class dead too, the
+/// constructor would surface (under `-k constructor`) as report-only.
 class const Secret._(final int seed);
 
 // --- Uses ---
@@ -119,5 +100,4 @@ void usePrimaryConstructors() {
   print(Ranged(1).low);
 }
 
-/// Keeps [Secret] alive as a type without ever invoking its constructor.
 void useSecretType(Secret? secret) => print(secret);

--- a/example/lib/scenarios/primary_constructors.dart
+++ b/example/lib/scenarios/primary_constructors.dart
@@ -1,30 +1,21 @@
-// Fixture for Dart 3.13 primary constructors: a constructor, and the instance
-// variables its `var`/`final` parameters induce, declared in the type's header;
-// the `this : …` body part completing it; and the abbreviated `new`/`factory`
-// headers that ship with the same feature. Scanned only by the dedicated
+// Fixture for Dart 3.13 primary constructors. The rule it pins down: a dead
+// declaration in a class HEADER is reported but never auto-removed, while the
+// BODY of the same class stays ordinary ground. Scanned only by the dedicated
 // primary-constructor tests; see test/finder_test.dart.
-//
-// The rule it pins down: a dead declaration in the HEADER is reported but never
-// auto-removed, while the BODY of the same class stays ordinary ground.
 
 // --- Live: nothing here may be reported ---
 
-/// Header form with a `;` body.
 class Point(var int x, var int y);
 
-/// A `const`, named primary constructor.
 class const Money.cents(final int amount);
 
-/// A plain (non-declaring) parameter, an instance variable initialized from it,
-/// and a body part carrying the initializer list. The body part must never
-/// surface as a `Delta.this` finding.
+/// The body part must never surface as a `Delta.this` finding.
 class Delta(final int from, int step) {
   this : assert(step > 0);
 
   final int to = from + step;
 }
 
-/// A super parameter forwarded through a primary constructor.
 class Origin(final int at);
 
 class Shifted(super.at) extends Origin;
@@ -34,19 +25,15 @@ enum Suit(final String glyph) {
   spades('♠');
 }
 
-/// Empty bodies written as `;`.
 mixin Marker;
 
 class Marked with Marker;
 
 // --- Dead, and removable: declared in the body ---
 
-/// Reported as the whole CLASS — its declaring parameters go with it — and
-/// removed as one node, `;` body and all.
+/// Reported as the whole class, its declaring parameters included.
 class DeadPoint(var int x, var int y);
 
-/// A live class whose dead *body* members stay removable, the abbreviated
-/// `new`/`factory` headers included.
 class Registry {
   new() : tag = null;
 
@@ -65,22 +52,18 @@ class Registry {
 
 // --- Dead, but report-only: declared in the header ---
 
-/// Nothing reads `port`, but removing it would change `Endpoint`'s signature.
 class Endpoint(final String host, final int port);
 
-/// Named declaring parameters, one of them dead. They sit inside the parameter
-/// list's own `{…}`, which must not be taken for the start of the class body.
+/// `badge` sits inside the parameter list's own `{…}`, which must not be taken
+/// for the start of the class body.
 class Chip({required var String label, var int badge = 0}) {
   String get short => label;
 }
 
-/// An optional positional declaring parameter, also dead.
 class Ranged(var int low, [var int high = 10]);
 
-/// A private primary constructor that is never invoked. It is *not* reported —
-/// a query at the header resolves to the class, which is used as a type below —
-/// but its dead declaring parameter is. Were the class dead too, the
-/// constructor would surface (under `-k constructor`) as report-only.
+/// Not reported: a query at the header resolves to the class, which is used as
+/// a type below. Only its dead declaring parameter is.
 class const Secret._(final int seed);
 
 // --- Uses ---

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.13.0
 
 dev_dependencies:
   leancode_lint: ^24.0.0

--- a/lib/src/candidates.dart
+++ b/lib/src/candidates.dart
@@ -48,12 +48,19 @@ final class Candidate {
     required this.container,
     required this.isEnumValue,
     required this.isPreventInstantiationCtor,
+    this.containerSymbol,
   });
 
   final Uri uri;
   final String path;
   final DocumentSymbol symbol;
   final String? container;
+
+  /// The enclosing type declaration's symbol, when this candidate is a member
+  /// of one — the source span [container] names. Kept alongside the name so a
+  /// member can be placed against its type's *header* (where a primary
+  /// constructor and its declaring parameters live) or its body.
+  final DocumentSymbol? containerSymbol;
   final bool isEnumValue;
   final bool isPreventInstantiationCtor;
 

--- a/lib/src/candidates.dart
+++ b/lib/src/candidates.dart
@@ -56,10 +56,8 @@ final class Candidate {
   final DocumentSymbol symbol;
   final String? container;
 
-  /// The enclosing type declaration's symbol, when this candidate is a member
-  /// of one — the source span [container] names. Kept alongside the name so a
-  /// member can be placed against its type's *header* (where a primary
-  /// constructor and its declaring parameters live) or its body.
+  /// The symbol [container] names — the enclosing type's source span, kept so a
+  /// member can be placed against its header or its body.
   final DocumentSymbol? containerSymbol;
   final bool isEnumValue;
   final bool isPreventInstantiationCtor;

--- a/lib/src/candidates.dart
+++ b/lib/src/candidates.dart
@@ -56,8 +56,8 @@ final class Candidate {
   final DocumentSymbol symbol;
   final String? container;
 
-  /// The symbol [container] names — the enclosing type's source span, kept so a
-  /// member can be placed against its header or its body.
+  /// The symbol [container] names, so a member can be placed against its type's
+  /// header or body.
   final DocumentSymbol? containerSymbol;
   final bool isEnumValue;
   final bool isPreventInstantiationCtor;

--- a/lib/src/finder.dart
+++ b/lib/src/finder.dart
@@ -68,16 +68,12 @@ class Ciach {
       'looks like a prevent-instantiation constructor — for a '
       'non-instantiable static-only class, prefer `abstract final class`';
 
-  /// Advisory note attached to a dead primary constructor: it lives in the
-  /// class header, so there is nothing to delete on its own — the class itself
-  /// is what would have to go.
+  /// Notes on the two Dart 3.13 header declarations, saying why neither can be
+  /// auto-removed.
   static const _primaryConstructorHint =
       'primary constructor — declared in the class header, so it cannot be '
       'removed without removing the class';
 
-  /// Advisory note attached to a dead *declaring parameter* of a primary
-  /// constructor: the field and the constructor parameter are one declaration,
-  /// so dropping it changes the constructor signature.
   static const _declaringParameterHint =
       'declaring parameter of the primary constructor — removing it changes '
       'the constructor signature at every call site';
@@ -368,9 +364,7 @@ class Ciach {
   static String _simpleName(String name) =>
       name.contains('.') ? name.split('.').last : name;
 
-  /// The advisory note to attach to a finding, if any: an explanation of why a
-  /// header declaration can't be auto-removed, or the nudge toward
-  /// `abstract final class` on a sole, zero-parameter private constructor.
+  /// The advisory note to attach to a finding, if any.
   String? _hintFor(Candidate candidate) {
     if (_isHeaderDeclaration(candidate)) {
       return candidate.symbol.kind == .constructor
@@ -382,9 +376,8 @@ class Ciach {
         : null;
   }
 
-  /// Whether [candidate] is declared in its class's *header* rather than its
-  /// body: a primary constructor, or one of its declaring parameters (Dart
-  /// 3.13). Neither is a standalone node the remover can delete.
+  /// Whether [candidate] is a primary constructor or one of its declaring
+  /// parameters — see [StructuralChecks.isDeclaredInTypeHeader].
   bool _isHeaderDeclaration(Candidate candidate) =>
       switch (candidate.symbol.kind) {
         .constructor || .field => _sources.isDeclaredInTypeHeader(candidate),
@@ -426,9 +419,8 @@ class Ciach {
   /// * an enum value whose removal would empty a still-referenced enum;
   /// * the last constructor of a live class with `final` fields or
   ///   super-constructor forwarding;
-  /// * a primary constructor or one of its declaring parameters: both live in
-  ///   the class header, where deleting the node alone leaves a `class ;`
-  ///   fragment or silently changes the constructor's signature.
+  /// * a primary constructor or one of its declaring parameters, neither of
+  ///   which is a node that can be deleted on its own.
   ///
   /// Each is surfaced so a human can act on it, but the remover leaves it — and
   /// anything coupled to it — entirely alone.
@@ -564,8 +556,7 @@ class Ciach {
     if (symbol.isCallMethod) {
       return false;
     }
-    // A primary constructor's `this : …` body part is the tail of the
-    // constructor declared in the header, not a declaration of its own.
+    // Already represented by the header's constructor symbol.
     if (symbol.isPrimaryConstructorBody) {
       return false;
     }
@@ -608,10 +599,9 @@ class Ciach {
     );
   }
 
-  /// Whether [candidate] is part of an already-dead class's own declaration,
-  /// and so goes with it: any constructor, or a declaring parameter of a
-  /// primary constructor (which lives in the class header). Reporting those
-  /// separately would double-count a single removal.
+  /// Whether [candidate] is part of an already-dead class's own declaration —
+  /// any constructor, or a declaring parameter — and so goes with it. Reporting
+  /// those separately would double-count a single removal.
   bool _isRemovedWithDeadClass(
     Candidate candidate,
     Map<String, Set<String>> deadClassNames,

--- a/lib/src/finder.dart
+++ b/lib/src/finder.dart
@@ -68,8 +68,6 @@ class Ciach {
       'looks like a prevent-instantiation constructor — for a '
       'non-instantiable static-only class, prefer `abstract final class`';
 
-  /// Notes on the two Dart 3.13 header declarations, saying why neither can be
-  /// auto-removed.
   static const _primaryConstructorHint =
       'primary constructor — declared in the class header, so it cannot be '
       'removed without removing the class';
@@ -364,7 +362,6 @@ class Ciach {
   static String _simpleName(String name) =>
       name.contains('.') ? name.split('.').last : name;
 
-  /// The advisory note to attach to a finding, if any.
   String? _hintFor(Candidate candidate) {
     if (_isHeaderDeclaration(candidate)) {
       return candidate.symbol.kind == .constructor
@@ -376,8 +373,7 @@ class Ciach {
         : null;
   }
 
-  /// Whether [candidate] is a primary constructor or one of its declaring
-  /// parameters — see [StructuralChecks.isDeclaredInTypeHeader].
+  /// See [StructuralChecks.isDeclaredInTypeHeader].
   bool _isHeaderDeclaration(Candidate candidate) =>
       switch (candidate.symbol.kind) {
         .constructor || .field => _sources.isDeclaredInTypeHeader(candidate),
@@ -419,8 +415,7 @@ class Ciach {
   /// * an enum value whose removal would empty a still-referenced enum;
   /// * the last constructor of a live class with `final` fields or
   ///   super-constructor forwarding;
-  /// * a primary constructor or one of its declaring parameters, neither of
-  ///   which is a node that can be deleted on its own.
+  /// * a primary constructor or one of its declaring parameters.
   ///
   /// Each is surfaced so a human can act on it, but the remover leaves it — and
   /// anything coupled to it — entirely alone.
@@ -599,9 +594,9 @@ class Ciach {
     );
   }
 
-  /// Whether [candidate] is part of an already-dead class's own declaration —
-  /// any constructor, or a declaring parameter — and so goes with it. Reporting
-  /// those separately would double-count a single removal.
+  /// Whether [candidate] goes with an already-dead class's own declaration —
+  /// any constructor, or a declaring parameter — so a single removal is not
+  /// reported twice.
   bool _isRemovedWithDeadClass(
     Candidate candidate,
     Map<String, Set<String>> deadClassNames,

--- a/lib/src/finder.dart
+++ b/lib/src/finder.dart
@@ -25,6 +25,7 @@ import 'package:ciach/src/reference_classifier.dart';
 import 'package:ciach/src/remove_safety.dart';
 import 'package:ciach/src/source_index.dart';
 import 'package:ciach/src/symbols.dart';
+import 'package:ciach/src/syntax_rules.dart';
 import 'package:path/path.dart' as p;
 import 'package:pro_lsp/pro_lsp.dart' show DocumentSymbol, Location;
 
@@ -66,6 +67,20 @@ class Ciach {
   static const _preventInstantiationHint =
       'looks like a prevent-instantiation constructor — for a '
       'non-instantiable static-only class, prefer `abstract final class`';
+
+  /// Advisory note attached to a dead primary constructor: it lives in the
+  /// class header, so there is nothing to delete on its own — the class itself
+  /// is what would have to go.
+  static const _primaryConstructorHint =
+      'primary constructor — declared in the class header, so it cannot be '
+      'removed without removing the class';
+
+  /// Advisory note attached to a dead *declaring parameter* of a primary
+  /// constructor: the field and the constructor parameter are one declaration,
+  /// so dropping it changes the constructor signature.
+  static const _declaringParameterHint =
+      'declaring parameter of the primary constructor — removing it changes '
+      'the constructor signature at every call site';
 
   void _report(String message) => options.onProgress?.call(message);
 
@@ -219,11 +234,7 @@ class Ciach {
                       )
                     : const [],
                 removalBlocked: _isRemovalBlocked(candidate, refs, safety),
-                // A sole, zero-parameter private constructor is dead code like
-                // any other, but nudge toward `abstract final class`.
-                hint: candidate.isPreventInstantiationCtor
-                    ? _preventInstantiationHint
-                    : null,
+                hint: _hintFor(candidate),
               ),
             );
           case .docOnly:
@@ -357,6 +368,29 @@ class Ciach {
   static String _simpleName(String name) =>
       name.contains('.') ? name.split('.').last : name;
 
+  /// The advisory note to attach to a finding, if any: an explanation of why a
+  /// header declaration can't be auto-removed, or the nudge toward
+  /// `abstract final class` on a sole, zero-parameter private constructor.
+  String? _hintFor(Candidate candidate) {
+    if (_isHeaderDeclaration(candidate)) {
+      return candidate.symbol.kind == .constructor
+          ? _primaryConstructorHint
+          : _declaringParameterHint;
+    }
+    return candidate.isPreventInstantiationCtor
+        ? _preventInstantiationHint
+        : null;
+  }
+
+  /// Whether [candidate] is declared in its class's *header* rather than its
+  /// body: a primary constructor, or one of its declaring parameters (Dart
+  /// 3.13). Neither is a standalone node the remover can delete.
+  bool _isHeaderDeclaration(Candidate candidate) =>
+      switch (candidate.symbol.kind) {
+        .constructor || .field => _sources.isDeclaredInTypeHeader(candidate),
+        _ => false,
+      };
+
   /// Whether an unused [candidate] should be silently suppressed (never
   /// reported): a live freezed-union arm, an exempt `toJson` hook, a
   /// constructor removed with its already-dead class, or an enum value reached
@@ -374,7 +408,7 @@ class Ciach {
     if (!options.reportToJson && _sources.isToJsonHook(candidate)) {
       return true;
     }
-    if (_isConstructorOfDeadClass(candidate, deadClassNames)) {
+    if (_isRemovedWithDeadClass(candidate, deadClassNames)) {
       return true;
     }
     final containerKey = candidate.containerKey;
@@ -391,7 +425,10 @@ class Ciach {
   ///   scattered `case`s is a source rewrite this tool won't attempt;
   /// * an enum value whose removal would empty a still-referenced enum;
   /// * the last constructor of a live class with `final` fields or
-  ///   super-constructor forwarding.
+  ///   super-constructor forwarding;
+  /// * a primary constructor or one of its declaring parameters: both live in
+  ///   the class header, where deleting the node alone leaves a `class ;`
+  ///   fragment or silently changes the constructor's signature.
   ///
   /// Each is surfaced so a human can act on it, but the remover leaves it — and
   /// anything coupled to it — entirely alone.
@@ -409,7 +446,8 @@ class Ciach {
             safety.emptiedEnums.contains(containerKey)) ||
         (candidate.symbol.kind == .constructor &&
             containerKey != null &&
-            safety.blockedCtorClasses.contains(containerKey));
+            safety.blockedCtorClasses.contains(containerKey)) ||
+        _isHeaderDeclaration(candidate);
   }
 
   /// Opens [path] in the analysis server without collecting candidates from
@@ -444,6 +482,7 @@ class Ciach {
       path,
       symbols,
       null,
+      null,
       false,
       _sources.strippedLines(path),
       out,
@@ -461,6 +500,7 @@ class Ciach {
     String path,
     List<DocumentSymbol> symbols,
     String? container,
+    DocumentSymbol? containerSymbol,
     bool parentIsEnum,
     List<String> strippedLines,
     List<Candidate> out,
@@ -474,6 +514,7 @@ class Ciach {
             path: path,
             symbol: symbol,
             container: container,
+            containerSymbol: containerSymbol,
             isEnumValue: parentIsEnum && symbol.kind == .enum$,
             // `symbols` are this symbol's siblings (its class's members when
             // `symbol` is a constructor), so this confirms the sole-constructor
@@ -484,14 +525,13 @@ class Ciach {
           ),
         );
       }
-      final childContainer = typeLikeKinds.contains(symbol.kind)
-          ? symbol.name
-          : container;
+      final isTypeLike = typeLikeKinds.contains(symbol.kind);
       _collectCandidates(
         uri,
         path,
         symbol.children ?? const [],
-        childContainer,
+        isTypeLike ? symbol.name : container,
+        isTypeLike ? symbol : containerSymbol,
         symbol.kind == .enum$,
         strippedLines,
         out,
@@ -522,6 +562,11 @@ class Ciach {
     // Always skipped (no flag): implicit-call syntax is unresolvable, like
     // operators.
     if (symbol.isCallMethod) {
+      return false;
+    }
+    // A primary constructor's `this : …` body part is the tail of the
+    // constructor declared in the header, not a declaration of its own.
+    if (symbol.isPrimaryConstructorBody) {
       return false;
     }
 
@@ -563,11 +608,16 @@ class Ciach {
     );
   }
 
-  bool _isConstructorOfDeadClass(
+  /// Whether [candidate] is part of an already-dead class's own declaration,
+  /// and so goes with it: any constructor, or a declaring parameter of a
+  /// primary constructor (which lives in the class header). Reporting those
+  /// separately would double-count a single removal.
+  bool _isRemovedWithDeadClass(
     Candidate candidate,
     Map<String, Set<String>> deadClassNames,
   ) =>
-      candidate.symbol.kind == .constructor &&
+      (candidate.symbol.kind == .constructor ||
+          _isHeaderDeclaration(candidate)) &&
       (deadClassNames[candidate.path]?.contains(candidate.container) ?? false);
 
   static int _byLocation(UnusedDeclaration a, UnusedDeclaration b) {

--- a/lib/src/symbols.dart
+++ b/lib/src/symbols.dart
@@ -67,11 +67,9 @@ extension SymbolChecks on DocumentSymbol {
     return dot >= 0 && dot + 1 < name.length && name[dot + 1] == '_';
   }
 
-  /// Whether this is a primary constructor's body part — the `this : …` member
-  /// completing the constructor declared in the class header, which the server
-  /// reports as a constructor literally named `this` (a name no ordinary
-  /// constructor can have). It is that constructor's tail, not a declaration of
-  /// its own.
+  /// Whether this is a primary constructor's `this : …` body part, which the
+  /// server reports as a constructor named `this` — a name no ordinary
+  /// constructor can have.
   bool get isPrimaryConstructorBody => kind == .constructor && name == 'this';
 
   /// Whether the parameter list is empty. The server reports the signature in

--- a/lib/src/symbols.dart
+++ b/lib/src/symbols.dart
@@ -67,6 +67,17 @@ extension SymbolChecks on DocumentSymbol {
     return dot >= 0 && dot + 1 < name.length && name[dot + 1] == '_';
   }
 
+  /// Whether this is the *body part* of a primary constructor — the
+  /// `this : <initializers> { … }` member a Dart 3.13 class body may carry to
+  /// complete the constructor declared in its header.
+  ///
+  /// The analysis server reports it as a constructor literally named `this`, a
+  /// name no ordinary constructor can have (those are `Foo` or `Foo.named`).
+  /// It is not a declaration of its own — it is the tail of the primary
+  /// constructor, already represented by the header's constructor symbol — so
+  /// it is never a candidate on its own.
+  bool get isPrimaryConstructorBody => kind == .constructor && name == 'this';
+
   /// Whether the parameter list is empty. The server reports the signature in
   /// [DocumentSymbol.detail] as the parenthesized parameter list (`()`,
   /// `(int a)`, …); if the detail is missing we can't tell the arity, so treat

--- a/lib/src/symbols.dart
+++ b/lib/src/symbols.dart
@@ -67,15 +67,11 @@ extension SymbolChecks on DocumentSymbol {
     return dot >= 0 && dot + 1 < name.length && name[dot + 1] == '_';
   }
 
-  /// Whether this is the *body part* of a primary constructor — the
-  /// `this : <initializers> { … }` member a Dart 3.13 class body may carry to
-  /// complete the constructor declared in its header.
-  ///
-  /// The analysis server reports it as a constructor literally named `this`, a
-  /// name no ordinary constructor can have (those are `Foo` or `Foo.named`).
-  /// It is not a declaration of its own — it is the tail of the primary
-  /// constructor, already represented by the header's constructor symbol — so
-  /// it is never a candidate on its own.
+  /// Whether this is a primary constructor's body part — the `this : …` member
+  /// completing the constructor declared in the class header, which the server
+  /// reports as a constructor literally named `this` (a name no ordinary
+  /// constructor can have). It is that constructor's tail, not a declaration of
+  /// its own.
   bool get isPrimaryConstructorBody => kind == .constructor && name == 'this';
 
   /// Whether the parameter list is empty. The server reports the signature in

--- a/lib/src/syntax_rules.dart
+++ b/lib/src/syntax_rules.dart
@@ -95,6 +95,69 @@ extension StructuralChecks on SourceIndex {
     return false;
   }
 
+  /// Whether [candidate] is declared in the *header* of its enclosing type
+  /// rather than in its body — the shape Dart 3.13's primary constructors
+  /// introduce.
+  ///
+  /// Two candidate kinds land here:
+  ///
+  /// * the primary constructor itself (`class const Point._(…)`), reported by
+  ///   the analysis server as a constructor whose range starts at the class
+  ///   name (or the `const` before it);
+  /// * a *declaring parameter* (`var int x`, `final int y`), reported as a
+  ///   field whose range sits inside the header's parameter list.
+  ///
+  /// Neither can be deleted on its own: dropping the header constructor would
+  /// leave a `class ;` fragment, and dropping a declaring parameter changes the
+  /// constructor's signature, breaking every call site. Both are reported and
+  /// left to a human.
+  ///
+  /// Decided by position: the declaration starts before its type's header ends
+  /// — at the body's `{`, or at the `;` of a bodyless declaration
+  /// ([_typeHeaderEnd]).
+  bool isDeclaredInTypeHeader(Candidate candidate) {
+    final type = candidate.containerSymbol;
+    if (type == null) {
+      return false;
+    }
+    final headerEnd = _typeHeaderEnd(candidate.path, type);
+    final start = offsetOf(candidate.path, candidate.symbol.range.start);
+    return headerEnd != null && start != null && start < headerEnd;
+  }
+
+  /// The offset at which [type]'s header ends in [path]: the `{` opening its
+  /// body, or the `;` closing a bodyless declaration (`class Point(int x);`).
+  /// `null` when neither can be found.
+  ///
+  /// Parentheses and brackets are tracked so that the `{` of a *named*
+  /// parameter group (`class C({required var int x})`) is not mistaken for the
+  /// body — the body brace is the first one at nesting depth zero.
+  int? _typeHeaderEnd(String path, DocumentSymbol type) {
+    final window = tokenWindow(path, type);
+    if (window == null) {
+      return null;
+    }
+    final (:tokens, :start, :end) = window;
+    var depth = 0;
+    for (var i = start; i < end; i++) {
+      final t = tokens[i];
+      if (t.isWord) {
+        continue;
+      }
+      switch (t.value) {
+        case '(' || '[':
+          depth++;
+        case ')' || ']':
+          if (depth > 0) {
+            depth--;
+          }
+        case '{' || ';' when depth == 0:
+          return t.start;
+      }
+    }
+    return null;
+  }
+
   /// Whether [classCandidate] declares at least one `final` *instance* field
   /// (not `static`/`const`). Such a field relies on a constructor to be
   /// initialized, so removing the class's sole constructor would strand it

--- a/lib/src/syntax_rules.dart
+++ b/lib/src/syntax_rules.dart
@@ -95,14 +95,10 @@ extension StructuralChecks on SourceIndex {
     return false;
   }
 
-  /// Whether [candidate] starts before its type's body does — a Dart 3.13
-  /// primary constructor (`class const Point._(…)`) or one of its declaring
-  /// parameters (`var int x`), both reported as ordinary constructor/field
-  /// symbols that happen to sit in the header.
-  ///
-  /// Neither is a node that can be deleted on its own: dropping the
-  /// constructor leaves a `class ;` fragment, and dropping a declaring
-  /// parameter changes the constructor's signature.
+  /// Whether [candidate] starts before its type's body does: a primary
+  /// constructor (`class const Point._(…)`) or a declaring parameter
+  /// (`var int x`). Deleting either alone leaves a `class ;` fragment or
+  /// changes the constructor's signature.
   bool isDeclaredInTypeHeader(Candidate candidate) {
     final type = candidate.containerSymbol;
     if (type == null) {
@@ -113,12 +109,9 @@ extension StructuralChecks on SourceIndex {
     return headerEnd != null && start != null && start < headerEnd;
   }
 
-  /// The offset at which [type]'s header ends in [path]: the `{` opening its
-  /// body, or the `;` of a bodyless declaration (`class Point(int x);`).
-  ///
-  /// Parentheses are tracked so the `{` of a *named* parameter group
-  /// (`class C({required var int x})`) isn't taken for the body brace, which is
-  /// the first one at depth zero.
+  /// Where [type]'s header ends: its body `{`, or the `;` of a bodyless
+  /// declaration. Parens are tracked so a named parameter group's `{`
+  /// (`class C({required var int x})`) isn't taken for the body brace.
   int? _typeHeaderEnd(String path, DocumentSymbol type) {
     final window = tokenWindow(path, type);
     if (window == null) {

--- a/lib/src/syntax_rules.dart
+++ b/lib/src/syntax_rules.dart
@@ -95,26 +95,14 @@ extension StructuralChecks on SourceIndex {
     return false;
   }
 
-  /// Whether [candidate] is declared in the *header* of its enclosing type
-  /// rather than in its body — the shape Dart 3.13's primary constructors
-  /// introduce.
+  /// Whether [candidate] starts before its type's body does — a Dart 3.13
+  /// primary constructor (`class const Point._(…)`) or one of its declaring
+  /// parameters (`var int x`), both reported as ordinary constructor/field
+  /// symbols that happen to sit in the header.
   ///
-  /// Two candidate kinds land here:
-  ///
-  /// * the primary constructor itself (`class const Point._(…)`), reported by
-  ///   the analysis server as a constructor whose range starts at the class
-  ///   name (or the `const` before it);
-  /// * a *declaring parameter* (`var int x`, `final int y`), reported as a
-  ///   field whose range sits inside the header's parameter list.
-  ///
-  /// Neither can be deleted on its own: dropping the header constructor would
-  /// leave a `class ;` fragment, and dropping a declaring parameter changes the
-  /// constructor's signature, breaking every call site. Both are reported and
-  /// left to a human.
-  ///
-  /// Decided by position: the declaration starts before its type's header ends
-  /// — at the body's `{`, or at the `;` of a bodyless declaration
-  /// ([_typeHeaderEnd]).
+  /// Neither is a node that can be deleted on its own: dropping the
+  /// constructor leaves a `class ;` fragment, and dropping a declaring
+  /// parameter changes the constructor's signature.
   bool isDeclaredInTypeHeader(Candidate candidate) {
     final type = candidate.containerSymbol;
     if (type == null) {
@@ -126,12 +114,11 @@ extension StructuralChecks on SourceIndex {
   }
 
   /// The offset at which [type]'s header ends in [path]: the `{` opening its
-  /// body, or the `;` closing a bodyless declaration (`class Point(int x);`).
-  /// `null` when neither can be found.
+  /// body, or the `;` of a bodyless declaration (`class Point(int x);`).
   ///
-  /// Parentheses and brackets are tracked so that the `{` of a *named*
-  /// parameter group (`class C({required var int x})`) is not mistaken for the
-  /// body — the body brace is the first one at nesting depth zero.
+  /// Parentheses are tracked so the `{` of a *named* parameter group
+  /// (`class C({required var int x})`) isn't taken for the body brace, which is
+  /// the first one at depth zero.
   int? _typeHeaderEnd(String path, DocumentSymbol type) {
     final window = tokenWindow(path, type);
     if (window == null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: ciach
 description: >-
   Finds unused (never-referenced) declarations in a Dart/Flutter package by
   driving the Dart analysis server over LSP and querying textDocument/references.
-version: 0.4.1
+version: 0.4.2
 repository: https://github.com/leancodepl/ciach
 homepage: https://github.com/leancodepl/ciach
 issue_tracker: https://github.com/leancodepl/ciach/issues

--- a/test/finder_test.dart
+++ b/test/finder_test.dart
@@ -889,8 +889,6 @@ void main() {
   });
 
   group('primary constructors (Dart 3.13)', () {
-    // Scan only the primary-constructor fixture; it is self-contained (every
-    // live declaration is used from within the file).
     Future<FinderResult> runPrimary() => runFinder(
       include: ['lib/scenarios/primary_constructors.dart'],
       exclude: const [],
@@ -909,7 +907,6 @@ void main() {
       final result = await runPrimary();
       expect(result.unused.map((d) => d.qualifiedName).toSet(), {
         'Suit.spades',
-        // Reported as the class, not as its header declarations.
         'DeadPoint',
         'Registry.deadNamed',
         'Registry.deadFactory',
@@ -920,16 +917,14 @@ void main() {
         'Chip.badge',
         'Ranged.high',
         'Secret.seed',
-        // The fixture's own entry points, referenced by nothing in the scan.
+        // The fixture's own entry points, called by nothing in the scan.
         'usePrimaryConstructors',
         'useSecretType',
       });
     });
 
     test("a primary constructor's body part is never a finding of its own", () {
-      // `class Delta(…) { this : assert(…); }` — the server reports the body
-      // part as a constructor named `this`, which must not surface as a
-      // `Delta.this` finding nobody can act on.
+      // The server reports `this : assert(…);` as a constructor named `this`.
       return expectLater(
         runPrimary().then((r) => r.unused.map((d) => d.qualifiedName)),
         completion(isNot(contains(anyOf('Delta.this', 'Delta.new')))),
@@ -940,9 +935,7 @@ void main() {
       'a dead declaring parameter is reported but removal-blocked',
       () async {
         final result = await runPrimary();
-        // Positional, named (`{required var String label, …}`) and optional
-        // positional (`[var int high = 10]`) alike: a parameter group's own
-        // brackets must not be mistaken for the class body.
+        // A parameter group's own brackets must not be taken for the body.
         for (final qualified in const [
           'Endpoint.port',
           'Chip.badge',
@@ -962,8 +955,6 @@ void main() {
       final decl = findByQualified(result, 'DeadPoint');
       expect(decl, isNotNull);
       expect(decl!.kind, SymbolKind.class$);
-      // The `;`-bodied declaration goes whole, so its declaring parameters must
-      // not also be reported (or blocked) on their own.
       expect(decl.removalBlocked, isFalse);
       for (final qualified in const ['DeadPoint.x', 'DeadPoint.y']) {
         expect(findByQualified(result, qualified), isNull);
@@ -983,15 +974,14 @@ void main() {
         expect(
           decl.removalBlocked,
           isFalse,
-          reason: '$qualified is a body member, not part of the header',
+          reason: '$qualified is a body member',
         );
       }
     });
 
     test('a primary constructor asked for on its own is report-only', () async {
-      // Restricting the run to constructors drops the class candidates that
-      // would otherwise absorb a dead class's header constructor, so
-      // `DeadPoint` is reported through its constructor alone.
+      // Without class candidates to absorb it, a dead class's header
+      // constructor is reported on its own.
       final result = await runFinder(
         include: ['lib/scenarios/primary_constructors.dart'],
         exclude: const [],
@@ -1001,11 +991,9 @@ void main() {
       expect(decl, isNotNull, reason: '`DeadPoint` is never constructed');
       expect(decl!.removalBlocked, isTrue);
       expect(decl.hint, contains('primary constructor'));
-      // The header constructor of a live, constructed class is not a finding.
       expect(findByQualified(result, 'Point.new'), isNull);
-      // Nor is one whose class is alive as a type only: a query at the header
-      // resolves to the class, so a primary constructor always inherits its
-      // class's references.
+      // A query at the header resolves to the class, so `Secret._` inherits the
+      // references of a class that is still used as a type.
       expect(findByQualified(result, 'Secret._'), isNull);
     });
   });

--- a/test/finder_test.dart
+++ b/test/finder_test.dart
@@ -85,6 +85,9 @@ void main() {
     return result.docOnly.map((d) => d.qualifiedName).toSet();
   }
 
+  UnusedDeclaration? findByQualified(FinderResult result, String qualified) =>
+      result.unused.firstWhereOrNull((d) => d.qualifiedName == qualified);
+
   test('reports exactly the expected unused declarations by default', () async {
     expect(await findUnused(), {
       'danglingFunction',
@@ -434,15 +437,6 @@ void main() {
     // alive by in-file type references), so no cross-file setup is needed.
     Future<FinderResult> runGuards() =>
         runFinder(include: ['lib/scenarios/guards.dart'], exclude: const []);
-
-    UnusedDeclaration? findByQualified(FinderResult result, String qualified) {
-      for (final decl in result.unused) {
-        if (decl.qualifiedName == qualified) {
-          return decl;
-        }
-      }
-      return null;
-    }
 
     test(
       'emptying a still-referenced enum is reported but removal-blocked',
@@ -894,9 +888,6 @@ void main() {
       include: ['lib/scenarios/primary_constructors.dart'],
       exclude: const [],
     );
-
-    UnusedDeclaration? findByQualified(FinderResult result, String qualified) =>
-        result.unused.firstWhereOrNull((d) => d.qualifiedName == qualified);
 
     test("reports exactly the fixture's dead declarations", () async {
       final result = await runPrimary();

--- a/test/finder_test.dart
+++ b/test/finder_test.dart
@@ -15,6 +15,7 @@ import 'dart:io';
 
 import 'package:ciach/src/finder.dart';
 import 'package:ciach/src/models.dart';
+import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 import 'package:pro_lsp/pro_lsp.dart' show SymbolKind;
 import 'package:test/test.dart';
@@ -894,14 +895,8 @@ void main() {
       exclude: const [],
     );
 
-    UnusedDeclaration? findByQualified(FinderResult result, String qualified) {
-      for (final decl in result.unused) {
-        if (decl.qualifiedName == qualified) {
-          return decl;
-        }
-      }
-      return null;
-    }
+    UnusedDeclaration? findByQualified(FinderResult result, String qualified) =>
+        result.unused.firstWhereOrNull((d) => d.qualifiedName == qualified);
 
     test("reports exactly the fixture's dead declarations", () async {
       final result = await runPrimary();

--- a/test/finder_test.dart
+++ b/test/finder_test.dart
@@ -888,6 +888,142 @@ void main() {
     });
   });
 
+  group('primary constructors (Dart 3.13)', () {
+    // Scan only the primary-constructor fixture; it is self-contained (every
+    // live declaration is used from within the file).
+    Future<FinderResult> runPrimary() => runFinder(
+      include: ['lib/scenarios/primary_constructors.dart'],
+      exclude: const [],
+    );
+
+    UnusedDeclaration? findByQualified(FinderResult result, String qualified) {
+      for (final decl in result.unused) {
+        if (decl.qualifiedName == qualified) {
+          return decl;
+        }
+      }
+      return null;
+    }
+
+    test("reports exactly the fixture's dead declarations", () async {
+      final result = await runPrimary();
+      expect(result.unused.map((d) => d.qualifiedName).toSet(), {
+        // A dead enum value of an enum that has a primary constructor.
+        'Suit.spades',
+        // A class whose whole declaration — header constructor and the
+        // instance variables its declaring parameters induce — is dead.
+        'DeadPoint',
+        // The abbreviated `new`/`factory` headers: body members like any other.
+        'Registry.deadNamed',
+        'Registry.deadFactory',
+        'Registry.deadRedirect',
+        // A plain body field of a class that has a primary constructor.
+        'Registry.deadCounter',
+        // Declaring parameters nothing ever reads — positional, named, and
+        // optional positional.
+        'Endpoint.port',
+        'Chip.badge',
+        'Ranged.high',
+        'Secret.seed',
+        // The fixture's own entry points, referenced by nothing in the scan.
+        'usePrimaryConstructors',
+        'useSecretType',
+      });
+    });
+
+    test("a primary constructor's body part is never a finding of its own", () {
+      // `class Delta(…) { this : assert(…); }` — the analysis server reports
+      // the body part as a constructor literally named `this`. It is the tail
+      // of the header's constructor, not a declaration, so it must not surface
+      // (least of all as a `Delta.this` finding nobody can act on).
+      return expectLater(
+        runPrimary().then((r) => r.unused.map((d) => d.qualifiedName)),
+        completion(isNot(contains(anyOf('Delta.this', 'Delta.new')))),
+      );
+    });
+
+    test(
+      'a dead declaring parameter is reported but removal-blocked',
+      () async {
+        final result = await runPrimary();
+        // Positional, named (`{required var String label, var int badge = 0}`)
+        // and optional positional (`[var int high = 10]`) alike: a parameter
+        // group's own brackets must not be mistaken for the class body.
+        for (final qualified in const [
+          'Endpoint.port',
+          'Chip.badge',
+          'Ranged.high',
+        ]) {
+          final decl = findByQualified(result, qualified);
+          expect(decl, isNotNull, reason: 'nothing ever reads $qualified');
+          expect(decl!.kind, SymbolKind.field);
+          // The field and the constructor parameter are one declaration in the
+          // header: deleting it would change the constructor's signature at
+          // every call site, so the finding is surfaced and left in place.
+          expect(decl.removalBlocked, isTrue);
+          expect(decl.hint, contains('declaring parameter'));
+        }
+      },
+    );
+
+    test('a dead class takes its header declarations with it', () async {
+      final result = await runPrimary();
+      final decl = findByQualified(result, 'DeadPoint');
+      expect(decl, isNotNull);
+      expect(decl!.kind, SymbolKind.class$);
+      // Removing the class removes its `;`-bodied declaration whole, so its
+      // declaring parameters must not also be reported (or blocked) on their
+      // own.
+      expect(decl.removalBlocked, isFalse);
+      for (final qualified in const ['DeadPoint.x', 'DeadPoint.y']) {
+        expect(findByQualified(result, qualified), isNull);
+      }
+    });
+
+    test('abbreviated `new`/`factory` constructors stay removable', () async {
+      final result = await runPrimary();
+      for (final qualified in const [
+        'Registry.deadNamed',
+        'Registry.deadFactory',
+        'Registry.deadRedirect',
+      ]) {
+        final decl = findByQualified(result, qualified);
+        expect(decl, isNotNull, reason: '$qualified is never invoked');
+        expect(decl!.kind, SymbolKind.constructor);
+        // Declared in the class BODY, so an ordinary whole-node removal.
+        expect(
+          decl.removalBlocked,
+          isFalse,
+          reason: '$qualified is a body member, not part of the header',
+        );
+      }
+    });
+
+    test('a primary constructor asked for on its own is report-only', () async {
+      // Restricting the run to constructors drops the class candidates that
+      // would otherwise absorb a dead class's header constructor: `DeadPoint`
+      // is then reported through its constructor alone. It must be blocked —
+      // that declaration IS the class header, so deleting the node would leave
+      // a `class ;` fragment behind.
+      final result = await runFinder(
+        include: ['lib/scenarios/primary_constructors.dart'],
+        exclude: const [],
+        kinds: const {SymbolKind.constructor},
+      );
+      final decl = findByQualified(result, 'DeadPoint.new');
+      expect(decl, isNotNull, reason: '`DeadPoint` is never constructed');
+      expect(decl!.removalBlocked, isTrue);
+      expect(decl.hint, contains('primary constructor'));
+      // The header constructor of a live, constructed class is not a finding.
+      expect(findByQualified(result, 'Point.new'), isNull);
+      // Nor is one whose class is alive as a type only: a references query at
+      // the header resolves to the class itself, so a primary constructor
+      // always inherits its class's references. Conservative on purpose — the
+      // failure mode is missing a dead constructor, never deleting a live one.
+      expect(findByQualified(result, 'Secret._'), isNull);
+    });
+  });
+
   group('annotation detection ignores comments', () {
     Future<Set<String>> runCommentAnnotations() async {
       final result = await runFinder(

--- a/test/finder_test.dart
+++ b/test/finder_test.dart
@@ -908,19 +908,14 @@ void main() {
     test("reports exactly the fixture's dead declarations", () async {
       final result = await runPrimary();
       expect(result.unused.map((d) => d.qualifiedName).toSet(), {
-        // A dead enum value of an enum that has a primary constructor.
         'Suit.spades',
-        // A class whose whole declaration — header constructor and the
-        // instance variables its declaring parameters induce — is dead.
+        // Reported as the class, not as its header declarations.
         'DeadPoint',
-        // The abbreviated `new`/`factory` headers: body members like any other.
         'Registry.deadNamed',
         'Registry.deadFactory',
         'Registry.deadRedirect',
-        // A plain body field of a class that has a primary constructor.
         'Registry.deadCounter',
-        // Declaring parameters nothing ever reads — positional, named, and
-        // optional positional.
+        // Declaring parameters: positional, named, optional positional.
         'Endpoint.port',
         'Chip.badge',
         'Ranged.high',
@@ -932,10 +927,9 @@ void main() {
     });
 
     test("a primary constructor's body part is never a finding of its own", () {
-      // `class Delta(…) { this : assert(…); }` — the analysis server reports
-      // the body part as a constructor literally named `this`. It is the tail
-      // of the header's constructor, not a declaration, so it must not surface
-      // (least of all as a `Delta.this` finding nobody can act on).
+      // `class Delta(…) { this : assert(…); }` — the server reports the body
+      // part as a constructor named `this`, which must not surface as a
+      // `Delta.this` finding nobody can act on.
       return expectLater(
         runPrimary().then((r) => r.unused.map((d) => d.qualifiedName)),
         completion(isNot(contains(anyOf('Delta.this', 'Delta.new')))),
@@ -946,9 +940,9 @@ void main() {
       'a dead declaring parameter is reported but removal-blocked',
       () async {
         final result = await runPrimary();
-        // Positional, named (`{required var String label, var int badge = 0}`)
-        // and optional positional (`[var int high = 10]`) alike: a parameter
-        // group's own brackets must not be mistaken for the class body.
+        // Positional, named (`{required var String label, …}`) and optional
+        // positional (`[var int high = 10]`) alike: a parameter group's own
+        // brackets must not be mistaken for the class body.
         for (final qualified in const [
           'Endpoint.port',
           'Chip.badge',
@@ -957,9 +951,6 @@ void main() {
           final decl = findByQualified(result, qualified);
           expect(decl, isNotNull, reason: 'nothing ever reads $qualified');
           expect(decl!.kind, SymbolKind.field);
-          // The field and the constructor parameter are one declaration in the
-          // header: deleting it would change the constructor's signature at
-          // every call site, so the finding is surfaced and left in place.
           expect(decl.removalBlocked, isTrue);
           expect(decl.hint, contains('declaring parameter'));
         }
@@ -971,9 +962,8 @@ void main() {
       final decl = findByQualified(result, 'DeadPoint');
       expect(decl, isNotNull);
       expect(decl!.kind, SymbolKind.class$);
-      // Removing the class removes its `;`-bodied declaration whole, so its
-      // declaring parameters must not also be reported (or blocked) on their
-      // own.
+      // The `;`-bodied declaration goes whole, so its declaring parameters must
+      // not also be reported (or blocked) on their own.
       expect(decl.removalBlocked, isFalse);
       for (final qualified in const ['DeadPoint.x', 'DeadPoint.y']) {
         expect(findByQualified(result, qualified), isNull);
@@ -990,7 +980,6 @@ void main() {
         final decl = findByQualified(result, qualified);
         expect(decl, isNotNull, reason: '$qualified is never invoked');
         expect(decl!.kind, SymbolKind.constructor);
-        // Declared in the class BODY, so an ordinary whole-node removal.
         expect(
           decl.removalBlocked,
           isFalse,
@@ -1001,10 +990,8 @@ void main() {
 
     test('a primary constructor asked for on its own is report-only', () async {
       // Restricting the run to constructors drops the class candidates that
-      // would otherwise absorb a dead class's header constructor: `DeadPoint`
-      // is then reported through its constructor alone. It must be blocked —
-      // that declaration IS the class header, so deleting the node would leave
-      // a `class ;` fragment behind.
+      // would otherwise absorb a dead class's header constructor, so
+      // `DeadPoint` is reported through its constructor alone.
       final result = await runFinder(
         include: ['lib/scenarios/primary_constructors.dart'],
         exclude: const [],
@@ -1016,10 +1003,9 @@ void main() {
       expect(decl.hint, contains('primary constructor'));
       // The header constructor of a live, constructed class is not a finding.
       expect(findByQualified(result, 'Point.new'), isNull);
-      // Nor is one whose class is alive as a type only: a references query at
-      // the header resolves to the class itself, so a primary constructor
-      // always inherits its class's references. Conservative on purpose — the
-      // failure mode is missing a dead constructor, never deleting a live one.
+      // Nor is one whose class is alive as a type only: a query at the header
+      // resolves to the class, so a primary constructor always inherits its
+      // class's references.
       expect(findByQualified(result, 'Secret._'), isNull);
     });
   });

--- a/test/remover_test.dart
+++ b/test/remover_test.dart
@@ -753,6 +753,80 @@ Holder? holderRef;
       expect(result, contains('const Holder(this.label);'));
     },
   );
+
+  test('removes a dead class declared with a primary constructor and a `;` '
+      'body', () {
+    // Dart 3.13: the whole declaration is the header, ending in `;` instead of
+    // a `{}` body. The class range covers it, terminator included.
+    const source = '''
+class Kept(var int x);
+
+/// Never referenced.
+class DeadPoint(var int x, var int y);
+
+int useKept() => Kept(1).x;
+''';
+    // `class DeadPoint(var int x, var int y);` is line index 3, columns 0..38.
+    final result = applyRemoval(source, [
+      decl(
+        startLine: 3,
+        startColumn: 0,
+        endLine: 3,
+        endColumn: 38,
+        kind: .class$,
+      ),
+    ]);
+    expect(result, isNot(contains('DeadPoint')));
+    // Neither the doc comment nor a stray `;` may be left behind.
+    expect(result, isNot(contains('Never referenced')));
+    expect(result, contains('class Kept(var int x);'));
+    expect(result, contains('int useKept() => Kept(1).x;'));
+    _expectBalanced(result);
+  });
+
+  test(
+    'removes an abbreviated `new`/`factory` constructor from a class body',
+    () {
+      // Dart 3.13's abbreviated in-body constructor headers name no class, but
+      // they are ordinary body members: whole-node removal, `;` and all.
+      const source = '''
+class Registry {
+  new() : tag = null;
+
+  /// Never invoked.
+  new deadNamed() : tag = null;
+
+  /// Never invoked either.
+  factory deadRedirect() = Registry;
+
+  final String? tag;
+}
+''';
+      final result = applyRemoval(source, [
+        // `new deadNamed() : tag = null;` is line index 4, columns 2..30.
+        decl(
+          startLine: 4,
+          startColumn: 2,
+          endLine: 4,
+          endColumn: 30,
+          kind: .constructor,
+        ),
+        // `factory deadRedirect() = Registry;` is line index 7, columns 2..35.
+        decl(
+          startLine: 7,
+          startColumn: 2,
+          endLine: 7,
+          endColumn: 35,
+          kind: .constructor,
+        ),
+      ]);
+      expect(result, isNot(contains('deadNamed')));
+      expect(result, isNot(contains('deadRedirect')));
+      expect(result, contains('new() : tag = null;'));
+      expect(result, contains('final String? tag;'));
+      _expectBalanced(result);
+    },
+  );
 }
 
 /// A cheap brace-balance check so a regression that mangles a removal shows

--- a/test/remover_test.dart
+++ b/test/remover_test.dart
@@ -756,8 +756,7 @@ Holder? holderRef;
 
   test('removes a dead class declared with a primary constructor and a `;` '
       'body', () {
-    // The whole declaration is the header, ending in `;` instead of a `{}`
-    // body; the class range covers it, terminator included.
+    // The whole declaration is the header; the class range covers the `;`.
     const source = '''
 class Kept(var int x);
 
@@ -786,8 +785,6 @@ int useKept() => Kept(1).x;
   test(
     'removes an abbreviated `new`/`factory` constructor from a class body',
     () {
-      // These name no class, but are ordinary body members: whole-node
-      // removal, `;` and all.
       const source = '''
 class Registry {
   new() : tag = null;

--- a/test/remover_test.dart
+++ b/test/remover_test.dart
@@ -756,8 +756,8 @@ Holder? holderRef;
 
   test('removes a dead class declared with a primary constructor and a `;` '
       'body', () {
-    // Dart 3.13: the whole declaration is the header, ending in `;` instead of
-    // a `{}` body. The class range covers it, terminator included.
+    // The whole declaration is the header, ending in `;` instead of a `{}`
+    // body; the class range covers it, terminator included.
     const source = '''
 class Kept(var int x);
 
@@ -777,7 +777,6 @@ int useKept() => Kept(1).x;
       ),
     ]);
     expect(result, isNot(contains('DeadPoint')));
-    // Neither the doc comment nor a stray `;` may be left behind.
     expect(result, isNot(contains('Never referenced')));
     expect(result, contains('class Kept(var int x);'));
     expect(result, contains('int useKept() => Kept(1).x;'));
@@ -787,8 +786,8 @@ int useKept() => Kept(1).x;
   test(
     'removes an abbreviated `new`/`factory` constructor from a class body',
     () {
-      // Dart 3.13's abbreviated in-body constructor headers name no class, but
-      // they are ordinary body members: whole-node removal, `;` and all.
+      // These name no class, but are ordinary body members: whole-node
+      // removal, `;` and all.
       const source = '''
 class Registry {
   new() : tag = null;


### PR DESCRIPTION
A primary constructor, and the instance variables its `var`/`final` parameters
induce, live in the class header, where the analysis server reports them as
ordinary constructor/field symbols. `--remove` deleted those nodes:

```dart
class const Secret._(final int v);   // ciach --remove -k constructor
class Ghost(final int v) { … }
```
```dart
class                                // …left this behind
class  { … }
```

Candidates are now placed against their type's header/body boundary, and a
header declaration is reported but never auto-removed. Two smaller fixes: the
`this : …` body part no longer surfaces as a bogus `Class.this` finding, and a
dead class's declaring parameters go with the class instead of being reported
again. Abbreviated `new`/`factory` body headers from the same feature needed no
work — they are ordinary members and stay removable.

`--remove`'s summary now counts only what it actually deleted, instead of
claiming removals that never happened.

## SDK

`sdk: ^3.10.0` is unchanged and still verified against a real 3.10 SDK (`dart
analyze` clean, floor-check runs). The fixture package moves to `^3.13.0`
(nothing older parses the new scenario), so the test and publish jobs move to
3.13; `verify-sdk-floor` stays on 3.10.

## Testing

`dart test` (176 passing), `dart analyze` and `dart format --set-exit-if-changed`
on Dart 3.13.0, plus an end-to-end `--remove --force` over the new fixture whose
output still analyzes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016NgZHvSX83v629fckDg4dU

---
_Generated by [Claude Code](https://claude.ai/code/session_016NgZHvSX83v629fckDg4dU)_