### PR TITLE
feat: add --version and put the version in the help header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.4.3
 
 - Add `--version`, printing the ciach version, and lead the `--help` output with
   it. The version also reaches the analysis server as the LSP client version,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+- Add `--version`, printing the ciach version, and lead the `--help` output with
+  it. The version also reaches the analysis server as the LSP client version,
+  which was pinned at `1.0.0` before.
+
 ## 0.4.2
 
 - Support Dart 3.13 primary constructors: a dead constructor or declaring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## 0.4.3
 
-- Add `--version`, printing the ciach version, and lead the `--help` output with
-  it. The version also reaches the analysis server as the LSP client version,
-  which was pinned at `1.0.0` before.
+- Add `--version`, and show the version in the `--help` header. The analysis
+  server now sees the real version instead of `1.0.0`.
 
 ## 0.4.2
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ ciach --verbose                        # explain each step
 | --- | --- | --- |
 | `[path]` | `.` | Package root to analyze. |
 | `-h, --help` | — | Print usage information. |
+| `--version` | — | Print the ciach version and exit. The `--help` header carries it too. |
 | `--config <path>` | auto | Read settings from this YAML file instead of the auto-discovered one. See [Configuration file](#configuration-file). |
 | `--no-config` | off | Ignore the config file, even if one is found. |
 | `--[no-]public` | on | Report unused public declarations too. Disable to report only private (`_`-prefixed) ones. |

--- a/bin/ciach.dart
+++ b/bin/ciach.dart
@@ -17,6 +17,7 @@ import 'package:ciach/src/cli/config.dart';
 import 'package:ciach/src/cli/options.dart';
 import 'package:ciach/src/cli/verbose.dart';
 import 'package:ciach/src/reporter.dart';
+import 'package:ciach/src/version.dart';
 import 'package:collection/collection.dart';
 import 'package:config/config.dart';
 import 'package:path/path.dart' as p;
@@ -43,6 +44,11 @@ Future<int> _run(List<String> arguments) async {
 
   if (args.flag('help')) {
     stdout.writeln(usage(parser));
+    return 0;
+  }
+
+  if (args.flag('version')) {
+    stdout.writeln('ciach $ciachVersion');
     return 0;
   }
 

--- a/lib/src/cli/args.dart
+++ b/lib/src/cli/args.dart
@@ -10,6 +10,7 @@
 
 import 'package:args/args.dart';
 import 'package:ciach/ciach.dart';
+import 'package:ciach/src/version.dart';
 import 'package:collection/collection.dart';
 import 'package:config/config.dart';
 
@@ -61,8 +62,8 @@ Set<SymbolKind> parseKinds(List<String> raw) {
 /// Every setting ciach accepts, declared once for the command line, the config
 /// file (`configKey`) and its default.
 ///
-/// [help], [config] and [noConfig] have no `configKey`: a config file doesn't
-/// get to decide whether it is read.
+/// [help], [version], [config] and [noConfig] have no `configKey`: a config
+/// file doesn't get to decide whether it is read, or what ciach is called.
 enum CiachOption<V> implements OptionDefinition<V> {
   help(
     FlagOption(
@@ -71,6 +72,15 @@ enum CiachOption<V> implements OptionDefinition<V> {
       negatable: false,
       defaultsTo: false,
       helpText: 'Print this usage information.',
+    ),
+  ),
+  // No `-v`: that is --verbose.
+  version(
+    FlagOption(
+      argName: 'version',
+      negatable: false,
+      defaultsTo: false,
+      helpText: 'Print the ciach version and exit.',
     ),
   ),
   config(
@@ -357,6 +367,8 @@ ArgParser buildParser() {
 /// The full `--help` text, wrapping [parser]'s generated option list.
 String usage(ArgParser parser) =>
     '''
+ciach $ciachVersion
+
 Find unused (never-referenced) declarations in a Dart/Flutter package.
 
 Usage: ciach [options] [path]

--- a/lib/src/cli/verbose.dart
+++ b/lib/src/cli/verbose.dart
@@ -88,7 +88,7 @@ String _setting(
   .concurrency => '${resolved.concurrency}',
   .dart => dartExecutable,
   // No config key, so never listed; spelled out so a new option must be too.
-  .help || .config || .noConfig => '',
+  .help || .version || .config || .noConfig => '',
 };
 
 /// Where a value came from, in the user's words.

--- a/lib/src/lsp/lsp_client.dart
+++ b/lib/src/lsp/lsp_client.dart
@@ -12,6 +12,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:ciach/src/version.dart';
 import 'package:pro_lsp/pro_lsp.dart' as lsp;
 import 'package:stream_channel/stream_channel.dart';
 
@@ -57,7 +58,7 @@ class LspClient {
       'language-server',
       '--protocol=lsp',
       '--client-id=ciach',
-      '--client-version=1.0.0',
+      '--client-version=$ciachVersion',
     ]);
 
     final channel = StreamChannel<List<int>>(process.stdout, process.stdin);
@@ -95,7 +96,7 @@ class LspClient {
   Future<void> initialize(Uri rootUri) async {
     final uri = rootUri.toString();
     final result = await _client.start(
-      clientInfo: const .new(name: 'ciach', version: '1.0.0'),
+      clientInfo: const .new(name: 'ciach', version: ciachVersion),
       rootUri: uri,
       workspaceFolders: [.new(uri: uri, name: 'root')],
       // Hierarchical document symbols yield nested `DocumentSymbol[]` rather

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -8,10 +8,5 @@
  *     - mark-ai-provenance
  */
 
-/// The published version of ciach, as `--version` and the `--help` header
-/// report it.
-///
-/// A compiled or globally activated binary has no `pubspec.yaml` to read at
-/// run time, so the version is a constant here and `test/version_test.dart`
-/// fails if a release bumps `pubspec.yaml` without it.
+/// The published version of ciach. Keep in sync with `pubspec.yaml`.
 const ciachVersion = '0.4.2';

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -9,4 +9,4 @@
  */
 
 /// The published version of ciach. Keep in sync with `pubspec.yaml`.
-const ciachVersion = '0.4.2';
+const ciachVersion = '0.4.3';

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,0 +1,17 @@
+/*
+ * AI-Provenance:
+ *   model: claude-opus-5
+ *   harness: Claude Code
+ *   plugins:
+ *     - lean-ai-provenance
+ *   skills:
+ *     - mark-ai-provenance
+ */
+
+/// The published version of ciach, as `--version` and the `--help` header
+/// report it.
+///
+/// A compiled or globally activated binary has no `pubspec.yaml` to read at
+/// run time, so the version is a constant here and `test/version_test.dart`
+/// fails if a release bumps `pubspec.yaml` without it.
+const ciachVersion = '0.4.2';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Finds unused (never-referenced) declarations in a Dart/Flutter package by
   driving the Dart analysis server over LSP and querying textDocument/references.
 # Keep in sync with `ciachVersion` in lib/src/version.dart.
-version: 0.4.2
+version: 0.4.3
 repository: https://github.com/leancodepl/ciach
 homepage: https://github.com/leancodepl/ciach
 issue_tracker: https://github.com/leancodepl/ciach/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,7 @@ name: ciach
 description: >-
   Finds unused (never-referenced) declarations in a Dart/Flutter package by
   driving the Dart analysis server over LSP and querying textDocument/references.
+# Keep in sync with `ciachVersion` in lib/src/version.dart.
 version: 0.4.2
 repository: https://github.com/leancodepl/ciach
 homepage: https://github.com/leancodepl/ciach

--- a/test/config_test.dart
+++ b/test/config_test.dart
@@ -91,7 +91,7 @@ dart: /sdk/bin/dart
 
     test('covers every command-line option', () {
       // Anything settable on the command line is settable in the file.
-      final cliOnly = {'help', 'config', 'no-config'};
+      final cliOnly = {'help', 'version', 'config', 'no-config'};
       final optionNames = parser.options.keys.toSet().difference(cliOnly);
 
       expect(configKeys.difference({'path'}), optionNames);

--- a/test/version_test.dart
+++ b/test/version_test.dart
@@ -1,0 +1,54 @@
+/*
+ * AI-Provenance:
+ *   model: claude-opus-5
+ *   harness: Claude Code
+ *   plugins:
+ *     - lean-ai-provenance
+ *   skills:
+ *     - mark-ai-provenance
+ */
+
+@Timeout(Duration(minutes: 2))
+library;
+
+import 'dart:io';
+
+import 'package:ciach/src/version.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  final entrypoint = p.join('bin', 'ciach.dart');
+
+  test('ciachVersion matches the pubspec version', () {
+    final pubspec = loadYaml(File('pubspec.yaml').readAsStringSync()) as Map;
+    expect(
+      ciachVersion,
+      pubspec['version'],
+      reason:
+          'A release bumped pubspec.yaml without lib/src/version.dart (or the '
+          'other way around); --version would report the wrong number.',
+    );
+  });
+
+  test('--version prints the version and exits 0', () async {
+    final result = await Process.run(Platform.resolvedExecutable, [
+      'run',
+      entrypoint,
+      '--version',
+    ]);
+    expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
+    expect(result.stdout, 'ciach $ciachVersion\n');
+  });
+
+  test('--help leads with the version', () async {
+    final result = await Process.run(Platform.resolvedExecutable, [
+      'run',
+      entrypoint,
+      '--help',
+    ]);
+    expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
+    expect(result.stdout, startsWith('ciach $ciachVersion\n'));
+  });
+}


### PR DESCRIPTION
ciach never told anyone which ciach was running: a bug report, or a
question about whether a fix had shipped, had no answer short of
`dart pub deps`. Add a `--version` flag printing `ciach <version>`, and
lead the `--help` output with the same line so the version is there
without asking for it twice. No `-v` abbreviation — that is `--verbose`.

A compiled or globally activated binary has no `pubspec.yaml` to read at
run time, so the number is a constant in `lib/src/version.dart` and a
test asserts it equals the pubspec's, failing CI when a release bumps
one and not the other.

The same constant now goes to the analysis server as the LSP client
version and `--client-id=ciach`'s `--client-version`, both of which
claimed `1.0.0` regardless of the release.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Awo6t6hMWSJBqXUjxDjJxW