### PR TITLE
Fix compiled binary spawning itself as analysis server

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ Install it globally for a `ciach` command everywhere, in `~/.pub-cache/bin`:
 dart pub global activate ciach
 ```
 
+Or, on a recent SDK, as a compiled binary:
+
+```bash
+dart install ciach
+```
+
+A compiled `ciach` runs the analysis server with the `dart` on your `PATH` (an
+fvm or Flutter `dart` works too); `--dart <path>` picks a different one.
+
 Or add it as a dev dependency, which pins the version for the team and CI:
 
 ```bash
@@ -91,7 +100,7 @@ ciach --verbose                        # explain each step
 | `--[no-]color` | auto | Colorize text output. |
 | `--[no-]progress` | auto | Show scan progress on stderr. |
 | `-v, --verbose` | off | Explain what's happening on stderr. See [Verbose mode](#verbose-mode). |
-| `--dart <path>` | current SDK | Path to the `dart` executable to launch the server with. |
+| `--dart <path>` | auto | Path to the `dart` executable to launch the server with. Defaults to the SDK running ciach, or to `dart` from `PATH` for a compiled binary. |
 
 Exit codes: `0` success, `1` unused found with `--set-exit-if-changed`, `2`
 usage or analysis error.

--- a/bin/ciach.dart
+++ b/bin/ciach.dart
@@ -108,18 +108,25 @@ Future<int> _run(List<String> arguments) async {
   final showProgress = resolved.showProgress;
   final rootPath = resolved.absoluteRootPath;
 
+  // Resolved up front so a missing SDK fails before any scanning, and so the
+  // verbose rundown shows the `dart` the run will actually use.
+  final String dartExecutable;
+  try {
+    dartExecutable = findDartExecutable(explicit: resolved.dartExecutable);
+  } on DartSdkNotFoundException catch (e) {
+    stderr.writeln(e.message);
+    return 2;
+  }
+
   log?.writeAll(
-    describeSettings(
-      configuration,
-      resolved,
-      dartExecutable: resolved.dartExecutable ?? Platform.resolvedExecutable,
-    ),
+    describeSettings(configuration, resolved, dartExecutable: dartExecutable),
   );
 
   final FinderResult result;
   try {
     result = await Ciach(
       resolved.finderOptions(
+        dartExecutable: dartExecutable,
         // Verbose keeps every phase line; progress overwrites one in place.
         onProgress:
             log?.write ?? (showProgress ? _ProgressPrinter().update : null),

--- a/bin/ciach.dart
+++ b/bin/ciach.dart
@@ -108,8 +108,7 @@ Future<int> _run(List<String> arguments) async {
   final showProgress = resolved.showProgress;
   final rootPath = resolved.absoluteRootPath;
 
-  // Resolved up front so a missing SDK fails before any scanning, and so the
-  // verbose rundown shows the `dart` the run will actually use.
+  // Up front: a missing SDK fails fast, and verbose shows the real `dart`.
   final String dartExecutable;
   try {
     dartExecutable = findDartExecutable(explicit: resolved.dartExecutable);

--- a/lib/ciach.dart
+++ b/lib/ciach.dart
@@ -27,6 +27,8 @@ library;
 
 export 'package:pro_lsp/pro_lsp.dart' show SymbolKind;
 
+export 'src/dart_executable.dart'
+    show DartSdkNotFoundException, findDartExecutable;
 export 'src/finder.dart' show Ciach;
 export 'src/models.dart'
     show

--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -65,10 +65,8 @@ class ResolvedOptions {
   /// [rootPath] resolved against the current directory.
   String get absoluteRootPath => p.normalize(p.absolute(rootPath));
 
-  /// The finder's share of these settings, reporting progress to [onProgress].
-  ///
-  /// [dartExecutable] is the `dart` the caller resolved (see
-  /// `findDartExecutable`); when null the finder resolves one itself.
+  /// The finder's share of these settings, reporting progress to [onProgress]
+  /// and launching the server with [dartExecutable] (else it finds one).
   FinderOptions finderOptions({
     String? dartExecutable,
     void Function(String message)? onProgress,

--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -66,23 +66,28 @@ class ResolvedOptions {
   String get absoluteRootPath => p.normalize(p.absolute(rootPath));
 
   /// The finder's share of these settings, reporting progress to [onProgress].
-  FinderOptions finderOptions({void Function(String message)? onProgress}) =>
-      .new(
-        rootPath: absoluteRootPath,
-        includeGlobs: includeGlobs,
-        excludeGlobs: excludeGlobs,
-        additionalGeneratedSuffixes: additionalGeneratedSuffixes,
-        kinds: kinds,
-        includePublic: includePublic,
-        includeGenerated: includeGenerated,
-        skipOverrides: !overrides,
-        skipOperators: !operators,
-        unusedUnionMembers: unusedUnionMembers,
-        reportToJson: reportToJson,
-        concurrency: concurrency,
-        dartExecutable: dartExecutable,
-        onProgress: onProgress,
-      );
+  ///
+  /// [dartExecutable] is the `dart` the caller resolved (see
+  /// `findDartExecutable`); when null the finder resolves one itself.
+  FinderOptions finderOptions({
+    String? dartExecutable,
+    void Function(String message)? onProgress,
+  }) => .new(
+    rootPath: absoluteRootPath,
+    includeGlobs: includeGlobs,
+    excludeGlobs: excludeGlobs,
+    additionalGeneratedSuffixes: additionalGeneratedSuffixes,
+    kinds: kinds,
+    includePublic: includePublic,
+    includeGenerated: includeGenerated,
+    skipOverrides: !overrides,
+    skipOperators: !operators,
+    unusedUnionMembers: unusedUnionMembers,
+    reportToJson: reportToJson,
+    concurrency: concurrency,
+    dartExecutable: dartExecutable ?? this.dartExecutable,
+    onProgress: onProgress,
+  );
 }
 
 /// Resolves every [CiachOption] from [args] and [config], the command line

--- a/lib/src/dart_executable.dart
+++ b/lib/src/dart_executable.dart
@@ -1,0 +1,121 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// Thrown when no `dart` executable to launch the analysis server with could be
+/// found. [message] is written for the user and names the way out.
+class DartSdkNotFoundException implements Exception {
+  const DartSdkNotFoundException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+/// Locates the `dart` executable that launches the analysis server.
+///
+/// Tried in order:
+///
+/// 1. [explicit], the user's `--dart` / `dart:` setting, taken as is.
+/// 2. The Dart VM running this tool, when there is one — `dart run ciach`,
+///    `dart pub global run`, `dart test`. It is recognised by name: the SDK's VM
+///    is always called `dart` (`dart.exe` on Windows), wherever the SDK lives
+///    (fvm, asdf, Homebrew, a Flutter SDK's `bin/cache/dart-sdk`, …). A
+///    compiled binary — `dart compile exe`, `dart build cli`, `dart install` —
+///    is the program itself, named after the tool, and is deliberately *not*
+///    treated as an SDK: spawning it as the server would run ciach recursively
+///    and fail. ([#42](https://github.com/leancodepl/ciach/issues/42))
+/// 3. `dart` on `PATH`, as the user's shell would find it. On Windows also
+///    `dart.exe`, `dart.bat` and `dart.cmd`.
+///
+/// Throws a [DartSdkNotFoundException] when none of these yields anything.
+///
+/// The optional parameters replace the running process's environment, for
+/// tests; production callers pass none of them.
+String findDartExecutable({
+  String? explicit,
+  String? currentExecutable,
+  Map<String, String>? environment,
+  bool? isWindows,
+  bool Function(String path)? fileExists,
+}) {
+  if (explicit != null) {
+    return explicit;
+  }
+
+  final windows = isWindows ?? Platform.isWindows;
+  final exists = fileExists ?? (path) => File(path).existsSync();
+
+  final running = currentExecutable ?? Platform.resolvedExecutable;
+  if (_isNamedDart(running, windows: windows)) {
+    return running;
+  }
+
+  final env = environment ?? Platform.environment;
+  final onPath = _searchPath(env, windows: windows, exists: exists);
+  if (onPath != null) {
+    return onPath;
+  }
+
+  throw DartSdkNotFoundException(
+    'Could not find the Dart SDK to run the analysis server with.\n'
+    'This is a compiled ciach binary ($running), not one running under '
+    '`dart`, and there is no `dart` on PATH.\n'
+    'Pass --dart <path-to-dart>, set `dart: <path>` in ciach.yaml, or put '
+    "the SDK's bin directory on PATH.",
+  );
+}
+
+/// Whether [executable] is the SDK's VM going by its file name.
+bool _isNamedDart(String executable, {required bool windows}) {
+  if (windows) {
+    final name = p.windows.basename(executable).toLowerCase();
+    return name == 'dart' || name == 'dart.exe';
+  }
+  return p.posix.basename(executable) == 'dart';
+}
+
+/// The first `dart` found on the environment's `PATH`, or null.
+String? _searchPath(
+  Map<String, String> environment, {
+  required bool windows,
+  required bool Function(String path) exists,
+}) {
+  // Windows keys are case-insensitive; `Path` is the usual spelling there.
+  final path = windows
+      ? environment.entries
+            .where((e) => e.key.toUpperCase() == 'PATH')
+            .map((e) => e.value)
+            .firstOrNull
+      : environment['PATH'];
+  if (path == null || path.isEmpty) {
+    return null;
+  }
+
+  final context = windows ? p.windows : p.posix;
+  final names = windows
+      ? const ['dart.exe', 'dart.bat', 'dart.cmd', 'dart']
+      : const ['dart'];
+
+  for (final dir in path.split(windows ? ';' : ':')) {
+    // An empty entry means the current directory; too surprising to honour.
+    if (dir.isEmpty) {
+      continue;
+    }
+    for (final name in names) {
+      final candidate = context.join(dir, name);
+      if (exists(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return null;
+}
+
+/// Whether [executable] needs a shell to run: a Windows batch script cannot be
+/// started directly, and Flutter ships its `dart` as one.
+bool executableNeedsShell(String executable) {
+  final ext = p.windows.extension(executable).toLowerCase();
+  return ext == '.bat' || ext == '.cmd';
+}

--- a/lib/src/dart_executable.dart
+++ b/lib/src/dart_executable.dart
@@ -1,9 +1,7 @@
-import 'dart:io';
-
+import 'package:cli_util/cli_util.dart' as cli_util;
 import 'package:path/path.dart' as p;
 
-/// Thrown when no `dart` executable to launch the analysis server with could be
-/// found. [message] is written for the user and names the way out.
+/// No `dart` to run the analysis server with; [message] names the way out.
 class DartSdkNotFoundException implements Exception {
   const DartSdkNotFoundException(this.message);
 
@@ -13,109 +11,22 @@ class DartSdkNotFoundException implements Exception {
   String toString() => message;
 }
 
-/// Locates the `dart` executable that launches the analysis server.
-///
-/// Tried in order:
-///
-/// 1. [explicit], the user's `--dart` / `dart:` setting, taken as is.
-/// 2. The Dart VM running this tool, when there is one — `dart run ciach`,
-///    `dart pub global run`, `dart test`. It is recognised by name: the SDK's VM
-///    is always called `dart` (`dart.exe` on Windows), wherever the SDK lives
-///    (fvm, asdf, Homebrew, a Flutter SDK's `bin/cache/dart-sdk`, …). A
-///    compiled binary — `dart compile exe`, `dart build cli`, `dart install` —
-///    is the program itself, named after the tool, and is deliberately *not*
-///    treated as an SDK: spawning it as the server would run ciach recursively
-///    and fail. ([#42](https://github.com/leancodepl/ciach/issues/42))
-/// 3. `dart` on `PATH`, as the user's shell would find it. On Windows also
-///    `dart.exe`, `dart.bat` and `dart.cmd`.
-///
-/// Throws a [DartSdkNotFoundException] when none of these yields anything.
-///
-/// The optional parameters replace the running process's environment, for
-/// tests; production callers pass none of them.
-String findDartExecutable({
-  String? explicit,
-  String? currentExecutable,
-  Map<String, String>? environment,
-  bool? isWindows,
-  bool Function(String path)? fileExists,
-}) {
-  if (explicit != null) {
-    return explicit;
-  }
+/// The `dart` that launches the analysis server: [explicit] (`--dart`), else
+/// the SDK `package:cli_util` finds — the VM running this tool, or `dart` on
+/// `PATH` for a compiled binary (`dart install`, `dart compile exe`), which is
+/// ciach itself and must not be spawned as the server (#42).
+String findDartExecutable({String? explicit}) =>
+    explicit ??
+    cli_util.dartExecutable ??
+    (throw const DartSdkNotFoundException(
+      'Could not find a Dart SDK to run the analysis server with: this is a '
+      'compiled ciach, not one running under `dart`, and `dart` is not on '
+      'PATH.\nPass --dart <path>, set `dart:` in ciach.yaml, or add the '
+      "SDK's bin directory to PATH.",
+    ));
 
-  final windows = isWindows ?? Platform.isWindows;
-  final exists = fileExists ?? (path) => File(path).existsSync();
-
-  final running = currentExecutable ?? Platform.resolvedExecutable;
-  if (_isNamedDart(running, windows: windows)) {
-    return running;
-  }
-
-  final env = environment ?? Platform.environment;
-  final onPath = _searchPath(env, windows: windows, exists: exists);
-  if (onPath != null) {
-    return onPath;
-  }
-
-  throw DartSdkNotFoundException(
-    'Could not find the Dart SDK to run the analysis server with.\n'
-    'This is a compiled ciach binary ($running), not one running under '
-    '`dart`, and there is no `dart` on PATH.\n'
-    'Pass --dart <path-to-dart>, set `dart: <path>` in ciach.yaml, or put '
-    "the SDK's bin directory on PATH.",
-  );
-}
-
-/// Whether [executable] is the SDK's VM going by its file name.
-bool _isNamedDart(String executable, {required bool windows}) {
-  if (windows) {
-    final name = p.windows.basename(executable).toLowerCase();
-    return name == 'dart' || name == 'dart.exe';
-  }
-  return p.posix.basename(executable) == 'dart';
-}
-
-/// The first `dart` found on the environment's `PATH`, or null.
-String? _searchPath(
-  Map<String, String> environment, {
-  required bool windows,
-  required bool Function(String path) exists,
-}) {
-  // Windows keys are case-insensitive; `Path` is the usual spelling there.
-  final path = windows
-      ? environment.entries
-            .where((e) => e.key.toUpperCase() == 'PATH')
-            .map((e) => e.value)
-            .firstOrNull
-      : environment['PATH'];
-  if (path == null || path.isEmpty) {
-    return null;
-  }
-
-  final context = windows ? p.windows : p.posix;
-  final names = windows
-      ? const ['dart.exe', 'dart.bat', 'dart.cmd', 'dart']
-      : const ['dart'];
-
-  for (final dir in path.split(windows ? ';' : ':')) {
-    // An empty entry means the current directory; too surprising to honour.
-    if (dir.isEmpty) {
-      continue;
-    }
-    for (final name in names) {
-      final candidate = context.join(dir, name);
-      if (exists(candidate)) {
-        return candidate;
-      }
-    }
-  }
-  return null;
-}
-
-/// Whether [executable] needs a shell to run: a Windows batch script cannot be
-/// started directly, and Flutter ships its `dart` as one.
-bool executableNeedsShell(String executable) {
-  final ext = p.windows.extension(executable).toLowerCase();
-  return ext == '.bat' || ext == '.cmd';
-}
+/// Windows batch scripts (Flutter's `dart.bat`) only run through a shell.
+bool executableNeedsShell(String executable) => const {
+  '.bat',
+  '.cmd',
+}.contains(p.windows.extension(executable).toLowerCase());

--- a/lib/src/lsp/lsp_client.dart
+++ b/lib/src/lsp/lsp_client.dart
@@ -37,10 +37,9 @@ class LspClient {
   final Process _process;
   final lsp.LspClient _client;
 
-  /// Completes when the server process exits, however it does.
   final _exited = Completer<void>();
 
-  /// Why the server died, when it did so outside [dispose]; null otherwise.
+  /// Set when the server dies outside [dispose].
   StateError? _exitError;
 
   /// Completers waiting for the server to become idle.
@@ -60,10 +59,8 @@ class LspClient {
 
   /// Spawns `<dart> language-server --protocol=lsp` and wires up the client.
   ///
-  /// [dartExecutable] defaults to [findDartExecutable]: the Dart VM running
-  /// this tool when there is one, so the server matches the SDK the user
-  /// invoked us with, else `dart` from `PATH`. Throws a
-  /// [DartSdkNotFoundException] when neither exists.
+  /// [dartExecutable] defaults to [findDartExecutable], which throws a
+  /// [DartSdkNotFoundException] when there is no SDK to be found.
   static Future<LspClient> start({String? dartExecutable}) async {
     final executable = findDartExecutable(explicit: dartExecutable);
     final process = await Process.start(executable, [
@@ -82,14 +79,11 @@ class LspClient {
         .listen(wrapper._stderrBuffer.write, onError: (_) {})
         .asFuture<void>()
         .catchError((_) {});
-    // Writes to a dead server's stdin fail with a broken pipe. The exit report
-    // below is the account of that death; the pipe error has nothing to add
-    // and nobody awaits it.
+    // A dead server's stdin fails with a broken pipe; the exit report covers it.
     unawaited(process.stdin.done.catchError((_) {}));
     unawaited(() async {
       final code = await process.exitCode;
-      // The exit code can land before the last of stderr does; the report
-      // should carry all of it.
+      // Can land before the last of stderr does.
       await stderrDrained;
       if (!wrapper._shuttingDown) {
         final stderr = wrapper.stderr.trim();
@@ -144,14 +138,8 @@ class LspClient {
     _semanticTokenTypes = _legendTokenTypes(result.capabilities);
   }
 
-  /// Runs [request], swapping the opaque error a dead connection produces for
-  /// the server's exit code and stderr.
-  ///
-  /// When the server process dies, `json_rpc_2` fails every pending request
-  /// with `The client closed with pending request "<method>"`, which says
-  /// nothing about why. The exit handler in [start] records the real story;
-  /// this gives it a moment to arrive (the exit code and the closed pipe race)
-  /// and throws that instead.
+  /// Runs [request]; if the server died meanwhile, throws its exit code and
+  /// stderr instead of `json_rpc_2`'s uninformative "client closed" error.
   Future<T> _guard<T>(Future<T> Function() request) async {
     try {
       return await request();

--- a/lib/src/lsp/lsp_client.dart
+++ b/lib/src/lsp/lsp_client.dart
@@ -12,6 +12,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:ciach/src/dart_executable.dart';
 import 'package:ciach/src/version.dart';
 import 'package:pro_lsp/pro_lsp.dart' as lsp;
 import 'package:stream_channel/stream_channel.dart';
@@ -28,10 +29,19 @@ const _analyzerStatusMethod = r'$/analyzerStatus';
 /// does not: spawning the server process, waiting for the Dart-specific
 /// `$/analyzerStatus` idle signal, and shutting the process down cleanly.
 class LspClient {
-  LspClient._(this._process, this._client);
+  LspClient._(this.dartExecutable, this._process, this._client);
+
+  /// The `dart` the server was launched with.
+  final String dartExecutable;
 
   final Process _process;
   final lsp.LspClient _client;
+
+  /// Completes when the server process exits, however it does.
+  final _exited = Completer<void>();
+
+  /// Why the server died, when it did so outside [dispose]; null otherwise.
+  StateError? _exitError;
 
   /// Completers waiting for the server to become idle.
   final _idleWaiters = <Completer<void>>[];
@@ -50,36 +60,50 @@ class LspClient {
 
   /// Spawns `<dart> language-server --protocol=lsp` and wires up the client.
   ///
-  /// [dartExecutable] defaults to the Dart VM currently running this tool, so
-  /// the analysis server always matches the SDK the user invoked us with.
+  /// [dartExecutable] defaults to [findDartExecutable]: the Dart VM running
+  /// this tool when there is one, so the server matches the SDK the user
+  /// invoked us with, else `dart` from `PATH`. Throws a
+  /// [DartSdkNotFoundException] when neither exists.
   static Future<LspClient> start({String? dartExecutable}) async {
-    final executable = dartExecutable ?? Platform.resolvedExecutable;
+    final executable = findDartExecutable(explicit: dartExecutable);
     final process = await Process.start(executable, [
       'language-server',
       '--protocol=lsp',
       '--client-id=ciach',
       '--client-version=$ciachVersion',
-    ]);
+    ], runInShell: executableNeedsShell(executable));
 
     final channel = StreamChannel<List<int>>(process.stdout, process.stdin);
     final client = lsp.LspClient.fromChannel(channel);
-    final wrapper = LspClient._(process, client);
+    final wrapper = LspClient._(executable, process, client);
 
-    process.stderr
+    final stderrDrained = process.stderr
         .transform(utf8.decoder)
-        .listen(wrapper._stderrBuffer.write, onError: (_) {});
-    unawaited(
-      process.exitCode.then((code) {
-        if (!wrapper._shuttingDown) {
-          wrapper._failIdleWaiters(
-            StateError(
-              'Language server exited unexpectedly (code $code).\n'
-              '${wrapper.stderr}',
-            ),
-          );
-        }
-      }),
-    );
+        .listen(wrapper._stderrBuffer.write, onError: (_) {})
+        .asFuture<void>()
+        .catchError((_) {});
+    // Writes to a dead server's stdin fail with a broken pipe. The exit report
+    // below is the account of that death; the pipe error has nothing to add
+    // and nobody awaits it.
+    unawaited(process.stdin.done.catchError((_) {}));
+    unawaited(() async {
+      final code = await process.exitCode;
+      // The exit code can land before the last of stderr does; the report
+      // should carry all of it.
+      await stderrDrained;
+      if (!wrapper._shuttingDown) {
+        final stderr = wrapper.stderr.trim();
+        final error = StateError(
+          'The Dart analysis server (`$executable language-server`) exited '
+          'unexpectedly with code $code.\n'
+          '${stderr.isEmpty ? 'It wrote nothing to stderr.' : 'Its stderr:\n$stderr'}',
+        );
+        wrapper
+          .._exitError = error
+          .._failIdleWaiters(error);
+      }
+      wrapper._exited.complete();
+    }());
 
     // Register before the handshake so no status notification is missed. The
     // Dart server only emits `$/analyzerStatus` after `initialized`, by which
@@ -95,27 +119,52 @@ class LspClient {
   /// Performs the `initialize` / `initialized` handshake for [rootUri].
   Future<void> initialize(Uri rootUri) async {
     final uri = rootUri.toString();
-    final result = await _client.start(
-      clientInfo: const .new(name: 'ciach', version: ciachVersion),
-      rootUri: uri,
-      workspaceFolders: [.new(uri: uri, name: 'root')],
-      // Hierarchical document symbols yield nested `DocumentSymbol[]` rather
-      // than flat `SymbolInformation`; semantic tokens make the server send its
-      // legend. `workDoneProgress` is left unset so progress arrives via
-      // `$/analyzerStatus`.
-      capabilities: const .new(
-        textDocument: .new(
-          documentSymbol: .new(hierarchicalDocumentSymbolSupport: true),
-          semanticTokens: .new(
-            requests: .new(full: .bool(true)),
-            tokenTypes: [],
-            tokenModifiers: [],
-            formats: [.relative],
+    final result = await _guard(
+      () => _client.start(
+        clientInfo: const .new(name: 'ciach', version: ciachVersion),
+        rootUri: uri,
+        workspaceFolders: [.new(uri: uri, name: 'root')],
+        // Hierarchical document symbols yield nested `DocumentSymbol[]` rather
+        // than flat `SymbolInformation`; semantic tokens make the server send its
+        // legend. `workDoneProgress` is left unset so progress arrives via
+        // `$/analyzerStatus`.
+        capabilities: const .new(
+          textDocument: .new(
+            documentSymbol: .new(hierarchicalDocumentSymbolSupport: true),
+            semanticTokens: .new(
+              requests: .new(full: .bool(true)),
+              tokenTypes: [],
+              tokenModifiers: [],
+              formats: [.relative],
+            ),
           ),
         ),
       ),
     );
     _semanticTokenTypes = _legendTokenTypes(result.capabilities);
+  }
+
+  /// Runs [request], swapping the opaque error a dead connection produces for
+  /// the server's exit code and stderr.
+  ///
+  /// When the server process dies, `json_rpc_2` fails every pending request
+  /// with `The client closed with pending request "<method>"`, which says
+  /// nothing about why. The exit handler in [start] records the real story;
+  /// this gives it a moment to arrive (the exit code and the closed pipe race)
+  /// and throws that instead.
+  Future<T> _guard<T>(Future<T> Function() request) async {
+    try {
+      return await request();
+    } on Object {
+      if (_shuttingDown) {
+        rethrow;
+      }
+      await _exited.future.timeout(const .new(seconds: 1)).catchError((_) {});
+      if (_exitError case final error?) {
+        throw error;
+      }
+      rethrow;
+    }
   }
 
   /// Reads the legend from raw capabilities JSON to avoid depending on the
@@ -188,8 +237,10 @@ class LspClient {
   /// Hierarchical support is advertised in [initialize], so this is always the
   /// `DocumentSymbol[]` variant (never flat `SymbolInformation`).
   Future<List<lsp.DocumentSymbol>> documentSymbol(Uri uri) async {
-    final result = await _client.server.textDocument.documentSymbol(
-      .new(textDocument: .new(uri: uri.toString())),
+    final result = await _guard(
+      () => _client.server.textDocument.documentSymbol(
+        .new(textDocument: .new(uri: uri.toString())),
+      ),
     );
     if (result.isNull) {
       return const [];
@@ -206,11 +257,13 @@ class LspClient {
     lsp.Position position, {
     bool includeDeclaration = false,
   }) async {
-    final result = await _client.server.textDocument.references(
-      .new(
-        textDocument: .new(uri: uri.toString()),
-        position: position,
-        context: .new(includeDeclaration: includeDeclaration),
+    final result = await _guard(
+      () => _client.server.textDocument.references(
+        .new(
+          textDocument: .new(uri: uri.toString()),
+          position: position,
+          context: .new(includeDeclaration: includeDeclaration),
+        ),
       ),
     );
     return result ?? const [];
@@ -219,10 +272,12 @@ class LspClient {
   /// Resolves the declaration(s) the symbol at [position] in [uri] points to,
   /// via `textDocument/definition` (forward resolution).
   Future<List<lsp.Location>> definition(Uri uri, lsp.Position position) async {
-    final result = await _client.server.textDocument.definition(
-      .new(
-        textDocument: .new(uri: uri.toString()),
-        position: position,
+    final result = await _guard(
+      () => _client.server.textDocument.definition(
+        .new(
+          textDocument: .new(uri: uri.toString()),
+          position: position,
+        ),
       ),
     );
     final definition = result.asDefinition;
@@ -232,8 +287,10 @@ class LspClient {
   /// The raw, delta-encoded `textDocument/semanticTokens/full` data for [uri],
   /// or empty when the server produces no tokens.
   Future<List<int>> semanticTokensFull(Uri uri) async {
-    final result = await _client.server.textDocument.semanticTokensFull(
-      .new(textDocument: .new(uri: uri.toString())),
+    final result = await _guard(
+      () => _client.server.textDocument.semanticTokensFull(
+        .new(textDocument: .new(uri: uri.toString())),
+      ),
     );
     return result?.data ?? const [];
   }

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -118,7 +118,8 @@ class FinderOptions {
   final int concurrency;
 
   /// Path to the `dart` executable used to launch the analysis server.
-  /// Defaults to the SDK currently running this tool.
+  /// Defaults to the SDK running this tool, or to `dart` from `PATH` when this
+  /// is a compiled binary; see `findDartExecutable`.
   final String? dartExecutable;
 
   /// Optional progress callback, invoked with a human-readable status line.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ environment:
 
 dependencies:
   args: ^2.7.0
+  cli_util: ^0.6.0
   collection: ^1.19.0
   config: ^0.9.0
   glob: ^2.1.3

--- a/test/compiled_binary_test.dart
+++ b/test/compiled_binary_test.dart
@@ -1,0 +1,68 @@
+@Timeout(Duration(minutes: 5))
+library;
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+/// `dart compile exe` / `dart build cli` / `dart install` produce a binary in
+/// which `Platform.resolvedExecutable` is ciach itself, not the SDK. Before
+/// #42 was fixed, such a binary spawned itself as the analysis server and
+/// failed every run with `The client closed with pending request "initialize"`.
+void main() {
+  final fixturePath = p.join(Directory.current.path, 'example');
+  final sdkBin = p.dirname(Platform.resolvedExecutable);
+  late Directory tmp;
+  late String binary;
+
+  setUpAll(() async {
+    final config = File(
+      p.join(fixturePath, '.dart_tool', 'package_config.json'),
+    );
+    if (!config.existsSync()) {
+      final result = await Process.run(Platform.resolvedExecutable, [
+        'pub',
+        'get',
+      ], workingDirectory: fixturePath);
+      expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
+    }
+
+    tmp = Directory.systemTemp.createTempSync('ciach_compiled_test');
+    binary = p.join(tmp.path, Platform.isWindows ? 'ciach.exe' : 'ciach');
+    final compile = await Process.run(Platform.resolvedExecutable, [
+      'compile',
+      'exe',
+      p.join('bin', 'ciach.dart'),
+      '-o',
+      binary,
+    ]);
+    expect(compile.exitCode, 0, reason: '${compile.stdout}\n${compile.stderr}');
+  });
+
+  tearDownAll(() => tmp.deleteSync(recursive: true));
+
+  Future<ProcessResult> run(Map<String, String> environment) => Process.run(
+    binary,
+    [fixturePath, '--no-progress', '--include', 'lib/orphans.dart'],
+    environment: environment,
+    includeParentEnvironment: false,
+  );
+
+  test('finds the SDK on PATH and analyzes', () async {
+    final result = await run({'PATH': sdkBin});
+    expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
+    expect(result.stdout, contains('UnusedClass'));
+  });
+
+  test(
+    'with no SDK on PATH, fails fast with a hint instead of hanging',
+    () async {
+      final result = await run({'PATH': tmp.path});
+      expect(result.exitCode, 2);
+      expect(result.stderr, contains('Could not find the Dart SDK'));
+      expect(result.stderr, contains('--dart'));
+      expect(result.stderr, isNot(contains('pending request')));
+    },
+  );
+}

--- a/test/compiled_binary_test.dart
+++ b/test/compiled_binary_test.dart
@@ -6,10 +6,8 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
-/// `dart compile exe` / `dart build cli` / `dart install` produce a binary in
-/// which `Platform.resolvedExecutable` is ciach itself, not the SDK. Before
-/// #42 was fixed, such a binary spawned itself as the analysis server and
-/// failed every run with `The client closed with pending request "initialize"`.
+/// In a compiled binary (`dart compile exe`, `dart install`) the resolved
+/// executable is ciach itself; it used to spawn itself as the server (#42).
 void main() {
   final fixturePath = p.join(Directory.current.path, 'example');
   final sdkBin = p.dirname(Platform.resolvedExecutable);
@@ -60,7 +58,7 @@ void main() {
     () async {
       final result = await run({'PATH': tmp.path});
       expect(result.exitCode, 2);
-      expect(result.stderr, contains('Could not find the Dart SDK'));
+      expect(result.stderr, contains('Could not find a Dart SDK'));
       expect(result.stderr, contains('--dart'));
       expect(result.stderr, isNot(contains('pending request')));
     },

--- a/test/dart_executable_test.dart
+++ b/test/dart_executable_test.dart
@@ -1,0 +1,139 @@
+import 'package:ciach/src/dart_executable.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // A resolver over a fake filesystem: only [files] exist.
+  String? find({
+    String? explicit,
+    required String currentExecutable,
+    Map<String, String> environment = const {},
+    bool isWindows = false,
+    Set<String> files = const {},
+  }) => findDartExecutable(
+    explicit: explicit,
+    currentExecutable: currentExecutable,
+    environment: environment,
+    isWindows: isWindows,
+    fileExists: files.contains,
+  );
+
+  group('findDartExecutable', () {
+    test('--dart wins over everything, and is not checked', () {
+      expect(
+        find(
+          explicit: '/custom/dart',
+          currentExecutable: '/sdk/bin/dart',
+          environment: const {'PATH': '/other/bin'},
+          files: const {'/other/bin/dart'},
+        ),
+        '/custom/dart',
+      );
+    });
+
+    test('running under the SDK VM: uses that VM, wherever the SDK is', () {
+      for (final vm in [
+        '/usr/lib/dart/bin/dart',
+        '/Users/me/fvm/versions/3.13.0/bin/dart',
+        '/opt/flutter/bin/cache/dart-sdk/bin/dart',
+        '/weird/place/dart',
+      ]) {
+        expect(
+          find(currentExecutable: vm, environment: const {'PATH': '/x'}),
+          vm,
+          reason: vm,
+        );
+      }
+    });
+
+    test('running under dart.exe on Windows, any casing', () {
+      expect(
+        find(
+          currentExecutable: r'C:\tools\Dart-SDK\bin\Dart.EXE',
+          isWindows: true,
+        ),
+        r'C:\tools\Dart-SDK\bin\Dart.EXE',
+      );
+    });
+
+    test('a compiled binary is not the SDK: falls back to PATH (#42)', () {
+      // `dart install` puts the AOT-compiled tool itself here, so spawning it
+      // as the server would run ciach recursively.
+      expect(
+        find(
+          currentExecutable: '/home/me/.local/state/Dart/install/bin/ciach',
+          environment: const {
+            'PATH': '/usr/local/bin:/home/me/fvm/default/bin',
+          },
+          files: const {'/home/me/fvm/default/bin/dart'},
+        ),
+        '/home/me/fvm/default/bin/dart',
+      );
+    });
+
+    test('PATH is searched in order, skipping empty entries', () {
+      expect(
+        find(
+          currentExecutable: '/app/ciach',
+          environment: const {'PATH': ':/first:/second'},
+          files: const {'dart', '/first/dart', '/second/dart'},
+        ),
+        '/first/dart',
+      );
+    });
+
+    test('Windows PATH: semicolons, Path key, exe before bat', () {
+      expect(
+        find(
+          currentExecutable: r'C:\Users\me\AppData\Local\Dart\ciach.exe',
+          isWindows: true,
+          environment: const {'Path': r'C:\flutter\bin;C:\dart-sdk\bin'},
+          files: const {
+            r'C:\flutter\bin\dart.bat',
+            r'C:\dart-sdk\bin\dart.exe',
+          },
+        ),
+        r'C:\flutter\bin\dart.bat',
+      );
+      expect(
+        find(
+          currentExecutable: r'C:\app\ciach.exe',
+          isWindows: true,
+          environment: const {'Path': r'C:\dart-sdk\bin'},
+          files: const {
+            r'C:\dart-sdk\bin\dart.exe',
+            r'C:\dart-sdk\bin\dart.bat',
+          },
+        ),
+        r'C:\dart-sdk\bin\dart.exe',
+      );
+    });
+
+    test('nothing found: an error naming the binary and the way out', () {
+      expect(
+        () => find(
+          currentExecutable: '/app/ciach',
+          environment: const {'PATH': '/usr/bin'},
+        ),
+        throwsA(
+          isA<DartSdkNotFoundException>().having(
+            (e) => e.message,
+            'message',
+            allOf(contains('/app/ciach'), contains('--dart'), contains('PATH')),
+          ),
+        ),
+      );
+      expect(
+        () => find(currentExecutable: '/app/ciach'),
+        throwsA(isA<DartSdkNotFoundException>()),
+        reason: 'no PATH at all',
+      );
+    });
+  });
+
+  test('executableNeedsShell: only Windows batch scripts', () {
+    expect(executableNeedsShell(r'C:\flutter\bin\dart.bat'), isTrue);
+    expect(executableNeedsShell(r'C:\x\dart.CMD'), isTrue);
+    expect(executableNeedsShell(r'C:\dart-sdk\bin\dart.exe'), isFalse);
+    expect(executableNeedsShell('/usr/bin/dart'), isFalse);
+  });
+}

--- a/test/dart_executable_test.dart
+++ b/test/dart_executable_test.dart
@@ -1,131 +1,56 @@
+import 'dart:async';
+import 'dart:io';
+
 import 'package:ciach/src/dart_executable.dart';
+import 'package:cli_util/cli_util.dart' show environmentOverridesKey;
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 void main() {
-  // A resolver over a fake filesystem: only [files] exist.
-  String? find({
-    String? explicit,
-    required String currentExecutable,
-    Map<String, String> environment = const {},
-    bool isWindows = false,
-    Set<String> files = const {},
-  }) => findDartExecutable(
-    explicit: explicit,
-    currentExecutable: currentExecutable,
-    environment: environment,
-    isWindows: isWindows,
-    fileExists: files.contains,
+  // Runs [body] as if this process were [executable] in [environment].
+  T asProcess<T>(
+    String executable,
+    Map<String, String> environment,
+    T Function() body,
+  ) => runZoned(
+    body,
+    zoneValues: {
+      environmentOverridesKey: {
+        ...environment,
+        '_DART_RESOLVED_EXECUTABLE': executable,
+      },
+    },
   );
 
+  final vm = Platform.resolvedExecutable;
+  final sdkBin = p.dirname(vm);
+
   group('findDartExecutable', () {
-    test('--dart wins over everything, and is not checked', () {
+    test('--dart wins, unchecked', () {
+      expect(findDartExecutable(explicit: '/custom/dart'), '/custom/dart');
+    });
+
+    test('under the SDK VM: that VM', () {
+      expect(asProcess(vm, {'PATH': ''}, findDartExecutable), vm);
+    });
+
+    test('a compiled binary is not the SDK: dart from PATH (#42)', () {
       expect(
-        find(
-          explicit: '/custom/dart',
-          currentExecutable: '/sdk/bin/dart',
-          environment: const {'PATH': '/other/bin'},
-          files: const {'/other/bin/dart'},
-        ),
-        '/custom/dart',
+        asProcess('/app/bin/ciach', {'PATH': sdkBin}, findDartExecutable),
+        p.join(sdkBin, Platform.isWindows ? 'dart.exe' : 'dart'),
       );
     });
 
-    test('running under the SDK VM: uses that VM, wherever the SDK is', () {
-      for (final vm in [
-        '/usr/lib/dart/bin/dart',
-        '/Users/me/fvm/versions/3.13.0/bin/dart',
-        '/opt/flutter/bin/cache/dart-sdk/bin/dart',
-        '/weird/place/dart',
-      ]) {
-        expect(
-          find(currentExecutable: vm, environment: const {'PATH': '/x'}),
-          vm,
-          reason: vm,
-        );
-      }
-    });
-
-    test('running under dart.exe on Windows, any casing', () {
+    test('nothing found: an error pointing at --dart', () {
       expect(
-        find(
-          currentExecutable: r'C:\tools\Dart-SDK\bin\Dart.EXE',
-          isWindows: true,
-        ),
-        r'C:\tools\Dart-SDK\bin\Dart.EXE',
-      );
-    });
-
-    test('a compiled binary is not the SDK: falls back to PATH (#42)', () {
-      // `dart install` puts the AOT-compiled tool itself here, so spawning it
-      // as the server would run ciach recursively.
-      expect(
-        find(
-          currentExecutable: '/home/me/.local/state/Dart/install/bin/ciach',
-          environment: const {
-            'PATH': '/usr/local/bin:/home/me/fvm/default/bin',
-          },
-          files: const {'/home/me/fvm/default/bin/dart'},
-        ),
-        '/home/me/fvm/default/bin/dart',
-      );
-    });
-
-    test('PATH is searched in order, skipping empty entries', () {
-      expect(
-        find(
-          currentExecutable: '/app/ciach',
-          environment: const {'PATH': ':/first:/second'},
-          files: const {'dart', '/first/dart', '/second/dart'},
-        ),
-        '/first/dart',
-      );
-    });
-
-    test('Windows PATH: semicolons, Path key, exe before bat', () {
-      expect(
-        find(
-          currentExecutable: r'C:\Users\me\AppData\Local\Dart\ciach.exe',
-          isWindows: true,
-          environment: const {'Path': r'C:\flutter\bin;C:\dart-sdk\bin'},
-          files: const {
-            r'C:\flutter\bin\dart.bat',
-            r'C:\dart-sdk\bin\dart.exe',
-          },
-        ),
-        r'C:\flutter\bin\dart.bat',
-      );
-      expect(
-        find(
-          currentExecutable: r'C:\app\ciach.exe',
-          isWindows: true,
-          environment: const {'Path': r'C:\dart-sdk\bin'},
-          files: const {
-            r'C:\dart-sdk\bin\dart.exe',
-            r'C:\dart-sdk\bin\dart.bat',
-          },
-        ),
-        r'C:\dart-sdk\bin\dart.exe',
-      );
-    });
-
-    test('nothing found: an error naming the binary and the way out', () {
-      expect(
-        () => find(
-          currentExecutable: '/app/ciach',
-          environment: const {'PATH': '/usr/bin'},
-        ),
+        () => asProcess('/app/bin/ciach', {'PATH': ''}, findDartExecutable),
         throwsA(
           isA<DartSdkNotFoundException>().having(
             (e) => e.message,
             'message',
-            allOf(contains('/app/ciach'), contains('--dart'), contains('PATH')),
+            allOf(contains('--dart'), contains('PATH')),
           ),
         ),
-      );
-      expect(
-        () => find(currentExecutable: '/app/ciach'),
-        throwsA(isA<DartSdkNotFoundException>()),
-        reason: 'no PATH at all',
       );
     });
   });

--- a/test/dart_executable_test.dart
+++ b/test/dart_executable_test.dart
@@ -1,49 +1,28 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:ciach/src/dart_executable.dart';
 import 'package:cli_util/cli_util.dart' show environmentOverridesKey;
-import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
+// The search itself is package:cli_util's; this covers only what ciach adds.
 void main() {
-  // Runs [body] as if this process were [executable] in [environment].
-  T asProcess<T>(
-    String executable,
-    Map<String, String> environment,
-    T Function() body,
-  ) => runZoned(
-    body,
-    zoneValues: {
-      environmentOverridesKey: {
-        ...environment,
-        '_DART_RESOLVED_EXECUTABLE': executable,
-      },
-    },
-  );
-
-  final vm = Platform.resolvedExecutable;
-  final sdkBin = p.dirname(vm);
-
   group('findDartExecutable', () {
     test('--dart wins, unchecked', () {
       expect(findDartExecutable(explicit: '/custom/dart'), '/custom/dart');
     });
 
-    test('under the SDK VM: that VM', () {
-      expect(asProcess(vm, {'PATH': ''}, findDartExecutable), vm);
-    });
-
-    test('a compiled binary is not the SDK: dart from PATH (#42)', () {
-      expect(
-        asProcess('/app/bin/ciach', {'PATH': sdkBin}, findDartExecutable),
-        p.join(sdkBin, Platform.isWindows ? 'dart.exe' : 'dart'),
-      );
-    });
-
     test('nothing found: an error pointing at --dart', () {
+      // A compiled binary with no `dart` anywhere on PATH.
       expect(
-        () => asProcess('/app/bin/ciach', {'PATH': ''}, findDartExecutable),
+        () => runZoned(
+          findDartExecutable,
+          zoneValues: {
+            environmentOverridesKey: {
+              'PATH': '',
+              '_DART_RESOLVED_EXECUTABLE': '/app/bin/ciach',
+            },
+          },
+        ),
         throwsA(
           isA<DartSdkNotFoundException>().having(
             (e) => e.message,

--- a/test/lsp_client_test.dart
+++ b/test/lsp_client_test.dart
@@ -16,8 +16,8 @@ void main() {
 
   tearDown(() => tmp.deleteSync(recursive: true));
 
-  // A stand-in `dart` that, asked to be a language server, complains and dies —
-  // what a compiled ciach spawned as its own server does (#42).
+  // A `dart` that complains and dies, like a compiled ciach spawned as its own
+  // server did (#42).
   String fakeDart(String stderrText, int exitCode) {
     final script = File(
       p.join(tmp.path, 'dart'),

--- a/test/lsp_client_test.dart
+++ b/test/lsp_client_test.dart
@@ -1,0 +1,72 @@
+@TestOn('!windows')
+library;
+
+import 'dart:io';
+
+import 'package:ciach/src/lsp/lsp_client.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  late Directory tmp;
+
+  setUp(() {
+    tmp = Directory.systemTemp.createTempSync('ciach_lsp_test');
+  });
+
+  tearDown(() => tmp.deleteSync(recursive: true));
+
+  // A stand-in `dart` that, asked to be a language server, complains and dies —
+  // what a compiled ciach spawned as its own server does (#42).
+  String fakeDart(String stderrText, int exitCode) {
+    final script = File(
+      p.join(tmp.path, 'dart'),
+    )..writeAsStringSync('#!/bin/sh\necho "$stderrText" >&2\nexit $exitCode\n');
+    Process.runSync('chmod', ['+x', script.path]);
+    return script.path;
+  }
+
+  test(
+    'a server that dies during initialize reports its exit and stderr',
+    () async {
+      final client = await LspClient.start(
+        dartExecutable: fakeDart(
+          'Could not find an option named --protocol.',
+          2,
+        ),
+      );
+      addTearDown(client.dispose);
+
+      await expectLater(
+        client.initialize(tmp.uri),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            allOf(
+              contains('exited unexpectedly with code 2'),
+              contains('Could not find an option named --protocol.'),
+              contains(client.dartExecutable),
+            ),
+          ),
+        ),
+      );
+    },
+  );
+
+  test('a silent death says so instead of showing empty stderr', () async {
+    final client = await LspClient.start(dartExecutable: fakeDart('', 1));
+    addTearDown(client.dispose);
+
+    await expectLater(
+      client.initialize(tmp.uri),
+      throwsA(
+        isA<StateError>().having(
+          (e) => e.message,
+          'message',
+          allOf(contains('code 1'), contains('wrote nothing to stderr')),
+        ),
+      ),
+    );
+  });
+}


### PR DESCRIPTION
## Summary

When ciach is compiled as a binary (via `dart compile exe` or `dart install`), `Platform.resolvedExecutable` points to ciach itself rather than the Dart SDK. This caused the compiled binary to spawn itself as the analysis server, leading to hangs and failures. This PR fixes that by properly detecting and using the correct `dart` executable.

## Key Changes

- **New `dart_executable.dart` module**: Introduces `findDartExecutable()` which intelligently selects the right `dart` executable:
  - Uses explicit `--dart` flag if provided
  - Falls back to `package:cli_util.dartExecutable` (the SDK running ciach, or `dart` from PATH for compiled binaries)
  - Throws `DartSdkNotFoundException` with helpful guidance if no SDK is found
  - Includes `executableNeedsShell()` helper for Windows batch script detection

- **Enhanced `LspClient`**: 
  - Now tracks the `dartExecutable` used to launch the server
  - Improved error handling when the server dies unexpectedly via new `_guard()` wrapper method
  - Better error messages that include the actual `dart` command and stderr output
  - Properly waits for stderr to drain before reporting exit errors

- **Updated CLI integration**:
  - `bin/ciach.dart` now resolves the dart executable upfront and fails fast with helpful messaging if not found
  - `ResolvedOptions.finderOptions()` accepts optional `dartExecutable` parameter to override the configured value

- **Comprehensive test coverage**:
  - `lsp_client_test.dart`: Tests server death during initialization with proper error reporting
  - `dart_executable_test.dart`: Tests SDK detection logic and shell requirements
  - `compiled_binary_test.dart`: Integration test verifying compiled binaries work correctly with PATH-based SDK discovery

- **Documentation**: Updated README to document the new `dart install` installation method and `--dart` option behavior

## Notable Implementation Details

- The `_guard()` method wraps LSP requests to catch and report server exit errors instead of generic "client closed" messages
- Stderr is properly drained asynchronously before reporting exit codes to avoid losing error output
- Windows batch scripts (like Flutter's `dart.bat`) are detected and run with shell=true
- Error messages are user-friendly and suggest solutions (e.g., "Pass --dart <path>, set `dart:` in ciach.yaml, or add the SDK's bin directory to PATH")

https://claude.ai/code/session_01Q2PysdUS25yoDEH332He6o