### PR TITLE
Prepare v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.4
+
+- Fix a compiled `ciach` (`dart install`) spawning itself as the analysis
+  server and failing every run. ([#44](https://github.com/leancodepl/ciach/pull/44))
+- Show the analysis server's exit code and stderr when it dies.
+
 ## 0.4.3
 
 - Add `--version`, and show the version in the `--help` header. The analysis

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -9,4 +9,4 @@
  */
 
 /// The published version of ciach. Keep in sync with `pubspec.yaml`.
-const ciachVersion = '0.4.3';
+const ciachVersion = '0.4.4';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Finds unused (never-referenced) declarations in a Dart/Flutter package by
   driving the Dart analysis server over LSP and querying textDocument/references.
 # Keep in sync with `ciachVersion` in lib/src/version.dart.
-version: 0.4.3
+version: 0.4.4
 repository: https://github.com/leancodepl/ciach
 homepage: https://github.com/leancodepl/ciach
 issue_tracker: https://github.com/leancodepl/ciach/issues


### PR DESCRIPTION
Bumps the package to 0.4.4 and adds the changelog entry for the `dart install` fix.

Branched from https://github.com/leancodepl/ciach/pull/44, so until that merges the diff here shows its commits too; merge it first and this PR reduces to the version bump alone.

Changed: `CHANGELOG.md`, `pubspec.yaml`, `lib/src/version.dart` (kept in sync by `test/version_test.dart`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2PysdUS25yoDEH332He6o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2PysdUS25yoDEH332He6o)_