### PR TITLE
website: a pub.dev button in the hero, and the first ciach

### DIFF
--- a/website/lib/components/footer.dart
+++ b/website/lib/components/footer.dart
@@ -93,7 +93,7 @@ class SiteFooter extends StatelessComponent {
         [
           div(classes: 'container cta-inner', [
             const h2(id: 'cta-heading', [
-              .text('Ready to make the first cut?'),
+              .text('Ready to make the first ciach?'),
             ]),
             div(classes: 'hero-actions center', [
               Button(href: pubUrl, external: true, [

--- a/website/lib/components/hero.dart
+++ b/website/lib/components/hero.dart
@@ -168,9 +168,13 @@ class Hero extends StatelessComponent {
             ]),
             div(classes: 'install', [installCommandBox()]),
             div(classes: 'hero-actions', [
-              Button(href: '/docs', [
+              Button(href: pubUrl, external: true, [
+                const .text('Get it on pub.dev'),
+                Icon.external.build(size: 18),
+              ]),
+              Button(href: '/docs', variant: .secondary, [
+                Icon.book.build(size: 18),
                 const .text('Read the docs'),
-                Icon.arrow.build(size: 18),
               ]),
               Button(href: repoUrl, variant: .secondary, external: true, [
                 Icon.github.build(size: 18),


### PR DESCRIPTION
## Summary

Two suggestions from the `#dev-mobile` thread about the landing page.

- **A prominent pub.dev button.** The version pill and the header link were the only ways to pub.dev from the hero, and both are easy to miss. The hero actions now lead with "Get it on pub.dev" as the primary button, followed by "Read the docs" and "GitHub" as secondary ones. This mirrors the footer call to action, so both button rows read the same. At phone width the three buttons wrap with pub.dev alone on the first row.
- **"Ready to make the first ciach?"** The closing call to action asks about the first ciach instead of the first cut.

## Verification

- `dart analyze --fatal-infos`, `dart format`, `jaspr build` and `dart test` pass in `website/`; the root `dart analyze` and `dart format --set-exit-if-changed .` pass.
- Screenshots of the built site at 1280 and 375px confirm the button layout. The social card does not include the hero actions, so the golden is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VcpaLyVB3CBkMXd4CPxr79

---
_Generated by [Claude Code](https://claude.ai/code/session_01VcpaLyVB3CBkMXd4CPxr79)_