### PR TITLE
Report dead extensions whole and delete emptied files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,14 @@
   elsewhere. `removeDeclarations` now returns a `RemovalResult` with the deleted
   files instead of a bare count.
   ([#48](https://github.com/leancodepl/ciach/issues/48))
+- Report a dead `extension type` — one nothing names — as the whole
+  declaration and remove it, instead of stripping its members and leaving the
+  shell. It is classified like a class, so references from its own body no
+  longer keep it alive.
+  ([#48](https://github.com/leancodepl/ciach/issues/48))
 - `-k extension` now selects extensions; it matched a kind the analysis server
-  never emits.
+  never emits. Add `-k extension-type` for extension types, which share that
+  kind on the wire.
 
 ## 0.4.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## Unreleased
+
+- Report an extension whose every member is dead as the whole `extension`, the
+  way a fully dead class is reported, and remove it as one — instead of leaving
+  an empty `extension E on T {}` behind. One a `show`/`hide` names stays.
+  Extension members are now reported as `Extension.member`.
+  ([#48](https://github.com/leancodepl/ciach/issues/48))
+- `--remove` deletes a file it leaves with nothing but directives (`library`,
+  `import`s, `part of`) and drops the `import`/`export`/`part` lines naming it
+  elsewhere. `removeDeclarations` now returns a `RemovalResult` with the deleted
+  files instead of a bare count.
+  ([#48](https://github.com/leancodepl/ciach/issues/48))
+- `-k extension` now selects extensions; it matched a kind the analysis server
+  never emits.
+
 ## 0.4.4
 
 - Fix a compiled `ciach` (`dart install`) spawning itself as the analysis

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ ciach --verbose                        # explain each step
 | `-e, --exclude <glob>` | — | Skip files matching the glob (repeatable). |
 | `-i, --include <glob>` | — | Only scan files matching the glob (repeatable). |
 | `--generated-suffix <suffix>` | — | Extra filename suffix (with leading dot) to treat as generated and skip, on top of the built-in set; repeatable. Ignored when `--generated` is set. |
-| `-k, --kinds <list>` | all | Restrict to kinds: `class, mixin, interface, enum, extension, function, method, constructor, field, property, getter, setter, variable, constant, enum-value`. |
+| `-k, --kinds <list>` | all | Restrict to kinds: `class, mixin, interface, enum, extension, extension-type, function, method, constructor, field, property, getter, setter, variable, constant, enum-value`. |
 | `-f, --format <fmt>` | `text` | `text`, `json`, or `github` (GitHub Actions `::warning` annotations). |
 | `-j, --concurrency <n>` | `16` | Reference queries kept in flight against the analysis server. |
 | `--[no-]color` | auto | Colorize text output. |
@@ -222,6 +222,9 @@ Nothing is left behind as an empty shell, either:
   member is dead is reported and removed as the whole `extension`, the way a
   fully dead class is. One a `show`/`hide` combinator names stays, and only its
   members are reported.
+- An `extension type` is a *type*, named like a class, so it is dead when
+  nothing names it — references from its own body don't count — and is then
+  reported and removed whole. `-k extension-type` selects these on their own.
 - A file the removal leaves with nothing but directives — a `library` line,
   `import`s, a `part of` — is deleted, and the `import`/`export`/`part` lines
   naming it elsewhere are dropped; a barrel or a part's owner that is left

--- a/README.md
+++ b/README.md
@@ -216,6 +216,23 @@ false-positive risk, which `--overrides` and `--operators` widen considerably.
 [Doc-only findings](#doc-only-findings) are never included. Review the diff, as
 you would after any automated refactor.
 
+Nothing is left behind as an empty shell, either:
+
+- An extension is used through its members, never by name, so one whose every
+  member is dead is reported and removed as the whole `extension`, the way a
+  fully dead class is. One a `show`/`hide` combinator names stays, and only its
+  members are reported.
+- A file the removal leaves with nothing but directives — a `library` line,
+  `import`s, a `part of` — is deleted, and the `import`/`export`/`part` lines
+  naming it elsewhere are dropped; a barrel or a part's owner that is left
+  with nothing by that goes too. A file that still `export`s or owns a `part`,
+  one named in a conditional import, and one that had no declarations to begin
+  with are all left alone.
+
+```
+Removed 4 unused declarations from 2 files. Deleted 1 file left with nothing but imports: lib/legacy.dart.
+```
+
 Findings whose removal wouldn't compile are **report-only**: marked `unsafe to
 auto-remove — remove manually` and skipped, along with anything coupled to them.
 

--- a/bin/ciach.dart
+++ b/bin/ciach.dart
@@ -254,13 +254,25 @@ Future<void> _removeUnused(
     }
   }
 
-  final filesChanged = removeDeclarations(result.unused, rootPath);
+  final removal = removeDeclarations(result.unused, rootPath);
+  final filesChanged = removal.filesChanged;
   final left = blocked > 0
       ? ' $blocked left in place — unsafe to auto-remove.'
       : '';
+  final deleted = removal.deletedFiles;
+  final emptied = deleted.isEmpty
+      ? ''
+      : " Deleted ${deleted.length} file${deleted.length == 1 ? '' : 's'} left with nothing but imports: ${deleted.map((d) => d.filePath).join(', ')}.";
   stdout.writeln(
-    "Removed $count unused declaration$plural from $filesChanged file${filesChanged == 1 ? '' : 's'}.$left Run 'dart format' to tidy up spacing.",
+    "Removed $count unused declaration$plural from $filesChanged file${filesChanged == 1 ? '' : 's'}.$left$emptied Run 'dart format' to tidy up spacing.",
   );
+  for (final file in deleted) {
+    log?.write(
+      file.unlinkedFrom.isEmpty
+          ? 'Deleted ${file.filePath}: nothing left but directives.'
+          : 'Deleted ${file.filePath}: nothing left but directives. Dropped the directives naming it from ${file.unlinkedFrom.join(', ')}.',
+    );
+  }
   // Repeat any advisory hints: removing a declaration takes the reported line
   // that carried its hint with it.
   final removedHints = result.unused

--- a/example/README.md
+++ b/example/README.md
@@ -35,7 +35,7 @@ expected; each is scanned only by its own test, never by the demo run above.
 | `comment_annotations.dart` | a comment mentioning `@override` or `vm:entry-point` does not skip the declaration below it |
 | `dot_shorthands.dart`, `dot_shorthand_uses.dart` | every context a `.name` dot shorthand is allowed in, including nested constructor shorthands |
 | `primary_constructors.dart` | primary constructors: a dead declaration in the class header is report-only, while the class body stays removable |
-| `extensions_emptied.dart`, `extensions_emptied_uses.dart` | an extension whose every member is dead is reported (and removed) as the whole extension, unless a `show` names it |
+| `extensions_emptied.dart`, `extensions_emptied_uses.dart` | an extension whose every member is dead is reported (and removed) as the whole extension, unless a `show` names it; an extension type is dead when nothing names it |
 | `xref_*.dart` | the cross-library reference recovery, and telling same-named members apart |
 
 Run the finder against the demo tier from the repository root:

--- a/example/README.md
+++ b/example/README.md
@@ -35,6 +35,7 @@ expected; each is scanned only by its own test, never by the demo run above.
 | `comment_annotations.dart` | a comment mentioning `@override` or `vm:entry-point` does not skip the declaration below it |
 | `dot_shorthands.dart`, `dot_shorthand_uses.dart` | every context a `.name` dot shorthand is allowed in, including nested constructor shorthands |
 | `primary_constructors.dart` | primary constructors: a dead declaration in the class header is report-only, while the class body stays removable |
+| `extensions_emptied.dart`, `extensions_emptied_uses.dart` | an extension whose every member is dead is reported (and removed) as the whole extension, unless a `show` names it |
 | `xref_*.dart` | the cross-library reference recovery, and telling same-named members apart |
 
 Run the finder against the demo tier from the repository root:
@@ -47,7 +48,7 @@ Expected output:
 
 ```text
 lib/extensions.dart
-  13:7  method  tripled  (public)
+  13:7  method  IntExtras.tripled  (public)
 
 lib/greeting.dart
   15:6  function  danglingFunction  (public)
@@ -95,7 +96,9 @@ Things worth noticing:
 - Declarations that *are* referenced (e.g. `UsedClass`, `registerHandlers`,
   `Direction.north`, the mixin `Loud`) are not reported, no matter which file
   references them from.
-- Constructors are reported as `Class.named` or `Class.new`.
+- Constructors are reported as `Class.named` or `Class.new`; extension members
+  as `Extension.member`. `IntExtras` itself is not reported: an extension is
+  used through its members, and `doubled` is called.
 - `FullyDeadClass` is reported as the whole class, not as its constructor:
   removing the class takes the constructor with it.
 - `_docOnlyMentioned` is reached only by a `[link]` in another declaration's doc

--- a/example/lib/scenarios/extensions_emptied.dart
+++ b/example/lib/scenarios/extensions_emptied.dart
@@ -1,0 +1,50 @@
+// Fixture for dead extensions: an extension is used only through its members,
+// never by name, so one whose every member is dead is dead itself and is
+// reported (and removed) whole rather than left behind as an empty
+// `extension E on T {}` once its members go. Scanned only by its own test
+// (excluded from the default-run assertions); see test/finder_test.dart.
+//
+// extensions_emptied_uses.dart imports this file with a `show`, which is the
+// one way to refer to an extension by name.
+
+/// Never referenced by name, and neither member is called -> UNUSED, reported
+/// as the whole EXTENSION; `first` and `second` are not findings of their own.
+extension DeadHelpers on int {
+  int first() => this + 1;
+  int second() => this + 2;
+}
+
+/// `alive` is called from extensions_emptied_uses.dart, so the extension is
+/// USED even though nothing names `LiveHelpers` -> not reported. Its dead
+/// member is reported on its own, like any method.
+extension LiveHelpers on int {
+  int alive() => this * 2;
+
+  /// Never referenced -> UNUSED (method).
+  int stale() => this * 3;
+}
+
+/// Nothing can refer to an unnamed extension by name; both members are dead ->
+/// UNUSED, reported as the whole EXTENSION.
+extension on String {
+  String shoutedOnce() => '$this!';
+  String shoutedTwice() => '$this!!';
+}
+
+/// Every member is dead, but extensions_emptied_uses.dart names the extension
+/// in a `show` combinator -> the extension stays (dropping it would break the
+/// import); only the member is reported.
+extension ShownHelpers on int {
+  /// Never referenced -> UNUSED (method).
+  int shownButUnused() => this - 1;
+}
+
+/// No members and no references -> UNUSED (extension).
+extension Hollow on int {}
+
+/// Referenced as a type below, so used; an `extension type` is a type, not an
+/// extension, and is never a candidate -> not reported.
+extension type Meters(int value) {}
+
+/// Keeps [Meters] alive.
+Meters toMeters(int value) => Meters(value);

--- a/example/lib/scenarios/extensions_emptied.dart
+++ b/example/lib/scenarios/extensions_emptied.dart
@@ -1,5 +1,7 @@
-// Dead extensions: one is dead only once every member is, and is then reported
-// whole. Scanned with extensions_emptied_uses.dart by its own test.
+// Dead extensions and extension types. An extension is dead only once every
+// member is; an extension type is a type, dead when nothing names it. Either
+// is then reported whole. Scanned with extensions_emptied_uses.dart by its own
+// test.
 
 /// Nothing names it or calls a member -> UNUSED (extension).
 extension DeadHelpers on int {
@@ -28,7 +30,18 @@ extension ShownHelpers on int {
 /// No members, no references -> UNUSED (extension).
 extension Hollow on int {}
 
-/// An `extension type` is never a candidate.
+/// Nothing names it -> UNUSED (extension type), reported whole like a dead
+/// class, with its dead members alongside it.
+extension type DeadMeters(int value) {
+  int get scaled => value * 2;
+}
+
+/// Only its own body names it -> UNUSED (extension type).
+extension type SelfMeters(int value) {
+  SelfMeters get next => SelfMeters(value + 1);
+}
+
+/// Named as a type by [toMeters] -> USED.
 extension type Meters(int value) {}
 
 Meters toMeters(int value) => Meters(value);

--- a/example/lib/scenarios/extensions_emptied.dart
+++ b/example/lib/scenarios/extensions_emptied.dart
@@ -1,50 +1,34 @@
-// Fixture for dead extensions: an extension is used only through its members,
-// never by name, so one whose every member is dead is dead itself and is
-// reported (and removed) whole rather than left behind as an empty
-// `extension E on T {}` once its members go. Scanned only by its own test
-// (excluded from the default-run assertions); see test/finder_test.dart.
-//
-// extensions_emptied_uses.dart imports this file with a `show`, which is the
-// one way to refer to an extension by name.
+// Dead extensions: one is dead only once every member is, and is then reported
+// whole. Scanned with extensions_emptied_uses.dart by its own test.
 
-/// Never referenced by name, and neither member is called -> UNUSED, reported
-/// as the whole EXTENSION; `first` and `second` are not findings of their own.
+/// Nothing names it or calls a member -> UNUSED (extension).
 extension DeadHelpers on int {
   int first() => this + 1;
   int second() => this + 2;
 }
 
-/// `alive` is called from extensions_emptied_uses.dart, so the extension is
-/// USED even though nothing names `LiveHelpers` -> not reported. Its dead
-/// member is reported on its own, like any method.
+/// `alive` is called -> USED; only `stale` is reported.
 extension LiveHelpers on int {
   int alive() => this * 2;
 
-  /// Never referenced -> UNUSED (method).
   int stale() => this * 3;
 }
 
-/// Nothing can refer to an unnamed extension by name; both members are dead ->
-/// UNUSED, reported as the whole EXTENSION.
+/// Both members dead -> UNUSED (extension), under the server's placeholder name.
 extension on String {
   String shoutedOnce() => '$this!';
   String shoutedTwice() => '$this!!';
 }
 
-/// Every member is dead, but extensions_emptied_uses.dart names the extension
-/// in a `show` combinator -> the extension stays (dropping it would break the
-/// import); only the member is reported.
+/// Named in a `show` -> the extension stays; only the member is reported.
 extension ShownHelpers on int {
-  /// Never referenced -> UNUSED (method).
   int shownButUnused() => this - 1;
 }
 
-/// No members and no references -> UNUSED (extension).
+/// No members, no references -> UNUSED (extension).
 extension Hollow on int {}
 
-/// Referenced as a type below, so used; an `extension type` is a type, not an
-/// extension, and is never a candidate -> not reported.
+/// An `extension type` is never a candidate.
 extension type Meters(int value) {}
 
-/// Keeps [Meters] alive.
 Meters toMeters(int value) => Meters(value);

--- a/example/lib/scenarios/extensions_emptied_uses.dart
+++ b/example/lib/scenarios/extensions_emptied_uses.dart
@@ -1,0 +1,12 @@
+// The uses side of extensions_emptied.dart: calls one member of `LiveHelpers`
+// (keeping that extension alive through its member, not its name) and names
+// `ShownHelpers` in a `show` (keeping the extension, but not its member).
+
+// ignore_for_file: unused_shown_name, the `show` is the point
+
+import 'package:sample_pkg/scenarios/extensions_emptied.dart'
+    show LiveHelpers, ShownHelpers, toMeters;
+
+/// Reached from nothing in the scan -> UNUSED (function); it exists to hold the
+/// references above.
+int useEmptiedExtensions() => 21.alive() + toMeters(1).value;

--- a/example/lib/scenarios/extensions_emptied_uses.dart
+++ b/example/lib/scenarios/extensions_emptied_uses.dart
@@ -1,12 +1,9 @@
-// The uses side of extensions_emptied.dart: calls one member of `LiveHelpers`
-// (keeping that extension alive through its member, not its name) and names
-// `ShownHelpers` in a `show` (keeping the extension, but not its member).
-
-// ignore_for_file: unused_shown_name, the `show` is the point
+// Keeps `LiveHelpers` alive through a member and `ShownHelpers` through the
+// `show`, which is the point of the unused shown name.
+// ignore_for_file: unused_shown_name
 
 import 'package:sample_pkg/scenarios/extensions_emptied.dart'
     show LiveHelpers, ShownHelpers, toMeters;
 
-/// Reached from nothing in the scan -> UNUSED (function); it exists to hold the
-/// references above.
+/// Reached from nothing -> UNUSED (function).
 int useEmptiedExtensions() => 21.alive() + toMeters(1).value;

--- a/lib/ciach.dart
+++ b/lib/ciach.dart
@@ -34,9 +34,11 @@ export 'src/models.dart'
     show
         CoupledRemoval,
         DeclarationRange,
+        DeletedFile,
         FinderOptions,
         FinderResult,
         RecoveredReference,
+        RemovalResult,
         SymbolKindLabel,
         UnusedDeclaration;
 export 'src/remover.dart' show removeDeclarations;

--- a/lib/src/candidates.dart
+++ b/lib/src/candidates.dart
@@ -63,15 +63,12 @@ final class Candidate {
   final bool isEnumValue;
   final bool isPreventInstantiationCtor;
 
-  /// Whether this is an `extension on T { … }` with no name. Nothing can refer
-  /// to one by name, so it gets no reference query: its liveness is exactly
-  /// its members'.
+  /// `extension on T { … }`: nothing can name it, so it gets no reference
+  /// query.
   final bool isUnnamedExtension;
 
-  /// Whether this is an `extension` declaration (named or not).
   bool get isExtension => symbol.kind == .namespace;
 
-  /// Whether this is a member of an `extension`.
   bool get isExtensionMember => containerSymbol?.kind == .namespace;
 
   /// This candidate's own `(path, name)` key.

--- a/lib/src/candidates.dart
+++ b/lib/src/candidates.dart
@@ -49,6 +49,7 @@ final class Candidate {
     required this.isEnumValue,
     required this.isPreventInstantiationCtor,
     this.containerSymbol,
+    this.isUnnamedExtension = false,
   });
 
   final Uri uri;
@@ -61,6 +62,17 @@ final class Candidate {
   final DocumentSymbol? containerSymbol;
   final bool isEnumValue;
   final bool isPreventInstantiationCtor;
+
+  /// Whether this is an `extension on T { … }` with no name. Nothing can refer
+  /// to one by name, so it gets no reference query: its liveness is exactly
+  /// its members'.
+  final bool isUnnamedExtension;
+
+  /// Whether this is an `extension` declaration (named or not).
+  bool get isExtension => symbol.kind == .namespace;
+
+  /// Whether this is a member of an `extension`.
+  bool get isExtensionMember => containerSymbol?.kind == .namespace;
 
   /// This candidate's own `(path, name)` key.
   DeclKey get key => DeclKey(path, symbol.name);

--- a/lib/src/candidates.dart
+++ b/lib/src/candidates.dart
@@ -50,6 +50,7 @@ final class Candidate {
     required this.isPreventInstantiationCtor,
     this.containerSymbol,
     this.isUnnamedExtension = false,
+    this.isExtensionType = false,
   });
 
   final Uri uri;
@@ -67,7 +68,11 @@ final class Candidate {
   /// query.
   final bool isUnnamedExtension;
 
-  bool get isExtension => symbol.kind == .namespace;
+  /// `extension type Name(…)`: a type, used by name like a class, not an
+  /// extension used through its members.
+  final bool isExtensionType;
+
+  bool get isExtension => symbol.kind == .namespace && !isExtensionType;
 
   bool get isExtensionMember => containerSymbol?.kind == .namespace;
 

--- a/lib/src/cli/args.dart
+++ b/lib/src/cli/args.dart
@@ -20,7 +20,7 @@ const kindAliases = <String, SymbolKind>{
   'mixin': .interface$,
   'interface': .interface$,
   'enum': .enum$,
-  'extension': .struct,
+  'extension': .namespace,
   'function': .function,
   'method': .method,
   'constructor': .constructor,

--- a/lib/src/cli/args.dart
+++ b/lib/src/cli/args.dart
@@ -21,6 +21,7 @@ const kindAliases = <String, SymbolKind>{
   'interface': .interface$,
   'enum': .enum$,
   'extension': .namespace,
+  'extension-type': .struct,
   'function': .function,
   'method': .method,
   'constructor': .constructor,

--- a/lib/src/emptied_files.dart
+++ b/lib/src/emptied_files.dart
@@ -7,24 +7,10 @@ import 'package:ciach/src/paths.dart';
 import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 
-/// Deletes the files among [rewritten] (absolute paths `--remove` has just
-/// rewritten) that were left with nothing but directives — a `library` line,
-/// `import`s, a `part of` — and drops the `import`/`export`/`part` directives
-/// that pointed at them from the rest of the package under [rootPath], so
-/// nothing is left naming a file that no longer exists.
-///
-/// Only a file the removal itself emptied is a candidate — by taking its last
-/// declaration, or the last `export`/`part` it had left to hand on; one that
-/// had nothing to begin with is left alone. Conservative in the usual way — a
-/// file that still `export`s or owns `part`s hands something on and stays; a
-/// file named in a conditional import (`import 'a.dart' if (dart.library.io)
-/// 'b.dart'`) stays, since rewriting that directive is more than dropping it;
-/// and a `package:` URI whose package no pubspec under the root claims is taken
-/// to mean this file (kept) rather than a foreign one (ignored) whenever the
-/// paths line up.
-///
-/// Returns the deleted files, root-relative, with the files they were unlinked
-/// from.
+/// Deletes the [rewritten] files (absolute paths) left with nothing but
+/// `library`/`import`/`part of` directives, dropping the `import`/`export`/
+/// `part` lines naming them elsewhere under [rootPath]. A file that still
+/// `export`s or owns `part`s, or is named in a conditional import, stays.
 List<DeletedFile> deleteEmptiedFiles(Set<String> rewritten, String rootPath) {
   if (rewritten.isEmpty) {
     return const [];
@@ -34,9 +20,7 @@ List<DeletedFile> deleteEmptiedFiles(Set<String> rewritten, String rootPath) {
   final pending = rewritten.map(p.normalize).toSet();
   final deleted = <DeletedFile>[];
 
-  // Dropping the `part 'x.dart';` of a deleted part file, or the one `export`
-  // of a barrel, can leave that file with nothing but directives too, so go
-  // round until nothing more falls.
+  // Dropping a `part`/`export` line can empty that file in turn.
   var progressed = true;
   while (progressed) {
     progressed = false;
@@ -51,7 +35,6 @@ List<DeletedFile> deleteEmptiedFiles(Set<String> rewritten, String rootPath) {
       }
       final links = package.linksTo(path);
       if (links == null) {
-        // Something still needs the file in a way dropping a line won't fix.
         pending.remove(path);
         continue;
       }
@@ -74,9 +57,6 @@ List<DeletedFile> deleteEmptiedFiles(Set<String> rewritten, String rootPath) {
   return deleted;
 }
 
-/// One `library`, `import` or `part of` statement, possibly several, and
-/// nothing else — the shape of a file with no declarations left. Comments are
-/// blanked before matching, so a file of nothing but comments is empty too.
 final _directiveOnly = RegExp(
   r'''^(?:\s*(?:library\b[^;]*|import\s+r?['"][^;]*|part\s+of\b[^;]*);)*\s*$''',
 );
@@ -84,9 +64,7 @@ final _directiveOnly = RegExp(
 bool _isDirectiveOnly(String content) =>
     _directiveOnly.hasMatch(stripComments(content));
 
-/// A directive statement at the start of a line, through its `;`. Only the
-/// three that can name another file matter here, and only with a URI string
-/// (a `part of lib.name;` names no file).
+/// A directive with a URI string, through its `;`.
 final _directive = RegExp(
   r'''^[ \t]*(import|export|part)\s+((?:of\s+)?r?['"][^;]*);''',
   multiLine: true,
@@ -96,15 +74,11 @@ final _uriLiteral = RegExp(r'''r?(['"])([^'"\n]*)\1''');
 final _partOf = RegExp(r'^\s*of\b');
 final _conditional = RegExp(r'\bif\s*\(');
 
-/// A `[start, end)` span within a file's content.
 typedef _Span = ({int start, int end});
 
-/// How a directive relates to a file: not at all, by naming it in a way that
-/// can simply be dropped, or by naming it in a way that cannot.
 enum _Link { none, droppable, blocking }
 
-/// The Dart files and pubspecs under the root, with their contents cached and
-/// kept current across the rewrites made here.
+/// The package's Dart files, with contents cached across the rewrites here.
 final class _Package {
   _Package._(this._files, this._libDirByPackage);
 
@@ -150,9 +124,8 @@ final class _Package {
     return _contents[path] = read;
   }
 
-  /// The directives in the other files that name [target], as spans to drop
-  /// per file — or `null` when any of them names it in a way that can't be
-  /// dropped, so [target] must stay.
+  /// Spans to drop per file, or `null` when a directive naming [target] can't
+  /// be dropped.
   Map<String, List<_Span>>? linksTo(String target) {
     final spans = <String, List<_Span>>{};
     for (final path in _files) {
@@ -199,19 +172,13 @@ final class _Package {
     if (link == .none) {
       return link;
     }
-    // A conditional import would need rewriting, not dropping; a `part of`
-    // naming the file makes it a library that owns parts, which stays.
     final partOf = kind == 'part' && _partOf.hasMatch(body);
     return partOf || _conditional.hasMatch(body) ? .blocking : link;
   }
 
-  /// Marker for a `package:` URI whose package no pubspec under the root
-  /// claims — foreign, or this package without a readable pubspec.
+  /// A `package:` URI no pubspec under the root claims.
   static const _uncertain = '';
 
-  /// The absolute path [uri] names from the file at [from]: `null` for a
-  /// `dart:` or otherwise unresolvable URI, [_uncertain] for an unknown
-  /// package.
   String? _resolve(String uri, String from) {
     if (uri.startsWith('package:')) {
       final rest = uri.substring('package:'.length);
@@ -233,8 +200,7 @@ final class _Package {
     return p.normalize(p.joinAll([p.dirname(from), ...p.posix.split(uri)]));
   }
 
-  /// Whether the lib-relative path of a `package:` [uri] is where [target]
-  /// sits under some `lib/` — the one way an unknown package could be this one.
+  /// Whether an unknown package's [uri] could still mean [target].
   static bool _libPathMatches(String uri, String target) {
     final slash = uri.indexOf('/');
     if (slash < 0) {
@@ -244,8 +210,6 @@ final class _Package {
     return p.posix.joinAll(p.split(target)).endsWith('/lib/$libRelative');
   }
 
-  /// Removes [spans] (in the file's current content) from the file at [path],
-  /// each with the rest of its line when nothing else is on it.
   void dropSpans(String path, List<_Span> spans) {
     final source = content(path);
     if (source == null) {
@@ -282,8 +246,6 @@ String? _pubspecName(String pubspecPath) {
   }
 }
 
-/// If nothing but whitespace follows [end] on its line, the offset past the
-/// line break — so dropping a directive doesn't leave a blank line behind.
 int _consumeTrailingBlankLine(String content, int end) {
   final nextNewline = content.indexOf('\n', end);
   final restOfLine = content.substring(

--- a/lib/src/emptied_files.dart
+++ b/lib/src/emptied_files.dart
@@ -1,0 +1,297 @@
+import 'dart:io';
+
+import 'package:ciach/src/file_discovery.dart';
+import 'package:ciach/src/lexing.dart';
+import 'package:ciach/src/models.dart';
+import 'package:ciach/src/paths.dart';
+import 'package:collection/collection.dart';
+import 'package:path/path.dart' as p;
+
+/// Deletes the files among [rewritten] (absolute paths `--remove` has just
+/// rewritten) that were left with nothing but directives — a `library` line,
+/// `import`s, a `part of` — and drops the `import`/`export`/`part` directives
+/// that pointed at them from the rest of the package under [rootPath], so
+/// nothing is left naming a file that no longer exists.
+///
+/// Only a file the removal itself emptied is a candidate — by taking its last
+/// declaration, or the last `export`/`part` it had left to hand on; one that
+/// had nothing to begin with is left alone. Conservative in the usual way — a
+/// file that still `export`s or owns `part`s hands something on and stays; a
+/// file named in a conditional import (`import 'a.dart' if (dart.library.io)
+/// 'b.dart'`) stays, since rewriting that directive is more than dropping it;
+/// and a `package:` URI whose package no pubspec under the root claims is taken
+/// to mean this file (kept) rather than a foreign one (ignored) whenever the
+/// paths line up.
+///
+/// Returns the deleted files, root-relative, with the files they were unlinked
+/// from.
+List<DeletedFile> deleteEmptiedFiles(Set<String> rewritten, String rootPath) {
+  if (rewritten.isEmpty) {
+    return const [];
+  }
+  final root = p.normalize(p.absolute(rootPath));
+  final package = _Package.scan(root);
+  final pending = rewritten.map(p.normalize).toSet();
+  final deleted = <DeletedFile>[];
+
+  // Dropping the `part 'x.dart';` of a deleted part file, or the one `export`
+  // of a barrel, can leave that file with nothing but directives too, so go
+  // round until nothing more falls.
+  var progressed = true;
+  while (progressed) {
+    progressed = false;
+    for (final path in pending.sorted()) {
+      final content = package.content(path);
+      if (content == null) {
+        pending.remove(path);
+        continue;
+      }
+      if (!_isDirectiveOnly(content)) {
+        continue;
+      }
+      final links = package.linksTo(path);
+      if (links == null) {
+        // Something still needs the file in a way dropping a line won't fix.
+        pending.remove(path);
+        continue;
+      }
+      for (final MapEntry(key: importer, value: spans) in links.entries) {
+        package.dropSpans(importer, spans);
+        pending.add(importer);
+      }
+      package.delete(path);
+      pending.remove(path);
+      deleted.add((
+        filePath: relativePosix(path, root),
+        unlinkedFrom: [
+          for (final importer in links.keys.sorted())
+            relativePosix(importer, root),
+        ],
+      ));
+      progressed = true;
+    }
+  }
+  return deleted;
+}
+
+/// One `library`, `import` or `part of` statement, possibly several, and
+/// nothing else — the shape of a file with no declarations left. Comments are
+/// blanked before matching, so a file of nothing but comments is empty too.
+final _directiveOnly = RegExp(
+  r'''^(?:\s*(?:library\b[^;]*|import\s+r?['"][^;]*|part\s+of\b[^;]*);)*\s*$''',
+);
+
+bool _isDirectiveOnly(String content) =>
+    _directiveOnly.hasMatch(stripComments(content));
+
+/// A directive statement at the start of a line, through its `;`. Only the
+/// three that can name another file matter here, and only with a URI string
+/// (a `part of lib.name;` names no file).
+final _directive = RegExp(
+  r'''^[ \t]*(import|export|part)\s+((?:of\s+)?r?['"][^;]*);''',
+  multiLine: true,
+);
+
+final _uriLiteral = RegExp(r'''r?(['"])([^'"\n]*)\1''');
+final _partOf = RegExp(r'^\s*of\b');
+final _conditional = RegExp(r'\bif\s*\(');
+
+/// A `[start, end)` span within a file's content.
+typedef _Span = ({int start, int end});
+
+/// How a directive relates to a file: not at all, by naming it in a way that
+/// can simply be dropped, or by naming it in a way that cannot.
+enum _Link { none, droppable, blocking }
+
+/// The Dart files and pubspecs under the root, with their contents cached and
+/// kept current across the rewrites made here.
+final class _Package {
+  _Package._(this._files, this._libDirByPackage);
+
+  factory _Package.scan(String root) {
+    final files = <String>{};
+    final libDirByPackage = <String, String>{};
+    for (final entity in Directory(
+      root,
+    ).listSync(recursive: true, followLinks: false)) {
+      if (entity is! File) {
+        continue;
+      }
+      final absolute = p.normalize(entity.absolute.path);
+      if (isInSkippedDir(relativePosix(absolute, root))) {
+        continue;
+      }
+      final name = p.basename(absolute);
+      if (name.endsWith('.dart')) {
+        files.add(absolute);
+      } else if (name == 'pubspec.yaml') {
+        if (_pubspecName(absolute) case final package?) {
+          libDirByPackage[package] = p.join(p.dirname(absolute), 'lib');
+        }
+      }
+    }
+    return _Package._(files, libDirByPackage);
+  }
+
+  final Set<String> _files;
+  final Map<String, String> _libDirByPackage;
+  final _contents = <String, String?>{};
+
+  String? content(String path) {
+    if (_contents.containsKey(path)) {
+      return _contents[path];
+    }
+    String? read;
+    try {
+      read = File(path).readAsStringSync();
+    } on Object {
+      read = null;
+    }
+    return _contents[path] = read;
+  }
+
+  /// The directives in the other files that name [target], as spans to drop
+  /// per file — or `null` when any of them names it in a way that can't be
+  /// dropped, so [target] must stay.
+  Map<String, List<_Span>>? linksTo(String target) {
+    final spans = <String, List<_Span>>{};
+    for (final path in _files) {
+      if (path == target) {
+        continue;
+      }
+      final source = content(path);
+      if (source == null) {
+        continue;
+      }
+      for (final match in _directive.allMatches(stripComments(source))) {
+        switch (_link(match, path, target)) {
+          case .none:
+            break;
+          case .blocking:
+            return null;
+          case .droppable:
+            spans.putIfAbsent(path, () => []).add((
+              start: match.start,
+              end: match.end,
+            ));
+        }
+      }
+    }
+    return spans;
+  }
+
+  _Link _link(RegExpMatch directive, String from, String target) {
+    final kind = directive.group(1)!;
+    final body = directive.group(2)!;
+    var link = _Link.none;
+    for (final uri in _uriLiteral.allMatches(body)) {
+      final resolved = _resolve(uri.group(2)!, from);
+      if (resolved == null) {
+        continue;
+      }
+      if (resolved == target) {
+        link = .droppable;
+      } else if (resolved == _uncertain &&
+          _libPathMatches(uri.group(2)!, target)) {
+        return .blocking;
+      }
+    }
+    if (link == .none) {
+      return link;
+    }
+    // A conditional import would need rewriting, not dropping; a `part of`
+    // naming the file makes it a library that owns parts, which stays.
+    final partOf = kind == 'part' && _partOf.hasMatch(body);
+    return partOf || _conditional.hasMatch(body) ? .blocking : link;
+  }
+
+  /// Marker for a `package:` URI whose package no pubspec under the root
+  /// claims — foreign, or this package without a readable pubspec.
+  static const _uncertain = '';
+
+  /// The absolute path [uri] names from the file at [from]: `null` for a
+  /// `dart:` or otherwise unresolvable URI, [_uncertain] for an unknown
+  /// package.
+  String? _resolve(String uri, String from) {
+    if (uri.startsWith('package:')) {
+      final rest = uri.substring('package:'.length);
+      final slash = rest.indexOf('/');
+      if (slash < 0) {
+        return null;
+      }
+      final libDir = _libDirByPackage[rest.substring(0, slash)];
+      if (libDir == null) {
+        return _uncertain;
+      }
+      return p.normalize(
+        p.joinAll([libDir, ...p.posix.split(rest.substring(slash + 1))]),
+      );
+    }
+    if (uri.contains(':')) {
+      return null;
+    }
+    return p.normalize(p.joinAll([p.dirname(from), ...p.posix.split(uri)]));
+  }
+
+  /// Whether the lib-relative path of a `package:` [uri] is where [target]
+  /// sits under some `lib/` — the one way an unknown package could be this one.
+  static bool _libPathMatches(String uri, String target) {
+    final slash = uri.indexOf('/');
+    if (slash < 0) {
+      return false;
+    }
+    final libRelative = uri.substring(slash + 1);
+    return p.posix.joinAll(p.split(target)).endsWith('/lib/$libRelative');
+  }
+
+  /// Removes [spans] (in the file's current content) from the file at [path],
+  /// each with the rest of its line when nothing else is on it.
+  void dropSpans(String path, List<_Span> spans) {
+    final source = content(path);
+    if (source == null) {
+      return;
+    }
+    final buffer = StringBuffer();
+    var cursor = 0;
+    for (final span in spans.sortedBy<num>((s) => s.start)) {
+      buffer.write(source.substring(cursor, span.start));
+      cursor = _consumeTrailingBlankLine(source, span.end);
+    }
+    buffer.write(source.substring(cursor));
+    final updated = buffer.toString();
+    File(path).writeAsStringSync(updated);
+    _contents[path] = updated;
+  }
+
+  void delete(String path) {
+    File(path).deleteSync();
+    _files.remove(path);
+    _contents[path] = null;
+  }
+}
+
+final _pubspecNameLine = RegExp(r'^name:\s*([A-Za-z0-9_]+)', multiLine: true);
+
+String? _pubspecName(String pubspecPath) {
+  try {
+    return _pubspecNameLine
+        .firstMatch(File(pubspecPath).readAsStringSync())
+        ?.group(1);
+  } on Object {
+    return null;
+  }
+}
+
+/// If nothing but whitespace follows [end] on its line, the offset past the
+/// line break — so dropping a directive doesn't leave a blank line behind.
+int _consumeTrailingBlankLine(String content, int end) {
+  final nextNewline = content.indexOf('\n', end);
+  final restOfLine = content.substring(
+    end,
+    nextNewline == -1 ? content.length : nextNewline,
+  );
+  if (restOfLine.trim().isNotEmpty) {
+    return end;
+  }
+  return nextNewline == -1 ? content.length : nextNewline + 1;
+}

--- a/lib/src/file_discovery.dart
+++ b/lib/src/file_discovery.dart
@@ -108,8 +108,6 @@ DiscoveredDartFiles discoverDartFilesSplit(FinderOptions options) {
   return (candidates: candidates, warmOnly: warmOnly);
 }
 
-/// Whether the root-relative [relativePath] lies under a directory that never
-/// holds source worth touching (`build/`, `.dart_tool/`, …).
 bool isInSkippedDir(String relativePath) =>
     p.split(relativePath).any(_skippedDirs.contains);
 

--- a/lib/src/file_discovery.dart
+++ b/lib/src/file_discovery.dart
@@ -84,7 +84,7 @@ DiscoveredDartFiles discoverDartFilesSplit(FinderOptions options) {
       p.split(p.relative(absolute, from: rootPath)),
     );
 
-    if (_isInSkippedDir(relative)) {
+    if (isInSkippedDir(relative)) {
       continue;
     }
     if (!options.includeGenerated &&
@@ -108,7 +108,9 @@ DiscoveredDartFiles discoverDartFilesSplit(FinderOptions options) {
   return (candidates: candidates, warmOnly: warmOnly);
 }
 
-bool _isInSkippedDir(String relativePath) =>
+/// Whether the root-relative [relativePath] lies under a directory that never
+/// holds source worth touching (`build/`, `.dart_tool/`, …).
+bool isInSkippedDir(String relativePath) =>
     p.split(relativePath).any(_skippedDirs.contains);
 
 bool _isGenerated(

--- a/lib/src/finder.dart
+++ b/lib/src/finder.dart
@@ -536,6 +536,7 @@ class Ciach {
               symbols,
             ),
             isUnnamedExtension: extensionShape == .unnamed,
+            isExtensionType: extensionShape == .extensionType,
           ),
         );
       }
@@ -560,7 +561,10 @@ class Ciach {
     ExtensionShape? extensionShape,
   ) {
     if (!options.kinds.contains(
-      symbol.reportedKind(parentIsEnum: parentIsEnum),
+      symbol.reportedKind(
+        parentIsEnum: parentIsEnum,
+        isExtensionType: extensionShape == .extensionType,
+      ),
     )) {
       return false;
     }
@@ -568,9 +572,8 @@ class Ciach {
     if (symbol.kind == .function && symbol.name == 'main') {
       return false;
     }
-    // An `extension type` is never a candidate.
-    if (symbol.kind == .namespace &&
-        (extensionShape == null || extensionShape == .extensionType)) {
+    // A `namespace` whose shape the lexer can't confirm.
+    if (symbol.kind == .namespace && extensionShape == null) {
       return false;
     }
     if (!isPrivateName(symbol.name) && !options.includePublic) {
@@ -619,7 +622,10 @@ class Ciach {
         : candidate.container;
     return .new(
       name: name,
-      kind: symbol.reportedKind(parentIsEnum: candidate.isEnumValue),
+      kind: symbol.reportedKind(
+        parentIsEnum: candidate.isEnumValue,
+        isExtensionType: candidate.isExtensionType,
+      ),
       filePath: relativePosix(candidate.path, rootPath),
       // LSP positions are zero-based; report them one-based for humans.
       line: start.line + 1,

--- a/lib/src/finder.dart
+++ b/lib/src/finder.dart
@@ -265,7 +265,9 @@ class Ciach {
     final warnings = <RecoveredReference>[];
     for (var i = 0; i < candidates.length; i++) {
       final candidate = candidates[i];
-      if (refsByCandidate[i].isNotEmpty || candidate.symbol.kind == .class$) {
+      if (refsByCandidate[i].isNotEmpty ||
+          candidate.symbol.kind == .class$ ||
+          candidate.isExtension) {
         continue;
       }
       final usage = crossLib.recoveredUsage(candidate);
@@ -312,10 +314,14 @@ class Ciach {
     var filesDone = totalFiles - remainingPerFile.length;
 
     return mapPooled(candidates, options.concurrency, (candidate) async {
-      final refs = await client.references(
-        candidate.uri,
-        candidate.symbol.selectionRange.start,
-      );
+      // An unnamed extension has no name to refer to it by — the server would
+      // answer for the `on` type instead — so it reads as unreferenced.
+      final refs = candidate.isUnnamedExtension
+          ? const <Location>[]
+          : await client.references(
+              candidate.uri,
+              candidate.symbol.selectionRange.start,
+            );
       if (remainingPerFile.update(candidate.path, (n) => n - 1) == 0) {
         filesDone++;
         _report(
@@ -337,7 +343,8 @@ class Ciach {
     final emptyRefNames = <String>{
       for (var i = 0; i < candidates.length; i++)
         if (refsByCandidate[i].isEmpty &&
-            candidates[i].symbol.kind != .class$) ...[
+            candidates[i].symbol.kind != .class$ &&
+            !candidates[i].isExtension) ...[
           _simpleName(candidates[i].symbol.name),
           // An unnamed constructor is spelled by the class name at an
           // ordinary `Foo(…)` site but as `new` at a dot-shorthand one
@@ -382,8 +389,9 @@ class Ciach {
 
   /// Whether an unused [candidate] should be silently suppressed (never
   /// reported): a live freezed-union arm, an exempt `toJson` hook, a
-  /// constructor removed with its already-dead class, or an enum value reached
-  /// only through `.values` iteration.
+  /// constructor removed with its already-dead class, a member removed with
+  /// its dead extension (or an extension kept alive by a live member), or an
+  /// enum value reached only through `.values` iteration.
   bool _isSuppressed(
     Candidate candidate,
     int index,
@@ -400,9 +408,23 @@ class Ciach {
     if (_isRemovedWithDeadClass(candidate, deadClassNames)) {
       return true;
     }
+    // An extension is used through its members, never by name, so one with a
+    // live member stays even when nothing refers to the extension itself.
+    if (candidate.isExtension &&
+        !safety.deadExtensions.contains(candidate.key)) {
+      return true;
+    }
     final containerKey = candidate.containerKey;
+    if (containerKey == null) {
+      return false;
+    }
+    // A dead extension is removed whole, its members with it — like a dead
+    // class's constructors, they are not findings of their own.
+    if (candidate.isExtensionMember &&
+        safety.deadExtensions.contains(containerKey)) {
+      return true;
+    }
     return candidate.isEnumValue &&
-        containerKey != null &&
         safety.enumValuesIterated.contains(containerKey);
   }
 
@@ -494,7 +516,17 @@ class Ciach {
   ) {
     for (final symbol in symbols) {
       _freezed.noteIfAnnotated(path, symbol, strippedLines);
-      if (_shouldConsider(symbol, parentIsEnum, strippedLines)) {
+      // The server files an `extension type` under the same kind as an
+      // `extension`; only the latter is a candidate (see [_shouldConsider]).
+      final extensionShape = symbol.kind == .namespace
+          ? _sources.extensionShape(path, symbol)
+          : null;
+      if (_shouldConsider(
+        symbol,
+        parentIsEnum,
+        strippedLines,
+        extensionShape,
+      )) {
         out.add(
           Candidate(
             uri: uri,
@@ -509,6 +541,7 @@ class Ciach {
             isPreventInstantiationCtor: symbol.isPreventInstantiationMarker(
               symbols,
             ),
+            isUnnamedExtension: extensionShape == .unnamed,
           ),
         );
       }
@@ -530,6 +563,7 @@ class Ciach {
     DocumentSymbol symbol,
     bool parentIsEnum,
     List<String> strippedLines,
+    ExtensionShape? extensionShape,
   ) {
     if (!options.kinds.contains(
       symbol.reportedKind(parentIsEnum: parentIsEnum),
@@ -538,6 +572,13 @@ class Ciach {
     }
     // The program entry point is never "unused".
     if (symbol.kind == .function && symbol.name == 'main') {
+      return false;
+    }
+    // An `extension type` is a type, used by name like a class, and is not
+    // checked at all today; an `extension` is dead only once every member is
+    // (see [RemoveSafety.deadExtensions]).
+    if (symbol.kind == .namespace &&
+        (extensionShape == null || extensionShape == .extensionType)) {
       return false;
     }
     if (!isPrivateName(symbol.name) && !options.includePublic) {
@@ -575,8 +616,17 @@ class Ciach {
     String? hint,
   }) {
     final symbol = candidate.symbol;
-    final start = symbol.selectionRange.start;
+    // An unnamed extension's selection range is its `on` type; point at the
+    // declaration instead.
+    final start = candidate.isUnnamedExtension
+        ? symbol.range.start
+        : symbol.selectionRange.start;
     final name = symbol.declarationName(candidate.container);
+    // An unnamed extension's members are keyed under the server's placeholder
+    // for it (`extension on T`), which is no name to qualify them by.
+    final container = _isInUnnamedExtension(candidate)
+        ? null
+        : candidate.container;
     return .new(
       name: name,
       kind: symbol.reportedKind(parentIsEnum: candidate.isEnumValue),
@@ -585,7 +635,7 @@ class Ciach {
       line: start.line + 1,
       column: start.character + 1,
       isPrivate: isPrivateName(name),
-      container: candidate.container,
+      container: container,
       isEnumValue: candidate.isEnumValue,
       range: symbol.declarationRange,
       coupledRemovals: coupledRemovals,
@@ -593,6 +643,11 @@ class Ciach {
       hint: hint,
     );
   }
+
+  bool _isInUnnamedExtension(Candidate candidate) =>
+      candidate.isExtensionMember &&
+      _sources.extensionShape(candidate.path, candidate.containerSymbol!) ==
+          .unnamed;
 
   /// Whether [candidate] goes with an already-dead class's own declaration —
   /// any constructor, or a declaring parameter — so a single removal is not

--- a/lib/src/finder.dart
+++ b/lib/src/finder.dart
@@ -314,8 +314,7 @@ class Ciach {
     var filesDone = totalFiles - remainingPerFile.length;
 
     return mapPooled(candidates, options.concurrency, (candidate) async {
-      // An unnamed extension has no name to refer to it by — the server would
-      // answer for the `on` type instead — so it reads as unreferenced.
+      // The server would answer for an unnamed extension's `on` type.
       final refs = candidate.isUnnamedExtension
           ? const <Location>[]
           : await client.references(
@@ -389,9 +388,9 @@ class Ciach {
 
   /// Whether an unused [candidate] should be silently suppressed (never
   /// reported): a live freezed-union arm, an exempt `toJson` hook, a
-  /// constructor removed with its already-dead class, a member removed with
-  /// its dead extension (or an extension kept alive by a live member), or an
-  /// enum value reached only through `.values` iteration.
+  /// constructor removed with its already-dead class, an extension or its
+  /// members (see [RemoveSafety.deadExtensions]), or an enum value reached
+  /// only through `.values` iteration.
   bool _isSuppressed(
     Candidate candidate,
     int index,
@@ -408,8 +407,7 @@ class Ciach {
     if (_isRemovedWithDeadClass(candidate, deadClassNames)) {
       return true;
     }
-    // An extension is used through its members, never by name, so one with a
-    // live member stays even when nothing refers to the extension itself.
+    // Used through its members, never by name.
     if (candidate.isExtension &&
         !safety.deadExtensions.contains(candidate.key)) {
       return true;
@@ -418,8 +416,6 @@ class Ciach {
     if (containerKey == null) {
       return false;
     }
-    // A dead extension is removed whole, its members with it — like a dead
-    // class's constructors, they are not findings of their own.
     if (candidate.isExtensionMember &&
         safety.deadExtensions.contains(containerKey)) {
       return true;
@@ -516,8 +512,6 @@ class Ciach {
   ) {
     for (final symbol in symbols) {
       _freezed.noteIfAnnotated(path, symbol, strippedLines);
-      // The server files an `extension type` under the same kind as an
-      // `extension`; only the latter is a candidate (see [_shouldConsider]).
       final extensionShape = symbol.kind == .namespace
           ? _sources.extensionShape(path, symbol)
           : null;
@@ -574,9 +568,7 @@ class Ciach {
     if (symbol.kind == .function && symbol.name == 'main') {
       return false;
     }
-    // An `extension type` is a type, used by name like a class, and is not
-    // checked at all today; an `extension` is dead only once every member is
-    // (see [RemoveSafety.deadExtensions]).
+    // An `extension type` is never a candidate.
     if (symbol.kind == .namespace &&
         (extensionShape == null || extensionShape == .extensionType)) {
       return false;
@@ -616,14 +608,12 @@ class Ciach {
     String? hint,
   }) {
     final symbol = candidate.symbol;
-    // An unnamed extension's selection range is its `on` type; point at the
-    // declaration instead.
+    // An unnamed extension's selection range is its `on` type.
     final start = candidate.isUnnamedExtension
         ? symbol.range.start
         : symbol.selectionRange.start;
     final name = symbol.declarationName(candidate.container);
-    // An unnamed extension's members are keyed under the server's placeholder
-    // for it (`extension on T`), which is no name to qualify them by.
+    // `extension on T` is no name to qualify members by.
     final container = _isInUnnamedExtension(candidate)
         ? null
         : candidate.container;

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -129,7 +129,9 @@ class FinderOptions {
   /// [SymbolKind.typeParameter] (always "used" within its scope) and the
   /// primitive value kinds the server never emits for Dart declarations.
   ///
-  /// [SymbolKind.namespace] is how the server reports an `extension`.
+  /// [SymbolKind.namespace] is how the server reports an `extension`; an
+  /// `extension type` shares that kind and is remapped to [SymbolKind.struct]
+  /// (see `reportedKind`), which the server never emits itself.
   ///
   /// Operator overloads are *not* a separate kind here: the analysis server
   /// reports them as plain [SymbolKind.method] declarations named `+`, `==`,
@@ -139,6 +141,7 @@ class FinderOptions {
     .interface$,
     .enum$,
     .namespace,
+    .struct,
     .function,
     .method,
     .constructor,
@@ -158,6 +161,7 @@ extension SymbolKindLabel on SymbolKind {
     .enum$ => 'enum',
     .interface$ => 'interface',
     .namespace => 'extension',
+    .struct => 'extension type',
     .operator$ => 'operator',
     .null$ => 'null',
     .enumMember => 'enum value',

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -129,6 +129,9 @@ class FinderOptions {
   /// [SymbolKind.typeParameter] (always "used" within its scope) and the
   /// primitive value kinds the server never emits for Dart declarations.
   ///
+  /// [SymbolKind.namespace] is how the analysis server reports an `extension`
+  /// (and an `extension type`, which is never a candidate — see the finder).
+  ///
   /// Operator overloads are *not* a separate kind here: the analysis server
   /// reports them as plain [SymbolKind.method] declarations named `+`, `==`,
   /// etc. — see [skipOperators] for how they're excluded by default instead.
@@ -136,7 +139,7 @@ class FinderOptions {
     .class$,
     .interface$,
     .enum$,
-    .struct,
+    .namespace,
     .function,
     .method,
     .constructor,
@@ -155,6 +158,7 @@ extension SymbolKindLabel on SymbolKind {
     .class$ => 'class',
     .enum$ => 'enum',
     .interface$ => 'interface',
+    .namespace => 'extension',
     .operator$ => 'operator',
     .null$ => 'null',
     .enumMember => 'enum value',
@@ -260,6 +264,29 @@ class UnusedDeclaration {
     'container': ?container,
     'hint': ?hint,
   };
+}
+
+/// A file `--remove` deleted because nothing but directives — a `library`
+/// line, `import`s, a `part of` — was left in it once its declarations went.
+typedef DeletedFile = ({
+  /// Path to the deleted file, relative to the analyzed root, using `/`
+  /// separators.
+  String filePath,
+
+  /// The files (same form) whose `import`/`export`/`part` of it were dropped
+  /// so nothing names a file that no longer exists.
+  List<String> unlinkedFrom,
+});
+
+/// What a `removeDeclarations` run did to the package.
+class RemovalResult {
+  const RemovalResult({required this.filesChanged, required this.deletedFiles});
+
+  /// The files declarations were removed from, deleted ones included.
+  final int filesChanged;
+
+  /// The files deleted for having nothing but directives left, in path order.
+  final List<DeletedFile> deletedFiles;
 }
 
 /// A declaration that had no reported references but was confirmed used by the

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -129,8 +129,7 @@ class FinderOptions {
   /// [SymbolKind.typeParameter] (always "used" within its scope) and the
   /// primitive value kinds the server never emits for Dart declarations.
   ///
-  /// [SymbolKind.namespace] is how the analysis server reports an `extension`
-  /// (and an `extension type`, which is never a candidate — see the finder).
+  /// [SymbolKind.namespace] is how the server reports an `extension`.
   ///
   /// Operator overloads are *not* a separate kind here: the analysis server
   /// reports them as plain [SymbolKind.method] declarations named `+`, `==`,
@@ -266,26 +265,18 @@ class UnusedDeclaration {
   };
 }
 
-/// A file `--remove` deleted because nothing but directives — a `library`
-/// line, `import`s, a `part of` — was left in it once its declarations went.
-typedef DeletedFile = ({
-  /// Path to the deleted file, relative to the analyzed root, using `/`
-  /// separators.
-  String filePath,
+/// A file `--remove` deleted for having nothing but directives left, and the
+/// files whose `import`/`export`/`part` of it were dropped. Root-relative
+/// `/`-paths.
+typedef DeletedFile = ({String filePath, List<String> unlinkedFrom});
 
-  /// The files (same form) whose `import`/`export`/`part` of it were dropped
-  /// so nothing names a file that no longer exists.
-  List<String> unlinkedFrom,
-});
-
-/// What a `removeDeclarations` run did to the package.
+/// What `removeDeclarations` did.
 class RemovalResult {
   const RemovalResult({required this.filesChanged, required this.deletedFiles});
 
-  /// The files declarations were removed from, deleted ones included.
+  /// Files declarations were removed from, deleted ones included.
   final int filesChanged;
 
-  /// The files deleted for having nothing but directives left, in path order.
   final List<DeletedFile> deletedFiles;
 }
 

--- a/lib/src/reference_classifier.dart
+++ b/lib/src/reference_classifier.dart
@@ -47,7 +47,9 @@ class ReferenceClassifier {
     List<Location> refs,
     CrossLibraryReferences crossLib,
   ) {
-    if (candidate.symbol.kind == .class$) {
+    // An extension type is a type, named like a class, so it gets the class
+    // rule: references from its own body don't keep it alive.
+    if (candidate.symbol.kind == .class$ || candidate.isExtensionType) {
       return _classifyClass(candidate, refs);
     }
     if (refs.isEmpty) {

--- a/lib/src/remove_safety.dart
+++ b/lib/src/remove_safety.dart
@@ -25,11 +25,17 @@ import 'package:pro_lsp/pro_lsp.dart' show Location;
 /// * [enumValuesIterated] — enums whose values are all reachable through
 ///   `.values` iteration, so a value reached only that way is used, not dead,
 ///   and is suppressed entirely rather than reported.
+/// * [deadExtensions] — extensions nothing refers to by name and every member
+///   of which is dead. An extension is used only through its members, so this
+///   is what "unused extension" means; it is reported and removed whole, like
+///   a dead class, rather than left as an empty `extension E on T {}` shell
+///   once its members go.
 class RemoveSafety {
   const RemoveSafety({
     required this.emptiedEnums,
     required this.blockedCtorClasses,
     required this.enumValuesIterated,
+    required this.deadExtensions,
   });
 
   factory RemoveSafety.analyze(
@@ -47,12 +53,35 @@ class RemoveSafety {
     final ctorDead = <DeclKey, int>{};
     final ctorForwardsSuper = <DeclKey, bool>{};
     final classByKey = <DeclKey, Candidate>{};
+    final extensionUnreferenced = <DeclKey, bool>{};
+    final extensionMemberTotal = <DeclKey, int>{};
+    final extensionMemberDead = <DeclKey, int>{};
 
     for (var i = 0; i < candidates.length; i++) {
       final candidate = candidates[i];
       final symbol = candidate.symbol;
       final unused = statuses[i] == .unused;
-      if (symbol.kind == .enum$ && !candidate.isEnumValue) {
+      if (candidate.isExtensionMember && unused) {
+        if (candidate.containerKey case final key?) {
+          extensionMemberDead.update(key, (n) => n + 1, ifAbsent: () => 1);
+        }
+      }
+      if (candidate.isExtension) {
+        // Two unnamed extensions on one type in a file share a key; their
+        // tallies merge, which can only keep both, never drop a live one.
+        extensionUnreferenced.update(
+          candidate.key,
+          (was) => was && unused,
+          ifAbsent: () => unused,
+        );
+        // Every member counts, candidate or not: one excluded by `--kinds` or
+        // `--no-public` is unaccounted for, and keeps the extension.
+        extensionMemberTotal.update(
+          candidate.key,
+          (n) => n + (symbol.children?.length ?? 0),
+          ifAbsent: () => symbol.children?.length ?? 0,
+        );
+      } else if (symbol.kind == .enum$ && !candidate.isEnumValue) {
         enumTypeHasRef[candidate.key] = refsByCandidate[i].isNotEmpty;
         if (refsByCandidate[i].any(sources.isDotValuesRef) ||
             sources.enumIteratesOwnValues(candidate)) {
@@ -113,14 +142,24 @@ class RemoveSafety {
       }
     }
 
+    final deadExtensions = <DeclKey>{
+      for (final MapEntry(:key, value: unreferenced)
+          in extensionUnreferenced.entries)
+        if (unreferenced &&
+            (extensionMemberDead[key] ?? 0) == extensionMemberTotal[key])
+          key,
+    };
+
     return RemoveSafety(
       emptiedEnums: emptiedEnums,
       blockedCtorClasses: blockedCtorClasses,
       enumValuesIterated: enumValuesIterated,
+      deadExtensions: deadExtensions,
     );
   }
 
   final Set<DeclKey> emptiedEnums;
   final Set<DeclKey> blockedCtorClasses;
   final Set<DeclKey> enumValuesIterated;
+  final Set<DeclKey> deadExtensions;
 }

--- a/lib/src/remove_safety.dart
+++ b/lib/src/remove_safety.dart
@@ -25,11 +25,8 @@ import 'package:pro_lsp/pro_lsp.dart' show Location;
 /// * [enumValuesIterated] — enums whose values are all reachable through
 ///   `.values` iteration, so a value reached only that way is used, not dead,
 ///   and is suppressed entirely rather than reported.
-/// * [deadExtensions] — extensions nothing refers to by name and every member
-///   of which is dead. An extension is used only through its members, so this
-///   is what "unused extension" means; it is reported and removed whole, like
-///   a dead class, rather than left as an empty `extension E on T {}` shell
-///   once its members go.
+/// * [deadExtensions] — extensions nothing names and every member of which is
+///   dead: reported and removed whole, like a dead class.
 class RemoveSafety {
   const RemoveSafety({
     required this.emptiedEnums,
@@ -67,15 +64,15 @@ class RemoveSafety {
         }
       }
       if (candidate.isExtension) {
-        // Two unnamed extensions on one type in a file share a key; their
-        // tallies merge, which can only keep both, never drop a live one.
+        // Unnamed extensions on one type share a key; merged tallies can only
+        // keep both.
         extensionUnreferenced.update(
           candidate.key,
           (was) => was && unused,
           ifAbsent: () => unused,
         );
-        // Every member counts, candidate or not: one excluded by `--kinds` or
-        // `--no-public` is unaccounted for, and keeps the extension.
+        // Every member counts, so one excluded by `--kinds`/`--no-public`
+        // keeps the extension.
         extensionMemberTotal.update(
           candidate.key,
           (n) => n + (symbol.children?.length ?? 0),

--- a/lib/src/remover.dart
+++ b/lib/src/remover.dart
@@ -26,8 +26,8 @@ typedef _Span = ({int start, int end});
 /// only removed on its own when that can be done unambiguously; otherwise it
 /// is left in place rather than risk producing invalid source.
 ///
-/// A rewritten file left with nothing but directives is then deleted, and the
-/// `import`s of it elsewhere dropped — see `deleteEmptiedFiles`.
+/// A rewritten file left with nothing but directives is then deleted; see
+/// `deleteEmptiedFiles`.
 RemovalResult removeDeclarations(
   List<UnusedDeclaration> declarations,
   String rootPath,

--- a/lib/src/remover.dart
+++ b/lib/src/remover.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:ciach/src/emptied_files.dart';
 import 'package:ciach/src/models.dart';
 import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
@@ -25,8 +26,12 @@ typedef _Span = ({int start, int end});
 /// only removed on its own when that can be done unambiguously; otherwise it
 /// is left in place rather than risk producing invalid source.
 ///
-/// Returns the number of files that were actually modified.
-int removeDeclarations(List<UnusedDeclaration> declarations, String rootPath) {
+/// A rewritten file left with nothing but directives is then deleted, and the
+/// `import`s of it elsewhere dropped — see `deleteEmptiedFiles`.
+RemovalResult removeDeclarations(
+  List<UnusedDeclaration> declarations,
+  String rootPath,
+) {
   final byFile = <String, List<UnusedDeclaration>>{};
   for (final decl in declarations) {
     // A blocked finding is reported but never auto-removed: deleting it safely
@@ -61,17 +66,20 @@ int removeDeclarations(List<UnusedDeclaration> declarations, String rootPath) {
     }
   }
 
-  var filesChanged = 0;
+  final rewritten = <String>{};
   for (final entry in byFile.entries) {
     final file = File(p.joinAll([rootPath, ...p.posix.split(entry.key)]));
     final content = file.readAsStringSync();
     final updated = _removeFromContent(content, entry.value);
     if (updated != content) {
       file.writeAsStringSync(updated);
-      filesChanged++;
+      rewritten.add(p.normalize(file.absolute.path));
     }
   }
-  return filesChanged;
+  return RemovalResult(
+    filesChanged: rewritten.length,
+    deletedFiles: deleteEmptiedFiles(rewritten, rootPath),
+  );
 }
 
 String _removeFromContent(String content, List<UnusedDeclaration> decls) {

--- a/lib/src/symbols.dart
+++ b/lib/src/symbols.dart
@@ -99,8 +99,14 @@ extension SymbolChecks on DocumentSymbol {
   /// The kind ciach reports for this symbol. The analysis server tags enum
   /// values with [SymbolKind.enum$] (same as the enum type), so remap them to
   /// [SymbolKind.enumMember] under an enum to match the `enum-value` CLI kind.
-  SymbolKind reportedKind({required bool parentIsEnum}) =>
-      parentIsEnum && kind == .enum$ ? .enumMember : kind;
+  SymbolKind reportedKind({
+    required bool parentIsEnum,
+    bool isExtensionType = false,
+  }) => switch (kind) {
+    .enum$ when parentIsEnum => .enumMember,
+    .namespace when isExtensionType => .struct,
+    _ => kind,
+  };
 
   /// The name to report for this symbol.
   ///

--- a/lib/src/symbols.dart
+++ b/lib/src/symbols.dart
@@ -14,8 +14,9 @@ import 'package:ciach/src/models.dart';
 import 'package:pro_lsp/pro_lsp.dart' show DocumentSymbol, Position, SymbolKind;
 
 /// Symbol kinds that introduce a lexical scope; their name becomes the
-/// container for nested members.
-const typeLikeKinds = <SymbolKind>{.class$, .interface$, .enum$, .struct};
+/// container for nested members. [SymbolKind.namespace] is an extension (or
+/// extension type).
+const typeLikeKinds = <SymbolKind>{.class$, .interface$, .enum$, .namespace};
 
 /// Names of Dart's overloadable operators. The analysis server reports an
 /// `operator +`/`operator ==`/… declaration as a plain [SymbolKind.method]

--- a/lib/src/symbols.dart
+++ b/lib/src/symbols.dart
@@ -14,8 +14,7 @@ import 'package:ciach/src/models.dart';
 import 'package:pro_lsp/pro_lsp.dart' show DocumentSymbol, Position, SymbolKind;
 
 /// Symbol kinds that introduce a lexical scope; their name becomes the
-/// container for nested members. [SymbolKind.namespace] is an extension (or
-/// extension type).
+/// container for nested members. [SymbolKind.namespace] is an extension.
 const typeLikeKinds = <SymbolKind>{.class$, .interface$, .enum$, .namespace};
 
 /// Names of Dart's overloadable operators. The analysis server reports an

--- a/lib/src/syntax_rules.dart
+++ b/lib/src/syntax_rules.dart
@@ -17,18 +17,8 @@ import 'package:pro_lsp/pro_lsp.dart' show DocumentSymbol, Location, SymbolKind;
 /// index of the referenced type name.
 typedef _TypeToken = ({List<Token> tokens, int ti});
 
-/// What a [SymbolKind.namespace] symbol declares, told apart by the tokens
-/// that open it — the analysis server reports all three under one kind.
-enum ExtensionShape {
-  /// `extension Name on T { … }`.
-  named,
-
-  /// `extension on T { … }` — nothing can refer to it by name.
-  unnamed,
-
-  /// `extension type Name(…) { … }` — a type, not an extension.
-  extensionType,
-}
+/// The three declarations the server reports as [SymbolKind.namespace].
+enum ExtensionShape { named, unnamed, extensionType }
 
 /// Structural, lexer-level checks over a declaration or a reference — the
 /// syntactic special cases the reference classifier layers on top of the raw
@@ -202,8 +192,7 @@ extension StructuralChecks on SourceIndex {
     return isFinal;
   }
 
-  /// How the `extension`-flavoured [symbol] in [path] is declared, or `null`
-  /// when its tokens don't open with the `extension` keyword at all.
+  /// `null` when [symbol] doesn't open with the `extension` keyword.
   ExtensionShape? extensionShape(String path, DocumentSymbol symbol) {
     final window = tokenWindow(path, symbol);
     if (window == null) {
@@ -216,8 +205,7 @@ extension StructuralChecks on SourceIndex {
         continue;
       }
       if (t.value != 'extension') {
-        // An annotation's name (`@Deprecated(…)`) precedes the keyword.
-        continue;
+        continue; // an annotation's name
       }
       final next = i + 1 < end ? tokens[i + 1] : null;
       if (next == null || !next.isWord) {

--- a/lib/src/syntax_rules.dart
+++ b/lib/src/syntax_rules.dart
@@ -11,11 +11,24 @@
 import 'package:ciach/src/candidates.dart';
 import 'package:ciach/src/lexing.dart';
 import 'package:ciach/src/source_index.dart';
-import 'package:pro_lsp/pro_lsp.dart' show DocumentSymbol, Location;
+import 'package:pro_lsp/pro_lsp.dart' show DocumentSymbol, Location, SymbolKind;
 
 /// The lexer token at a resolved reference: the file's token stream plus the
 /// index of the referenced type name.
 typedef _TypeToken = ({List<Token> tokens, int ti});
+
+/// What a [SymbolKind.namespace] symbol declares, told apart by the tokens
+/// that open it — the analysis server reports all three under one kind.
+enum ExtensionShape {
+  /// `extension Name on T { … }`.
+  named,
+
+  /// `extension on T { … }` — nothing can refer to it by name.
+  unnamed,
+
+  /// `extension type Name(…) { … }` — a type, not an extension.
+  extensionType,
+}
 
 /// Structural, lexer-level checks over a declaration or a reference — the
 /// syntactic special cases the reference classifier layers on top of the raw
@@ -187,6 +200,36 @@ extension StructuralChecks on SourceIndex {
       }
     }
     return isFinal;
+  }
+
+  /// How the `extension`-flavoured [symbol] in [path] is declared, or `null`
+  /// when its tokens don't open with the `extension` keyword at all.
+  ExtensionShape? extensionShape(String path, DocumentSymbol symbol) {
+    final window = tokenWindow(path, symbol);
+    if (window == null) {
+      return null;
+    }
+    final (:tokens, :start, :end) = window;
+    for (var i = start; i < end; i++) {
+      final t = tokens[i];
+      if (!t.isWord) {
+        continue;
+      }
+      if (t.value != 'extension') {
+        // An annotation's name (`@Deprecated(…)`) precedes the keyword.
+        continue;
+      }
+      final next = i + 1 < end ? tokens[i + 1] : null;
+      if (next == null || !next.isWord) {
+        return null;
+      }
+      return switch (next.value) {
+        'type' => .extensionType,
+        'on' => .unnamed,
+        _ => .named,
+      };
+    }
+    return null;
   }
 
   /// Whether [enumCandidate] iterates its own values via the implicit `values`

--- a/test/finder_test.dart
+++ b/test/finder_test.dart
@@ -111,7 +111,8 @@ void main() {
       'Direction.south',
       'Direction.west',
       'Loud.whisper',
-      'tripled',
+      // An extension's members are qualified by it, like a class's.
+      'IntExtras.tripled',
       // Private constructors are reported like any other dead code. The sole,
       // zero-parameter `SoleMarker._()` also carries a prevent-instantiation
       // hint (asserted separately below).
@@ -227,7 +228,9 @@ void main() {
     expect(unused, isNot(contains('UsedClass._format')));
     expect(unused, isNot(contains('UsedClass.name')));
     expect(unused, isNot(contains('UsedClass.nickname')));
-    expect(unused, isNot(contains('doubled')));
+    expect(unused, isNot(contains('IntExtras.doubled')));
+    // Alive through `doubled`, though nothing names the extension itself.
+    expect(unused, isNot(contains('IntExtras')));
     expect(unused, isNot(contains('Loud')));
     expect(unused, isNot(contains('Loud.emphasize')));
     expect(unused, isNot(contains('Direction')));
@@ -505,6 +508,107 @@ void main() {
         );
       },
     );
+  });
+
+  group('dead extensions', () {
+    // Scan the extension fixture and its uses file together: `LiveHelpers` is
+    // kept alive by a member call from the latter, `ShownHelpers` by a `show`.
+    Future<FinderResult> runExtensions() => runFinder(
+      include: [
+        'lib/scenarios/extensions_emptied.dart',
+        'lib/scenarios/extensions_emptied_uses.dart',
+      ],
+      exclude: const [],
+    );
+
+    test("reports exactly the fixture's dead declarations", () async {
+      final result = await runExtensions();
+      expect(result.unused.map((d) => d.qualifiedName).toSet(), {
+        'DeadHelpers',
+        'LiveHelpers.stale',
+        'extension on String',
+        'ShownHelpers.shownButUnused',
+        'Hollow',
+        'useEmptiedExtensions',
+      });
+    });
+
+    test('an extension whose every member is dead is reported as the '
+        'extension, not its members', () async {
+      final result = await runExtensions();
+      final decl = findByQualified(result, 'DeadHelpers');
+      expect(decl, isNotNull, reason: 'nothing calls either member');
+      expect(decl!.kind, SymbolKind.namespace);
+      expect(decl.kind.label, 'extension');
+      expect(decl.removalBlocked, isFalse);
+      // The members go with the extension, so they are not findings of their
+      // own — a double report would also be a double removal.
+      expect(findByQualified(result, 'DeadHelpers.first'), isNull);
+      expect(findByQualified(result, 'DeadHelpers.second'), isNull);
+    });
+
+    test('an extension with a live member is never reported, even though '
+        'nothing names it', () async {
+      final result = await runExtensions();
+      expect(findByQualified(result, 'LiveHelpers'), isNull);
+      // Its dead member is still an ordinary finding.
+      final stale = findByQualified(result, 'LiveHelpers.stale');
+      expect(stale, isNotNull);
+      expect(stale!.kind, SymbolKind.method);
+    });
+
+    test("an unnamed extension is reported whole under the server's "
+        'placeholder name, its members unqualified', () async {
+      final result = await runExtensions();
+      final decl = findByQualified(result, 'extension on String');
+      expect(decl, isNotNull);
+      expect(decl!.kind, SymbolKind.namespace);
+      // Points at the declaration, not at the `on` type.
+      expect(decl.column, 1);
+      expect(findByQualified(result, 'shoutedOnce'), isNull);
+      expect(
+        findByQualified(result, 'extension on String.shoutedOnce'),
+        isNull,
+      );
+    });
+
+    test('an extension named in a `show` stays; only its dead member is '
+        'reported', () async {
+      final result = await runExtensions();
+      expect(findByQualified(result, 'ShownHelpers'), isNull);
+      expect(findByQualified(result, 'ShownHelpers.shownButUnused'), isNotNull);
+    });
+
+    test('an extension with no members and no references is dead', () async {
+      final result = await runExtensions();
+      expect(findByQualified(result, 'Hollow'), isNotNull);
+    });
+
+    test('an extension type is never a candidate', () async {
+      final result = await runExtensions();
+      expect(findByQualified(result, 'Meters'), isNull);
+      expect(findByQualified(result, 'Meters.value'), isNull);
+    });
+
+    test('without extension candidates (`-k method`) the members are reported '
+        'on their own', () async {
+      final result = await runFinder(
+        include: [
+          'lib/scenarios/extensions_emptied.dart',
+          'lib/scenarios/extensions_emptied_uses.dart',
+        ],
+        exclude: const [],
+        kinds: const {SymbolKind.method},
+      );
+      expect(result.unused.map((d) => d.qualifiedName).toSet(), {
+        'DeadHelpers.first',
+        'DeadHelpers.second',
+        'LiveHelpers.stale',
+        'shoutedOnce',
+        'shoutedTwice',
+        'ShownHelpers.shownButUnused',
+      });
+    });
   });
 
   group('enum `.values` detection fix', () {

--- a/test/finder_test.dart
+++ b/test/finder_test.dart
@@ -111,7 +111,6 @@ void main() {
       'Direction.south',
       'Direction.west',
       'Loud.whisper',
-      // An extension's members are qualified by it, like a class's.
       'IntExtras.tripled',
       // Private constructors are reported like any other dead code. The sole,
       // zero-parameter `SoleMarker._()` also carries a prevent-instantiation
@@ -229,7 +228,6 @@ void main() {
     expect(unused, isNot(contains('UsedClass.name')));
     expect(unused, isNot(contains('UsedClass.nickname')));
     expect(unused, isNot(contains('IntExtras.doubled')));
-    // Alive through `doubled`, though nothing names the extension itself.
     expect(unused, isNot(contains('IntExtras')));
     expect(unused, isNot(contains('Loud')));
     expect(unused, isNot(contains('Loud.emphasize')));
@@ -511,8 +509,6 @@ void main() {
   });
 
   group('dead extensions', () {
-    // Scan the extension fixture and its uses file together: `LiveHelpers` is
-    // kept alive by a member call from the latter, `ShownHelpers` by a `show`.
     Future<FinderResult> runExtensions() => runFinder(
       include: [
         'lib/scenarios/extensions_emptied.dart',
@@ -541,8 +537,6 @@ void main() {
       expect(decl!.kind, SymbolKind.namespace);
       expect(decl.kind.label, 'extension');
       expect(decl.removalBlocked, isFalse);
-      // The members go with the extension, so they are not findings of their
-      // own — a double report would also be a double removal.
       expect(findByQualified(result, 'DeadHelpers.first'), isNull);
       expect(findByQualified(result, 'DeadHelpers.second'), isNull);
     });
@@ -551,7 +545,6 @@ void main() {
         'nothing names it', () async {
       final result = await runExtensions();
       expect(findByQualified(result, 'LiveHelpers'), isNull);
-      // Its dead member is still an ordinary finding.
       final stale = findByQualified(result, 'LiveHelpers.stale');
       expect(stale, isNotNull);
       expect(stale!.kind, SymbolKind.method);
@@ -563,7 +556,6 @@ void main() {
       final decl = findByQualified(result, 'extension on String');
       expect(decl, isNotNull);
       expect(decl!.kind, SymbolKind.namespace);
-      // Points at the declaration, not at the `on` type.
       expect(decl.column, 1);
       expect(findByQualified(result, 'shoutedOnce'), isNull);
       expect(

--- a/test/finder_test.dart
+++ b/test/finder_test.dart
@@ -508,14 +508,20 @@ void main() {
     );
   });
 
+  const extensionFixture = [
+    'lib/scenarios/extensions_emptied.dart',
+    'lib/scenarios/extensions_emptied_uses.dart',
+  ];
+
   group('dead extensions', () {
-    Future<FinderResult> runExtensions() => runFinder(
-      include: [
-        'lib/scenarios/extensions_emptied.dart',
-        'lib/scenarios/extensions_emptied_uses.dart',
-      ],
+    Future<FinderResult> runExtensions() =>
+        runFinder(include: extensionFixture, exclude: const []);
+
+    Future<Set<String>> byKind(SymbolKind kind) async => (await runFinder(
+      include: extensionFixture,
       exclude: const [],
-    );
+      kinds: {kind},
+    )).unused.map((d) => d.qualifiedName).toSet();
 
     test("reports exactly the fixture's dead declarations", () async {
       final result = await runExtensions();
@@ -525,6 +531,10 @@ void main() {
         'extension on String',
         'ShownHelpers.shownButUnused',
         'Hollow',
+        'DeadMeters',
+        'DeadMeters.scaled',
+        'SelfMeters',
+        'SelfMeters.next',
         'useEmptiedExtensions',
       });
     });
@@ -576,19 +586,50 @@ void main() {
       expect(findByQualified(result, 'Hollow'), isNotNull);
     });
 
-    test('an extension type is never a candidate', () async {
+    test('an extension type is a type: dead when nothing names it, reported '
+        'whole with its members, like a dead class', () async {
+      final result = await runExtensions();
+      final decl = findByQualified(result, 'DeadMeters');
+      expect(decl, isNotNull);
+      expect(decl!.kind, SymbolKind.struct);
+      expect(decl.kind.label, 'extension type');
+      expect(decl.removalBlocked, isFalse);
+      expect(findByQualified(result, 'DeadMeters.scaled'), isNotNull);
+    });
+
+    test(
+      'an extension type referenced only from its own body is dead',
+      () async {
+        final result = await runExtensions();
+        expect(findByQualified(result, 'SelfMeters'), isNotNull);
+      },
+    );
+
+    test('an extension type named as a type is never reported', () async {
       final result = await runExtensions();
       expect(findByQualified(result, 'Meters'), isNull);
-      expect(findByQualified(result, 'Meters.value'), isNull);
+    });
+
+    test('`-k extension-type` selects the extension types on their own, which '
+        '`-k extension` does not', () async {
+      expect(await byKind(SymbolKind.struct), {'DeadMeters', 'SelfMeters'});
+      expect(
+        await byKind(SymbolKind.namespace),
+        isNot(contains(anyOf('DeadMeters', 'SelfMeters'))),
+      );
+    });
+
+    test('`-k extension` alone keeps an extension whose members were never '
+        'checked, reporting only a member-less one', () async {
+      // Unchecked members can't be proven dead, so only `Hollow` — which has
+      // none — is.
+      expect(await byKind(SymbolKind.namespace), {'Hollow'});
     });
 
     test('without extension candidates (`-k method`) the members are reported '
         'on their own', () async {
       final result = await runFinder(
-        include: [
-          'lib/scenarios/extensions_emptied.dart',
-          'lib/scenarios/extensions_emptied_uses.dart',
-        ],
+        include: extensionFixture,
         exclude: const [],
         kinds: const {SymbolKind.method},
       );

--- a/test/remover_test.dart
+++ b/test/remover_test.dart
@@ -16,11 +16,13 @@ void main() {
   });
 
   /// Writes [content] to `<tempDir>/lib.dart`, removes [decls] from it, and
-  /// returns the resulting content.
+  /// returns the resulting content — or `''` when the removal left nothing and
+  /// deleted the file (see the `emptied files` group).
   String applyRemoval(String content, List<UnusedDeclaration> decls) {
-    File(p.join(tempDir.path, 'lib.dart')).writeAsStringSync(content);
+    final file = File(p.join(tempDir.path, 'lib.dart'))
+      ..writeAsStringSync(content);
     removeDeclarations(decls, tempDir.path);
-    return File(p.join(tempDir.path, 'lib.dart')).readAsStringSync();
+    return file.existsSync() ? file.readAsStringSync() : '';
   }
 
   UnusedDeclaration decl({
@@ -823,6 +825,280 @@ class Registry {
       _expectBalanced(result);
     },
   );
+
+  group('emptied files', () {
+    // Files are written under the temp root as a `pkg` package, so `package:`
+    // URIs resolve like the analysis server would resolve them.
+    void write(String relativePath, String content) {
+      File(p.join(tempDir.path, p.joinAll(p.posix.split(relativePath))))
+        ..createSync(recursive: true)
+        ..writeAsStringSync(content);
+    }
+
+    String read(String relativePath) => File(
+      p.join(tempDir.path, p.joinAll(p.posix.split(relativePath))),
+    ).readAsStringSync();
+
+    bool exists(String relativePath) => File(
+      p.join(tempDir.path, p.joinAll(p.posix.split(relativePath))),
+    ).existsSync();
+
+    /// The one declaration every emptied fixture file carries: a
+    /// `void gone() {}` on line index [line], columns 0..14.
+    UnusedDeclaration gone(String filePath, {int line = 2}) => .new(
+      name: 'gone',
+      kind: .function,
+      filePath: filePath,
+      line: line + 1,
+      column: 6,
+      isPrivate: false,
+      range: (startLine: line, startColumn: 0, endLine: line, endColumn: 14),
+    );
+
+    setUp(() {
+      write('pubspec.yaml', 'name: pkg\n');
+    });
+
+    test('deletes a file left with nothing but imports and drops the '
+        'directives naming it — relative, package:, and an export', () {
+      write('lib/dead.dart', '''
+import 'dart:async';
+
+void gone() {}
+''');
+      write('lib/user.dart', '''
+import 'package:pkg/dead.dart';
+import 'dart:io';
+
+void kept() {}
+''');
+      write('lib/sub/relative.dart', '''
+import '../dead.dart' show gone;
+
+void alsoKept() {}
+''');
+      write('lib/barrel.dart', '''
+export 'dead.dart';
+export 'user.dart';
+''');
+
+      final result = removeDeclarations([gone('lib/dead.dart')], tempDir.path);
+
+      expect(exists('lib/dead.dart'), isFalse);
+      expect(result.filesChanged, 1);
+      final deleted = result.deletedFiles.single;
+      expect(deleted.filePath, 'lib/dead.dart');
+      expect(deleted.unlinkedFrom, [
+        'lib/barrel.dart',
+        'lib/sub/relative.dart',
+        'lib/user.dart',
+      ]);
+      expect(read('lib/user.dart'), "import 'dart:io';\n\nvoid kept() {}\n");
+      expect(read('lib/sub/relative.dart'), '\nvoid alsoKept() {}\n');
+      // The barrel still exports something, so it stays.
+      expect(read('lib/barrel.dart'), "export 'user.dart';\n");
+    });
+
+    test('a `library` line and comments do not keep a file', () {
+      write('lib/dead.dart', '''
+// Copyright: nobody.
+
+/// Docs for the library.
+library dead;
+
+// ignore_for_file: unused_import
+import 'dart:async';
+
+/// Gone.
+void gone() {}
+''');
+      removeDeclarations([gone('lib/dead.dart', line: 9)], tempDir.path);
+      expect(exists('lib/dead.dart'), isFalse);
+    });
+
+    test('a file that still exports something stays', () {
+      write('lib/dead.dart', '''
+export 'other.dart';
+
+void gone() {}
+''');
+      write('lib/other.dart', 'void other() {}\n');
+      final result = removeDeclarations([gone('lib/dead.dart')], tempDir.path);
+      expect(exists('lib/dead.dart'), isTrue);
+      expect(read('lib/dead.dart'), "export 'other.dart';\n\n");
+      expect(result.deletedFiles, isEmpty);
+    });
+
+    test('a file that still owns a part stays', () {
+      write('lib/dead.dart', '''
+part 'dead.g.dart';
+
+void gone() {}
+''');
+      write('lib/dead.g.dart', "part of 'dead.dart';\n");
+      removeDeclarations([gone('lib/dead.dart')], tempDir.path);
+      expect(exists('lib/dead.dart'), isTrue);
+      expect(exists('lib/dead.g.dart'), isTrue);
+    });
+
+    test('an emptied part file is deleted with its `part` line, and the '
+        'owner left with nothing but imports follows it', () {
+      write('lib/owner.dart', '''
+import 'dart:async';
+
+part 'piece.dart';
+''');
+      write('lib/piece.dart', '''
+part of 'owner.dart';
+
+void gone() {}
+''');
+      write('bin/main.dart', '''
+import 'package:pkg/owner.dart';
+
+void main() {}
+''');
+
+      final result = removeDeclarations([gone('lib/piece.dart')], tempDir.path);
+
+      expect(exists('lib/piece.dart'), isFalse);
+      expect(exists('lib/owner.dart'), isFalse);
+      expect(result.deletedFiles.map((d) => d.filePath), [
+        'lib/piece.dart',
+        'lib/owner.dart',
+      ]);
+      expect(read('bin/main.dart'), '\nvoid main() {}\n');
+    });
+
+    test('a barrel left with nothing once its only export is deleted '
+        'follows it', () {
+      write('lib/dead.dart', '''
+import 'dart:async';
+
+void gone() {}
+''');
+      write('lib/barrel.dart', "export 'dead.dart';\n");
+      write('bin/main.dart', '''
+import 'package:pkg/barrel.dart';
+
+void main() {}
+''');
+
+      final result = removeDeclarations([gone('lib/dead.dart')], tempDir.path);
+
+      expect(exists('lib/dead.dart'), isFalse);
+      expect(exists('lib/barrel.dart'), isFalse);
+      expect(result.deletedFiles.map((d) => d.filePath), [
+        'lib/dead.dart',
+        'lib/barrel.dart',
+      ]);
+      expect(read('bin/main.dart'), '\nvoid main() {}\n');
+    });
+
+    test('a file named in a conditional import stays', () {
+      write('lib/dead.dart', '''
+import 'dart:async';
+
+void gone() {}
+''');
+      write('lib/switch.dart', '''
+import 'stub.dart' if (dart.library.io) 'dead.dart';
+
+void kept() {}
+''');
+      write('lib/stub.dart', 'void stub() {}\n');
+      final result = removeDeclarations([gone('lib/dead.dart')], tempDir.path);
+      expect(exists('lib/dead.dart'), isTrue);
+      expect(result.deletedFiles, isEmpty);
+      expect(read('lib/switch.dart'), contains("'dead.dart'"));
+    });
+
+    test('a `package:` URI of a package no pubspec claims keeps the file '
+        'when the paths line up', () {
+      write('lib/dead.dart', '''
+import 'dart:async';
+
+void gone() {}
+''');
+      write('lib/user.dart', '''
+import 'package:mystery/dead.dart';
+
+void kept() {}
+''');
+      removeDeclarations([gone('lib/dead.dart')], tempDir.path);
+      expect(exists('lib/dead.dart'), isTrue);
+      expect(read('lib/user.dart'), contains('package:mystery/dead.dart'));
+    });
+
+    test('a `package:` URI of another package under the root is not this '
+        'file', () {
+      write('lib/dead.dart', '''
+import 'dart:async';
+
+void gone() {}
+''');
+      write('example/pubspec.yaml', 'name: sample\n');
+      write('example/lib/dead.dart', 'void sampleDead() {}\n');
+      write('example/bin/main.dart', '''
+import 'package:sample/dead.dart';
+
+void main() {}
+''');
+      removeDeclarations([gone('lib/dead.dart')], tempDir.path);
+      expect(exists('lib/dead.dart'), isFalse);
+      // Names the example's own lib/dead.dart, not the deleted one.
+      expect(
+        read('example/bin/main.dart'),
+        contains('package:sample/dead.dart'),
+      );
+    });
+
+    test('a file nothing was removed from is never deleted, even if empty', () {
+      write('lib/placeholder.dart', '// Reserved for later.\n');
+      write('lib/dead.dart', '''
+import 'placeholder.dart';
+
+void gone() {}
+''');
+      removeDeclarations([gone('lib/dead.dart')], tempDir.path);
+      expect(exists('lib/dead.dart'), isFalse);
+      expect(exists('lib/placeholder.dart'), isTrue);
+    });
+
+    test('a file with a declaration left is not deleted, and its import of '
+        'a deleted file is dropped whole even across lines', () {
+      write('lib/dead.dart', 'void gone() {}\n');
+      write('lib/user.dart', '''
+import 'dead.dart'
+    show gone,
+        other;
+
+/// Still here.
+void kept() {}
+''');
+      removeDeclarations([gone('lib/dead.dart', line: 0)], tempDir.path);
+      expect(exists('lib/dead.dart'), isFalse);
+      expect(read('lib/user.dart'), '\n/// Still here.\nvoid kept() {}\n');
+    });
+
+    test('a report-only finding does not empty its file', () {
+      write('lib/dead.dart', 'void gone() {}\n');
+      const blocked = UnusedDeclaration(
+        name: 'gone',
+        kind: .function,
+        filePath: 'lib/dead.dart',
+        line: 1,
+        column: 6,
+        isPrivate: false,
+        range: (startLine: 0, startColumn: 0, endLine: 0, endColumn: 14),
+        removalBlocked: true,
+      );
+      final result = removeDeclarations([blocked], tempDir.path);
+      expect(exists('lib/dead.dart'), isTrue);
+      expect(result.filesChanged, 0);
+      expect(result.deletedFiles, isEmpty);
+    });
+  });
 }
 
 /// A cheap brace-balance check so a regression that mangles a removal shows

--- a/test/remover_test.dart
+++ b/test/remover_test.dart
@@ -16,8 +16,7 @@ void main() {
   });
 
   /// Writes [content] to `<tempDir>/lib.dart`, removes [decls] from it, and
-  /// returns the resulting content — or `''` when the removal left nothing and
-  /// deleted the file (see the `emptied files` group).
+  /// returns the resulting content, or `''` if the file was deleted.
   String applyRemoval(String content, List<UnusedDeclaration> decls) {
     final file = File(p.join(tempDir.path, 'lib.dart'))
       ..writeAsStringSync(content);
@@ -827,8 +826,6 @@ class Registry {
   );
 
   group('emptied files', () {
-    // Files are written under the temp root as a `pkg` package, so `package:`
-    // URIs resolve like the analysis server would resolve them.
     void write(String relativePath, String content) {
       File(p.join(tempDir.path, p.joinAll(p.posix.split(relativePath))))
         ..createSync(recursive: true)
@@ -843,8 +840,7 @@ class Registry {
       p.join(tempDir.path, p.joinAll(p.posix.split(relativePath))),
     ).existsSync();
 
-    /// The one declaration every emptied fixture file carries: a
-    /// `void gone() {}` on line index [line], columns 0..14.
+    /// `void gone() {}` on line index [line].
     UnusedDeclaration gone(String filePath, {int line = 2}) => .new(
       name: 'gone',
       kind: .function,
@@ -895,7 +891,6 @@ export 'user.dart';
       ]);
       expect(read('lib/user.dart'), "import 'dart:io';\n\nvoid kept() {}\n");
       expect(read('lib/sub/relative.dart'), '\nvoid alsoKept() {}\n');
-      // The barrel still exports something, so it stays.
       expect(read('lib/barrel.dart'), "export 'user.dart';\n");
     });
 
@@ -1046,7 +1041,6 @@ void main() {}
 ''');
       removeDeclarations([gone('lib/dead.dart')], tempDir.path);
       expect(exists('lib/dead.dart'), isFalse);
-      // Names the example's own lib/dead.dart, not the deleted one.
       expect(
         read('example/bin/main.dart'),
         contains('package:sample/dead.dart'),

--- a/website/lib/pages/docs_page.dart
+++ b/website/lib/pages/docs_page.dart
@@ -564,6 +564,24 @@ class DocsPage extends StatelessComponent {
                   code([.text('dart format')]),
                   .text(' afterward and review the diff.'),
                 ]),
+                const p([
+                  .text(
+                    'Nothing is left behind as an empty shell. An extension '
+                    'whose every member is dead is reported and removed as '
+                    'the whole extension, like a fully dead class (one a ',
+                  ),
+                  code([.text('show')]),
+                  .text(
+                    ' names stays). A file the removal leaves with nothing '
+                    'but directives is deleted, and the ',
+                  ),
+                  code([.text('import')]),
+                  .text(
+                    's of it elsewhere dropped; a file that still exports or '
+                    'owns a part, or that had no declarations to begin with, '
+                    'is left alone.',
+                  ),
+                ]),
                 const h3([.text('Report-only: removal would not compile')]),
                 ul(classes: 'checklist', [
                   for (final item in _reportOnly) li(rich(item)),


### PR DESCRIPTION
Fixes #48 

## Summary

Removal used to leave empty shells behind. Three of them, now gone:

1. **Dead extensions.** An extension whose every member is dead is reported and removed as the whole `extension`, like a fully dead class. One named by a `show`/`hide` stays, and only its members are reported. Members are now reported as `Extension.member`.

2. **Emptied files.** A file left with only `library`/`import`/`part of` lines is deleted, and the `import`/`export`/`part` lines naming it are dropped. A file that `export`s, owns a `part`, sits in a conditional import, or never had a declaration is left alone.

3. **Dead extension types** (added in 8c2291a, after [review feedback](https://github.com/leancodepl/ciach/pull/50#discussion_r3970350577)). An `extension type` is a type, so it is dead when nothing names it, and is removed whole rather than having its members stripped and the `extension type E(int value) {}` shell left standing. Selectable with `-k extension-type`.

## Key changes

- **`lib/src/emptied_files.dart`**, new: deletes emptied files and unlinks them, looping until nothing more falls, since dropping a `part` or `export` line can empty that file in turn. Conservative on anything it cannot resolve, including a `package:` URI no pubspec under the root claims.

- **`lib/src/finder.dart`**: extensions are kept alive by member references, not by name. An unnamed extension gets no reference query, because the analysis server would answer for its `on` type. An extension type goes through the class rule, so references from its own body no longer keep it alive.

- **`ExtensionSyntax`** in `syntax_rules.dart`, new: tells `namedExtension`, `unnamedExtension` and `extensionType` apart, which the server reports under one kind.

- **`RemovalResult`**: `removeDeclarations()` returns the deleted files alongside `filesChanged`, instead of a bare count.

- **`-k extension`** now selects extensions at all; it matched a kind the server never emits. `-k extension-type` is new.

## Notes

- An extension whose members were excluded from the scan by `--kinds` or `--no-public` is kept, since unchecked members cannot be proven dead.
- `remover_test.dart` covers the cascades (part files, barrels), a dead class beside a `package:` export, conditional imports, unknown package URIs, and multi-line directive removal.

https://claude.ai/code/session_014DdZMBctBLbo17EdBsSzi4