### PR TITLE
Recognize framework entry points, starting with testExecutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## Unreleased
 
 - Stop reporting (and removing) `testExecutable` in a `flutter_test_config.dart`:
-  the `flutter test` bootstrap calls it, with no reference on disk. Only a
-  top-level function with the bootstrap's signature is exempt. ([#49](https://github.com/leancodepl/ciach/issues/49))
-- Add `--entry-point <glob:name>` (`entry-point:` in `ciach.yaml`, repeatable)
-  to list a project's own framework-called declarations, so they are never
+  the `flutter test` bootstrap calls it, with no reference on disk.
+  ([#49](https://github.com/leancodepl/ciach/issues/49))
+- Add `entry-points` to `ciach.yaml`, a map of declaration name to file glob(s),
+  to list a project's own framework-called declarations so they are never
   reported. `--verbose` names each declaration skipped as an entry point.
 
 ## 0.4.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
   the `flutter test` bootstrap calls it, with no reference on disk.
   ([#49](https://github.com/leancodepl/ciach/issues/49))
 - Add `entry-points` to `ciach.yaml`, a list of `{name, glob}` rules, to list a
-  project's own framework-called declarations so they are never reported.
-  `--verbose` names each declaration skipped as an entry point.
+  project's own framework-called declarations so they are never reported. A
+  member rule (`MyPlugin.registerWith`) keeps its type too. `--verbose` names
+  each declaration skipped as an entry point.
 
 ## 0.4.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+- Stop reporting (and removing) `testExecutable` in a `flutter_test_config.dart`:
+  the `flutter test` bootstrap calls it, with no reference on disk. Only a
+  top-level function with the bootstrap's signature is exempt. ([#49](https://github.com/leancodepl/ciach/issues/49))
+- Add `--entry-point <glob:name>` (`entry-point:` in `ciach.yaml`, repeatable)
+  to list a project's own framework-called declarations, so they are never
+  reported. `--verbose` names each declaration skipped as an entry point.
+
 ## 0.4.4
 
 - Fix a compiled `ciach` (`dart install`) spawning itself as the analysis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 - Stop reporting (and removing) `testExecutable` in a `flutter_test_config.dart`:
   the `flutter test` bootstrap calls it, with no reference on disk.
   ([#49](https://github.com/leancodepl/ciach/issues/49))
-- Add `entry-points` to `ciach.yaml`, a map of declaration name to file glob(s),
-  to list a project's own framework-called declarations so they are never
-  reported. `--verbose` names each declaration skipped as an entry point.
+- Add `entry-points` to `ciach.yaml`, a list of `{name, glob}` rules, to list a
+  project's own framework-called declarations so they are never reported.
+  `--verbose` names each declaration skipped as an entry point.
 
 ## 0.4.4
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ function, and its one parameter to be the test's `main`,
 code. Verbose mode names each exemption as it happens:
 
 ```
-[  0.4s] Skipped test/flutter_test_config.dart:8 testExecutable: called by the `flutter test` bootstrap (entry point **/flutter_test_config.dart:testExecutable).
+[  0.4s] Skipped test/flutter_test_config.dart:6 testExecutable: called by the `flutter test` bootstrap (entry point **/flutter_test_config.dart:testExecutable).
 ```
 
 A project adds its own with `--entry-point`, or `entry-point:` in `ciach.yaml`,

--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ ciach --verbose                        # explain each step
 | `-e, --exclude <glob>` | — | Skip files matching the glob (repeatable). |
 | `-i, --include <glob>` | — | Only scan files matching the glob (repeatable). |
 | `--generated-suffix <suffix>` | — | Extra filename suffix (with leading dot) to treat as generated and skip, on top of the built-in set; repeatable. Ignored when `--generated` is set. |
-| `--entry-point <glob:name>` | — | A declaration a framework or tool of this project calls by convention, never reported: `<file glob>:<name>` or a bare `<name>`; repeatable. On top of the built-in `main` and `testExecutable`. See [Entry points](#entry-points). |
 | `-k, --kinds <list>` | all | Restrict to kinds: `class, mixin, interface, enum, extension, function, method, constructor, field, property, getter, setter, variable, constant, enum-value`. |
 | `-f, --format <fmt>` | `text` | `text`, `json`, or `github` (GitHub Actions `::warning` annotations). |
 | `-j, --concurrency <n>` | `16` | Reference queries kept in flight against the analysis server. |
@@ -114,10 +113,11 @@ long name minus the `--`, plus `path` for the positional argument:
 ```yaml
 public: false                     # --no-public
 exclude: ['test/**', 'tool/**']   # repeatable options take a list, or a bare string
-entry-point: ['lib/**_plugin.dart:registerWith']
 kinds: [class, function, method]
 format: github
 set-exit-if-changed: true
+entry-points:                     # file-only; see Entry points below
+  registerWith: 'lib/**_plugin.dart'
 ```
 
 Command line beats config file beats default, even when the flag matches the
@@ -236,7 +236,7 @@ that cost.
 | Skipped | Why | Flag |
 | --- | --- | --- |
 | `main` | the entry point is never unused | — |
-| `testExecutable` in a `flutter_test_config.dart` | `flutter test` generates a bootstrap that calls it; nothing on disk does. See [Entry points](#entry-points) | `--entry-point` adds more |
+| `testExecutable` in a `flutter_test_config.dart` | `flutter test` generates a bootstrap that calls it; nothing on disk does. See [Entry points](#entry-points) | `entry-points:` in `ciach.yaml` adds more |
 | `@override` members | often reached polymorphically or by a framework (`build`, `initState`, `==`, …), which a name-based search misses | `--overrides` |
 | Operator overloads | the server doesn't resolve `a + b` back to the declaration, so a used operator is flagged every time | `--operators` |
 | `call` methods | implicit-call syntax (`obj(…)`) is unresolvable the same way | — |
@@ -259,31 +259,31 @@ package: `flutter test` finds the nearest `flutter_test_config.dart` and runs it
 calls a conventionally-named function. A reference search cannot see those
 calls, so each would read as dead.
 
-ciach exempts a declaration only when it meets the caller's whole contract, not
-when it happens to share a name. The built-in `testExecutable` rule requires the
-file to be named `flutter_test_config.dart`, the declaration to be a top-level
-function, and its one parameter to be the test's `main`,
-`FutureOr<void> Function()` — anything less is reported like any other dead
-code. Verbose mode names each exemption as it happens:
+Such tools find their function the same way: by name, in a file they know, and
+leave its shape to the compiler at the generated call site. ciach applies the
+same contract — a top-level name in matching files — and nothing more, so a
+`testExecutable` with an unexpected signature is left alone too: it is a broken
+hook `flutter test` will complain about, not dead code. Verbose mode names each
+exemption:
 
 ```
-[  0.4s] Skipped test/flutter_test_config.dart:6 testExecutable: called by the `flutter test` bootstrap (entry point **/flutter_test_config.dart:testExecutable).
+[  0.4s] Skipped test/flutter_test_config.dart:6 testExecutable: called by the `flutter test` bootstrap.
 ```
 
-A project adds its own with `--entry-point`, or `entry-point:` in `ciach.yaml`,
-as `<file glob>:<name>` — the glob relative to the package root, the name bare
-for a top-level declaration or `Container.member` for a member — or a bare
-`<name>` for any file:
+A project adds its own under `entry-points:` in `ciach.yaml`, a map of
+declaration name — bare for a top-level declaration, `Container.member` for a
+member — to a file glob relative to the package root, a list of globs, or
+nothing for any file. This setting has no command-line form.
 
 ```yaml
-entry-point:
-  - 'lib/**_plugin.dart:registerWith'   # a top-level function, in matching files
-  - 'test/harness.dart:Harness.start'   # a member
-  - integrationMain                      # any file
+entry-points:
+  registerWith: 'lib/**_plugin.dart'          # a top-level function, in matching files
+  Harness.start: [test/harness.dart]          # a member
+  integrationMain:                            # any file
 ```
 
-These match on file and name only; a declaration that matches is never a
-candidate, so it is neither reported nor removed.
+A declaration that matches is never a candidate, so it is neither reported nor
+removed.
 
 ## Limitations
 
@@ -295,7 +295,7 @@ deleting blindly:
 - **Reflection, dynamic invocation, and names referenced only from generated
   code you excluded** are invisible to a reference search.
 - **Entry points other than `main`** (isolate entry points, plugin registrants)
-  need listing with [`--entry-point`](#entry-points) or
+  need listing under [`entry-points`](#entry-points) or
   `@pragma('vm:entry-point')`; only `flutter test`'s `testExecutable` is known
   out of the box.
 - **A primary constructor shares its class's references**, since a query at the

--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ kinds: [class, function, method]
 format: github
 set-exit-if-changed: true
 entry-points:                     # file-only; see Entry points below
-  registerWith: 'lib/**_plugin.dart'
+  - name: registerWith
+    glob: 'lib/**_plugin.dart'
 ```
 
 Command line beats config file beats default, even when the flag matches the
@@ -270,16 +271,19 @@ exemption:
 [  0.4s] Skipped test/flutter_test_config.dart:6 testExecutable: called by the `flutter test` bootstrap.
 ```
 
-A project adds its own under `entry-points:` in `ciach.yaml`, a map of
-declaration name — bare for a top-level declaration, `Container.member` for a
-member — to a file glob relative to the package root, a list of globs, or
-nothing for any file. This setting has no command-line form.
+A project adds its own under `entry-points:` in `ciach.yaml`: a list of rules,
+each with a `name` — bare for a top-level declaration, `Container.member` for a
+member — and an optional `glob` relative to the package root, one or a list, for
+the files it may live in; no `glob` means any file. This setting has no
+command-line form.
 
 ```yaml
 entry-points:
-  registerWith: 'lib/**_plugin.dart'          # a top-level function, in matching files
-  Harness.start: [test/harness.dart]          # a member
-  integrationMain:                            # any file
+  - name: registerWith
+    glob: 'lib/**_plugin.dart'   # a top-level function, in matching files
+  - name: Harness.start
+    glob: [test/harness.dart]    # a member
+  - name: integrationMain        # any file
 ```
 
 A declaration that matches is never a candidate, so it is neither reported nor

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ ciach --verbose                        # explain each step
 | `-e, --exclude <glob>` | — | Skip files matching the glob (repeatable). |
 | `-i, --include <glob>` | — | Only scan files matching the glob (repeatable). |
 | `--generated-suffix <suffix>` | — | Extra filename suffix (with leading dot) to treat as generated and skip, on top of the built-in set; repeatable. Ignored when `--generated` is set. |
+| `--entry-point <glob:name>` | — | A declaration a framework or tool of this project calls by convention, never reported: `<file glob>:<name>` or a bare `<name>`; repeatable. On top of the built-in `main` and `testExecutable`. See [Entry points](#entry-points). |
 | `-k, --kinds <list>` | all | Restrict to kinds: `class, mixin, interface, enum, extension, function, method, constructor, field, property, getter, setter, variable, constant, enum-value`. |
 | `-f, --format <fmt>` | `text` | `text`, `json`, or `github` (GitHub Actions `::warning` annotations). |
 | `-j, --concurrency <n>` | `16` | Reference queries kept in flight against the analysis server. |
@@ -113,6 +114,7 @@ long name minus the `--`, plus `path` for the positional argument:
 ```yaml
 public: false                     # --no-public
 exclude: ['test/**', 'tool/**']   # repeatable options take a list, or a bare string
+entry-point: ['lib/**_plugin.dart:registerWith']
 kinds: [class, function, method]
 format: github
 set-exit-if-changed: true
@@ -234,6 +236,7 @@ that cost.
 | Skipped | Why | Flag |
 | --- | --- | --- |
 | `main` | the entry point is never unused | — |
+| `testExecutable` in a `flutter_test_config.dart` | `flutter test` generates a bootstrap that calls it; nothing on disk does. See [Entry points](#entry-points) | `--entry-point` adds more |
 | `@override` members | often reached polymorphically or by a framework (`build`, `initState`, `==`, …), which a name-based search misses | `--overrides` |
 | Operator overloads | the server doesn't resolve `a + b` back to the declaration, so a used operator is flagged every time | `--operators` |
 | `call` methods | implicit-call syntax (`obj(…)`) is unresolvable the same way | — |
@@ -248,6 +251,40 @@ like any other. A sole zero-parameter `ClassName._()` — the classic
 prevent-instantiation marker — is reported with a hint suggesting `abstract final
 class` instead. See [example/](example) for a runnable demonstration of each case.
 
+### Entry points
+
+Some declarations are called by a framework or a tool, never by code in the
+package: `flutter test` finds the nearest `flutter_test_config.dart` and runs its
+`testExecutable`, a plugin registrant is named in `pubspec.yaml`, a driver script
+calls a conventionally-named function. A reference search cannot see those
+calls, so each would read as dead.
+
+ciach exempts a declaration only when it meets the caller's whole contract, not
+when it happens to share a name. The built-in `testExecutable` rule requires the
+file to be named `flutter_test_config.dart`, the declaration to be a top-level
+function, and its one parameter to be the test's `main`,
+`FutureOr<void> Function()` — anything less is reported like any other dead
+code. Verbose mode names each exemption as it happens:
+
+```
+[  0.4s] Skipped test/flutter_test_config.dart:8 testExecutable: called by the `flutter test` bootstrap (entry point **/flutter_test_config.dart:testExecutable).
+```
+
+A project adds its own with `--entry-point`, or `entry-point:` in `ciach.yaml`,
+as `<file glob>:<name>` — the glob relative to the package root, the name bare
+for a top-level declaration or `Container.member` for a member — or a bare
+`<name>` for any file:
+
+```yaml
+entry-point:
+  - 'lib/**_plugin.dart:registerWith'   # a top-level function, in matching files
+  - 'test/harness.dart:Harness.start'   # a member
+  - integrationMain                      # any file
+```
+
+These match on file and name only; a declaration that matches is never a
+candidate, so it is neither reported nor removed.
+
 ## Limitations
 
 This is a static, reference-based heuristic, so review its output rather than
@@ -258,7 +295,9 @@ deleting blindly:
 - **Reflection, dynamic invocation, and names referenced only from generated
   code you excluded** are invisible to a reference search.
 - **Entry points other than `main`** (isolate entry points, plugin registrants)
-  need excluding or `@pragma('vm:entry-point')`.
+  need listing with [`--entry-point`](#entry-points) or
+  `@pragma('vm:entry-point')`; only `flutter test`'s `testExecutable` is known
+  out of the box.
 - **A primary constructor shares its class's references**, since a query at the
   header resolves to the class: a never-invoked one only surfaces once the class
   itself is dead.

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ kinds: [class, function, method]
 format: github
 set-exit-if-changed: true
 entry-points:                     # file-only; see Entry points below
-  - name: registerWith
-    glob: 'lib/**_plugin.dart'
+  - name: MyPlugin.registerWith
+    glob: 'lib/my_plugin.dart'
 ```
 
 Command line beats config file beats default, even when the flag matches the
@@ -272,22 +272,27 @@ exemption:
 ```
 
 A project adds its own under `entry-points:` in `ciach.yaml`: a list of rules,
-each with a `name` — bare for a top-level declaration, `Container.member` for a
+each with a `name` — bare for a top-level declaration, `Type.member` for a
 member — and an optional `glob` relative to the package root, one or a list, for
 the files it may live in; no `glob` means any file. This setting has no
 command-line form.
 
 ```yaml
 entry-points:
-  - name: registerWith
-    glob: 'lib/**_plugin.dart'   # a top-level function, in matching files
-  - name: Harness.start
-    glob: [test/harness.dart]    # a member
-  - name: integrationMain        # any file
+  # The Dart plugin registrant flutter_tools generates from `dartPluginClass`
+  # in pubspec.yaml calls `MyPlugin.registerWith()`.
+  - name: MyPlugin.registerWith
+    glob: 'lib/my_plugin.dart'
+  # A builder factory named in build.yaml, called by build_runner's generated
+  # build script.
+  - name: myBuilder
+    glob: 'lib/builder.dart'
 ```
 
 A declaration that matches is never a candidate, so it is neither reported nor
-removed.
+removed. A member rule keeps the type it lives in as well — the generated call
+that reaches `MyPlugin.registerWith` names `MyPlugin` too — while the type's
+other members are checked as usual.
 
 ## Limitations
 

--- a/example/README.md
+++ b/example/README.md
@@ -18,6 +18,7 @@ everyday declaration kinds, referenced (or not) from `bin/app.dart`.
 | `lib/orphans.dart` | classes never referenced at all, and one referenced only as a type |
 | `lib/callables.dart` | a callable class (`call` method), whose implicit-call use is skipped |
 | `lib/private_ctors.dart` | private constructors reported like any dead code, with a prevent-instantiation hint on the sole zero-parameter `Foo._()` |
+| `test/flutter_test_config.dart` | the `flutter test` hook `testExecutable`, called by nothing on disk yet never reported |
 
 `lib/scenarios/` holds the **scenario fixtures**: one file (or a small cluster
 of them) per detection rule, each pinning down one behavior that is easy to
@@ -33,6 +34,7 @@ expected; each is scanned only by its own test, never by the demo run above.
 | `freezed_unions.dart` | `@freezed` union arms built only by a generated `fromJson` |
 | `serialization.dart` | the `toJson`/`fromJson` conventions, and `--report-tojson` |
 | `comment_annotations.dart` | a comment mentioning `@override` or `vm:entry-point` does not skip the declaration below it |
+| `entry_points.dart`, `entry_points/flutter_test_config.dart` | a built-in entry point exempts only its whole contract (file, name, signature), and `--entry-point` adds a project's own |
 | `dot_shorthands.dart`, `dot_shorthand_uses.dart` | every context a `.name` dot shorthand is allowed in, including nested constructor shorthands |
 | `primary_constructors.dart` | primary constructors: a dead declaration in the class header is report-only, while the class body stays removable |
 | `xref_*.dart` | the cross-library reference recovery, and telling same-named members apart |
@@ -83,7 +85,7 @@ Referenced only from doc comments — not counted as unused, never removed:
 lib/greeting.dart
   41:6  function  _docOnlyMentioned  (private)
 
-Found 21 unused declarations in 6 files (scanned 8 files, 59 declarations, ...s).
+Found 21 unused declarations in 6 files (scanned 9 files, 59 declarations, ...s).
 1 more referenced only from doc comments.
 ```
 
@@ -100,6 +102,8 @@ Things worth noticing:
   removing the class takes the constructor with it.
 - `_docOnlyMentioned` is reached only by a `[link]` in another declaration's doc
   comment, so it is listed separately and never removed.
+- `testExecutable` in `test/flutter_test_config.dart` is not reported: nothing
+  on disk calls it, but `flutter test` does, and ciach knows that contract.
 - `Dog.sound` (an `@override`) is skipped by default; add `--overrides` to
   include it — which also reveals `Animal.sound`, the abstract method it
   implements.

--- a/example/README.md
+++ b/example/README.md
@@ -34,7 +34,7 @@ expected; each is scanned only by its own test, never by the demo run above.
 | `freezed_unions.dart` | `@freezed` union arms built only by a generated `fromJson` |
 | `serialization.dart` | the `toJson`/`fromJson` conventions, and `--report-tojson` |
 | `comment_annotations.dart` | a comment mentioning `@override` or `vm:entry-point` does not skip the declaration below it |
-| `entry_points.dart`, `entry_points/flutter_test_config.dart` | a built-in entry point exempts only its whole contract (file, name, signature), and `--entry-point` adds a project's own |
+| `entry_points.dart`, `entry_points/flutter_test_config.dart` | an entry point is exempt by file and name, whatever its shape, and `entry-points` in `ciach.yaml` adds a project's own |
 | `dot_shorthands.dart`, `dot_shorthand_uses.dart` | every context a `.name` dot shorthand is allowed in, including nested constructor shorthands |
 | `primary_constructors.dart` | primary constructors: a dead declaration in the class header is report-only, while the class body stays removable |
 | `xref_*.dart` | the cross-library reference recovery, and telling same-named members apart |

--- a/example/lib/scenarios/entry_points.dart
+++ b/example/lib/scenarios/entry_points.dart
@@ -1,6 +1,7 @@
 // Entry points. Expected findings: everything, by default; with `entry-points`
 // rules for `integrationMain`, `Plugin.registerWith` and `bootstrap`, only
-// `testExecutable` — right name, wrong file.
+// `testExecutable` — right name, wrong file — and `Plugin.other`: the member
+// rule keeps `Plugin` itself, which nothing names, but not its other members.
 
 import 'dart:async';
 
@@ -8,10 +9,12 @@ Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   await testMain();
 }
 
-Object integrationMain() => Plugin;
+void integrationMain() {}
 
 class Plugin {
   static void registerWith() {}
+
+  void other() {}
 }
 
 void bootstrap() {}

--- a/example/lib/scenarios/entry_points.dart
+++ b/example/lib/scenarios/entry_points.dart
@@ -1,6 +1,6 @@
-// Entry points. Expected findings: everything, by default; with `--entry-point`
-// specs for `integrationMain`, `Plugin.registerWith` and `bootstrap`, only
-// `testExecutable` — right name and shape, wrong file.
+// Entry points. Expected findings: everything, by default; with `entry-points`
+// rules for `integrationMain`, `Plugin.registerWith` and `bootstrap`, only
+// `testExecutable` — right name, wrong file.
 
 import 'dart:async';
 

--- a/example/lib/scenarios/entry_points.dart
+++ b/example/lib/scenarios/entry_points.dart
@@ -1,27 +1,17 @@
-// Entry points: declarations a framework or tool calls by convention, with no
-// reference in the source. A built-in convention exempts only a declaration
-// meeting its whole contract; a project lists its own with `--entry-point`.
-//
-// Expected findings, by default: everything here. `testExecutable` has the name
-// and shape `flutter test` wants but sits in the wrong file, so it is dead like
-// any other function. With `--entry-point` specs for `integrationMain`,
-// `Plugin.registerWith` and `bootstrap`, only `testExecutable` remains.
+// Entry points. Expected findings: everything, by default; with `--entry-point`
+// specs for `integrationMain`, `Plugin.registerWith` and `bootstrap`, only
+// `testExecutable` — right name and shape, wrong file.
 
 import 'dart:async';
 
-/// Right name, right signature, wrong file: the `flutter test` bootstrap only
-/// ever imports a `flutter_test_config.dart`.
 Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   await testMain();
 }
 
-/// A project-specific entry point some driver script calls by convention.
 Object integrationMain() => Plugin;
 
-/// A member entry point, listed as `Plugin.registerWith`.
 class Plugin {
   static void registerWith() {}
 }
 
-/// Listed by bare name, so matched in any file.
 void bootstrap() {}

--- a/example/lib/scenarios/entry_points.dart
+++ b/example/lib/scenarios/entry_points.dart
@@ -1,0 +1,27 @@
+// Entry points: declarations a framework or tool calls by convention, with no
+// reference in the source. A built-in convention exempts only a declaration
+// meeting its whole contract; a project lists its own with `--entry-point`.
+//
+// Expected findings, by default: everything here. `testExecutable` has the name
+// and shape `flutter test` wants but sits in the wrong file, so it is dead like
+// any other function. With `--entry-point` specs for `integrationMain`,
+// `Plugin.registerWith` and `bootstrap`, only `testExecutable` remains.
+
+import 'dart:async';
+
+/// Right name, right signature, wrong file: the `flutter test` bootstrap only
+/// ever imports a `flutter_test_config.dart`.
+Future<void> testExecutable(FutureOr<void> Function() testMain) async {
+  await testMain();
+}
+
+/// A project-specific entry point some driver script calls by convention.
+Object integrationMain() => Plugin;
+
+/// A member entry point, listed as `Plugin.registerWith`.
+class Plugin {
+  static void registerWith() {}
+}
+
+/// Listed by bare name, so matched in any file.
+void bootstrap() {}

--- a/example/lib/scenarios/entry_points/flutter_test_config.dart
+++ b/example/lib/scenarios/entry_points/flutter_test_config.dart
@@ -1,7 +1,5 @@
-// A `flutter_test_config.dart` whose `testExecutable` the `flutter test`
-// bootstrap could not call: it takes an `int`, not the test's `main`. The file
-// name alone earns no exemption, so it is reported — as is the dead helper
-// beside it. Expected findings: both declarations.
+// Right file, wrong signature: the bootstrap could not call this. Expected
+// findings: both declarations.
 
 Future<void> testExecutable(int retries) async {}
 

--- a/example/lib/scenarios/entry_points/flutter_test_config.dart
+++ b/example/lib/scenarios/entry_points/flutter_test_config.dart
@@ -1,0 +1,8 @@
+// A `flutter_test_config.dart` whose `testExecutable` the `flutter test`
+// bootstrap could not call: it takes an `int`, not the test's `main`. The file
+// name alone earns no exemption, so it is reported — as is the dead helper
+// beside it. Expected findings: both declarations.
+
+Future<void> testExecutable(int retries) async {}
+
+void deadHelperNextToConfig() {}

--- a/example/lib/scenarios/entry_points/flutter_test_config.dart
+++ b/example/lib/scenarios/entry_points/flutter_test_config.dart
@@ -1,5 +1,5 @@
-// Right file, wrong signature: the bootstrap could not call this. Expected
-// findings: both declarations.
+// Right file: the bootstrap calls `testExecutable` whatever its shape, so it
+// is exempt. Expected findings: `deadHelperNextToConfig` only.
 
 Future<void> testExecutable(int retries) async {}
 

--- a/example/test/flutter_test_config.dart
+++ b/example/test/flutter_test_config.dart
@@ -1,0 +1,10 @@
+// The `flutter test` configuration hook. The test runner finds this file by
+// name, walking up from each test file, and generates a bootstrap that calls
+// `testExecutable(testMain)` — so nothing in the package references it, yet it
+// is live. Expected findings: none.
+
+import 'dart:async';
+
+Future<void> testExecutable(FutureOr<void> Function() testMain) async {
+  await testMain();
+}

--- a/example/test/flutter_test_config.dart
+++ b/example/test/flutter_test_config.dart
@@ -1,7 +1,5 @@
-// The `flutter test` configuration hook. The test runner finds this file by
-// name, walking up from each test file, and generates a bootstrap that calls
-// `testExecutable(testMain)` — so nothing in the package references it, yet it
-// is live. Expected findings: none.
+// The `flutter test` hook: the runner's generated bootstrap calls it, nothing
+// on disk does. Expected findings: none.
 
 import 'dart:async';
 

--- a/lib/ciach.dart
+++ b/lib/ciach.dart
@@ -27,6 +27,7 @@ library;
 
 export 'package:pro_lsp/pro_lsp.dart' show SymbolKind;
 
+export 'src/conventions/entry_points.dart' show EntryPoint;
 export 'src/dart_executable.dart'
     show DartSdkNotFoundException, findDartExecutable;
 export 'src/finder.dart' show Ciach;

--- a/lib/src/cli/args.dart
+++ b/lib/src/cli/args.dart
@@ -39,8 +39,8 @@ String get kindNames => kindAliases.keys.sorted().join(', ');
 /// The accepted `--format` values; the first one is the default.
 const formatNames = ['text', 'json', 'github'];
 
-/// The `entry-points` map: declaration name → file glob(s). It has no
-/// command-line form; `ConfigFile` hands it over already parsed and validated.
+/// The `entry-points` list of `{name, glob}` rules. It has no command-line
+/// form; `ConfigFile` hands it over already parsed and validated.
 final class EntryPointsOption extends ConfigOptionBase<List<EntryPoint>> {
   const EntryPointsOption({required super.configKey, super.helpText})
     : super(valueParser: const _EntryPointsParser(), defaultsTo: const []);
@@ -53,7 +53,7 @@ final class _EntryPointsParser extends ValueParser<List<EntryPoint>> {
 
   @override
   List<EntryPoint> parse(String value) => throw const FormatException(
-    'entry-points is a map of declaration names to file globs.',
+    'entry-points is a list of {name, glob} rules.',
   );
 }
 
@@ -281,9 +281,10 @@ enum CiachOption<V> implements OptionDefinition<V> {
       configKey: '/entry-points',
       helpText:
           'Declarations a framework calls by convention, so never reported:\n'
-          'a map of declaration name (`registerWith`, `Harness.start`) to a\n'
-          'file glob, a list of globs, or nothing for any file. Built in:\n'
-          '`main`, and `testExecutable` in a flutter_test_config.dart.',
+          'a list of rules, each with a `name` (`registerWith`,\n'
+          '`Harness.start`) and an optional `glob` (one, or a list) for the\n'
+          'files it may live in. Built in: `main`, and `testExecutable` in a\n'
+          'flutter_test_config.dart.',
     ),
   ),
   kinds(
@@ -417,17 +418,19 @@ Config file:
 
   `entry-points` lives only there: declarations a framework or tool calls by
   convention (on top of the built-in `main` and `testExecutable` in a
-  flutter_test_config.dart), as a map of declaration name to file glob, list
-  of globs, or nothing for any file.
+  flutter_test_config.dart), each a `name` with an optional `glob` (one, or a
+  list) for the files it may live in.
 
     # $configFileName
     public: false
     exclude:
       - 'test/**'
     entry-points:
-      registerWith: 'lib/**_plugin.dart'
-      Harness.start: [test/harness.dart]
-      integrationMain:
+      - name: registerWith
+        glob: 'lib/**_plugin.dart'
+      - name: Harness.start
+        glob: [test/harness.dart]
+      - name: integrationMain
     kinds: [class, function]
     format: json
 

--- a/lib/src/cli/args.dart
+++ b/lib/src/cli/args.dart
@@ -39,11 +39,23 @@ String get kindNames => kindAliases.keys.sorted().join(', ');
 /// The accepted `--format` values; the first one is the default.
 const formatNames = ['text', 'json', 'github'];
 
-/// Parses the `--entry-point` specs into rules; throws a [FormatException]
-/// naming a malformed one.
-List<EntryPoint> parseEntryPoints(List<String> raw) => [
-  for (final spec in raw) EntryPoint.parse(spec),
-];
+/// The `entry-points` map: declaration name → file glob(s). It has no
+/// command-line form; `ConfigFile` hands it over already parsed and validated.
+final class EntryPointsOption extends ConfigOptionBase<List<EntryPoint>> {
+  const EntryPointsOption({required super.configKey, super.helpText})
+    : super(valueParser: const _EntryPointsParser(), defaultsTo: const []);
+}
+
+/// Never reached: the config layer supplies the parsed list, and there is no
+/// string form to parse.
+final class _EntryPointsParser extends ValueParser<List<EntryPoint>> {
+  const _EntryPointsParser();
+
+  @override
+  List<EntryPoint> parse(String value) => throw const FormatException(
+    'entry-points is a map of declaration names to file globs.',
+  );
+}
 
 /// Parses the `--kinds` values (comma-separated, repeatable) into symbol kinds,
 /// falling back to [FinderOptions.defaultKinds] when none are given.
@@ -263,19 +275,15 @@ enum CiachOption<V> implements OptionDefinition<V> {
           'Ignored when --generated is set.',
     ),
   ),
-  entryPoint(
-    MultiStringOption.noSplit(
-      argName: 'entry-point',
-      configKey: '/entry-point',
-      defaultsTo: [],
-      valueHelp: 'glob:name',
-      customValidator: parseEntryPoints,
+  // Config file only: a map has no command-line spelling.
+  entryPoints(
+    EntryPointsOption(
+      configKey: '/entry-points',
       helpText:
-          'A declaration a framework calls by convention, so never reported:\n'
-          '`<file glob>:<name>` (e.g. `lib/**_plugin.dart:registerWith`,\n'
-          '`test/setup.dart:Harness.bootstrap`) or a bare `<name>` for any\n'
-          'file. Repeatable. Built in: `main`, and `testExecutable` in a\n'
-          'flutter_test_config.dart.',
+          'Declarations a framework calls by convention, so never reported:\n'
+          'a map of declaration name (`registerWith`, `Harness.start`) to a\n'
+          'file glob, a list of globs, or nothing for any file. Built in:\n'
+          '`main`, and `testExecutable` in a flutter_test_config.dart.',
     ),
   ),
   kinds(
@@ -407,12 +415,19 @@ Config file:
   line wins over the file; --no-config ignores the file; --verbose says which
   file was read and what it set.
 
+  `entry-points` lives only there: declarations a framework or tool calls by
+  convention (on top of the built-in `main` and `testExecutable` in a
+  flutter_test_config.dart), as a map of declaration name to file glob, list
+  of globs, or nothing for any file.
+
     # $configFileName
     public: false
     exclude:
       - 'test/**'
-    entry-point:
-      - 'lib/**_plugin.dart:registerWith'
+    entry-points:
+      registerWith: 'lib/**_plugin.dart'
+      Harness.start: [test/harness.dart]
+      integrationMain:
     kinds: [class, function]
     format: json
 

--- a/lib/src/cli/args.dart
+++ b/lib/src/cli/args.dart
@@ -39,6 +39,14 @@ String get kindNames => kindAliases.keys.sorted().join(', ');
 /// The accepted `--format` values; the first one is the default.
 const formatNames = ['text', 'json', 'github'];
 
+/// Parses the `--entry-point` specs (`<file glob>:<name>` or `<name>`,
+/// repeatable) into rules.
+///
+/// Throws a [FormatException] naming the offending spec on a malformed one.
+List<EntryPoint> parseEntryPoints(List<String> raw) => [
+  for (final spec in raw) EntryPoint.parse(spec),
+];
+
 /// Parses the `--kinds` values (comma-separated, repeatable) into symbol kinds,
 /// falling back to [FinderOptions.defaultKinds] when none are given.
 ///
@@ -257,6 +265,24 @@ enum CiachOption<V> implements OptionDefinition<V> {
           'Ignored when --generated is set.',
     ),
   ),
+  entryPoint(
+    MultiStringOption.noSplit(
+      argName: 'entry-point',
+      configKey: '/entry-point',
+      defaultsTo: [],
+      valueHelp: 'glob:name',
+      // Rejects a malformed spec wherever it came from; the conversion to
+      // rules happens later.
+      customValidator: parseEntryPoints,
+      helpText:
+          'A declaration a framework or tool of this project calls by\n'
+          'convention, with no reference in the source, so it is never\n'
+          'reported: `<file glob>:<name>` (e.g. `lib/**_plugin.dart:registerWith`\n'
+          'or `test/setup.dart:Harness.bootstrap`), or a bare `<name>` for any\n'
+          'file. Repeatable. On top of the built-in `main` and `testExecutable`\n'
+          'in flutter_test_config.dart.',
+    ),
+  ),
   kinds(
     MultiStringOption(
       argName: 'kinds',
@@ -390,6 +416,8 @@ Config file:
     public: false
     exclude:
       - 'test/**'
+    entry-point:
+      - 'lib/**_plugin.dart:registerWith'
     kinds: [class, function]
     format: json
 

--- a/lib/src/cli/args.dart
+++ b/lib/src/cli/args.dart
@@ -281,10 +281,10 @@ enum CiachOption<V> implements OptionDefinition<V> {
       configKey: '/entry-points',
       helpText:
           'Declarations a framework calls by convention, so never reported:\n'
-          'a list of rules, each with a `name` (`registerWith`,\n'
-          '`Harness.start`) and an optional `glob` (one, or a list) for the\n'
-          'files it may live in. Built in: `main`, and `testExecutable` in a\n'
-          'flutter_test_config.dart.',
+          'a list of rules, each with a `name` (`myBuilder`,\n'
+          '`MyPlugin.registerWith`) and an optional `glob` (one, or a list)\n'
+          'for the files it may live in. A member rule keeps its type too.\n'
+          'Built in: `main`, and `testExecutable` in a flutter_test_config.dart.',
     ),
   ),
   kinds(
@@ -419,18 +419,17 @@ Config file:
   `entry-points` lives only there: declarations a framework or tool calls by
   convention (on top of the built-in `main` and `testExecutable` in a
   flutter_test_config.dart), each a `name` with an optional `glob` (one, or a
-  list) for the files it may live in.
+  list) for the files it may live in. A member rule keeps its type too.
 
     # $configFileName
     public: false
     exclude:
       - 'test/**'
     entry-points:
-      - name: registerWith
-        glob: 'lib/**_plugin.dart'
-      - name: Harness.start
-        glob: [test/harness.dart]
-      - name: integrationMain
+      - name: MyPlugin.registerWith   # the generated plugin registrant
+        glob: 'lib/my_plugin.dart'
+      - name: myBuilder               # a build.yaml builder factory
+        glob: 'lib/builder.dart'
     kinds: [class, function]
     format: json
 

--- a/lib/src/cli/args.dart
+++ b/lib/src/cli/args.dart
@@ -39,10 +39,8 @@ String get kindNames => kindAliases.keys.sorted().join(', ');
 /// The accepted `--format` values; the first one is the default.
 const formatNames = ['text', 'json', 'github'];
 
-/// Parses the `--entry-point` specs (`<file glob>:<name>` or `<name>`,
-/// repeatable) into rules.
-///
-/// Throws a [FormatException] naming the offending spec on a malformed one.
+/// Parses the `--entry-point` specs into rules; throws a [FormatException]
+/// naming a malformed one.
 List<EntryPoint> parseEntryPoints(List<String> raw) => [
   for (final spec in raw) EntryPoint.parse(spec),
 ];
@@ -271,16 +269,13 @@ enum CiachOption<V> implements OptionDefinition<V> {
       configKey: '/entry-point',
       defaultsTo: [],
       valueHelp: 'glob:name',
-      // Rejects a malformed spec wherever it came from; the conversion to
-      // rules happens later.
       customValidator: parseEntryPoints,
       helpText:
-          'A declaration a framework or tool of this project calls by\n'
-          'convention, with no reference in the source, so it is never\n'
-          'reported: `<file glob>:<name>` (e.g. `lib/**_plugin.dart:registerWith`\n'
-          'or `test/setup.dart:Harness.bootstrap`), or a bare `<name>` for any\n'
-          'file. Repeatable. On top of the built-in `main` and `testExecutable`\n'
-          'in flutter_test_config.dart.',
+          'A declaration a framework calls by convention, so never reported:\n'
+          '`<file glob>:<name>` (e.g. `lib/**_plugin.dart:registerWith`,\n'
+          '`test/setup.dart:Harness.bootstrap`) or a bare `<name>` for any\n'
+          'file. Repeatable. Built in: `main`, and `testExecutable` in a\n'
+          'flutter_test_config.dart.',
     ),
   ),
   kinds(

--- a/lib/src/cli/config.dart
+++ b/lib/src/cli/config.dart
@@ -205,36 +205,52 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
     return values;
   }
 
-  /// The rules under [key]: a map of declaration name to a file glob, a list
-  /// of globs, or nothing for any file.
+  /// The rules under [key]: a list of `{name: …, glob: …}` entries, `glob` a
+  /// file glob, a list of globs, or absent for any file.
   List<EntryPoint>? _entryPoints(String key) => switch (settings[key]) {
     null => null,
-    final Map<Object?, Object?> rules => [
-      for (final rule in rules.entries)
-        _entryPoint(key, '${rule.key}', rule.value),
+    final Iterable<Object?> rules => [
+      for (final (i, rule) in rules.indexed) _entryPoint('$key[$i]', rule),
     ],
     final other => _wrong(
       key,
-      'a map of declaration names to file globs',
+      'a list of entry points, each a map with `name` and optional `glob`',
       other,
     ),
   };
 
-  EntryPoint _entryPoint(String key, String name, Object? files) {
-    const expected = 'a file glob, a list of them, or nothing';
-    final globs = switch (files) {
+  EntryPoint _entryPoint(String at, Object? rule) {
+    if (rule is! Map<Object?, Object?>) {
+      return _wrong(at, 'a map with `name` and optional `glob`', rule);
+    }
+    for (final field in rule.keys) {
+      if (field != 'name' && field != 'glob') {
+        throw FormatException(
+          "$path: '$at' has an unknown field '$field'; expected `name` and optional `glob`.",
+        );
+      }
+    }
+    final name = switch (rule['name']) {
+      final String name => name,
+      final other => _wrong('$at.name', 'a declaration name', other),
+    };
+    const globExpected = 'a file glob or a list of them';
+    final globs = switch (rule['glob']) {
       null => const <String>[],
       final String glob => [glob],
       final Iterable<Object?> values => [
         for (final value in values)
-          if (value is String) value else _wrong('$key.$name', expected, value),
+          if (value is String)
+            value
+          else
+            _wrong('$at.glob', globExpected, value),
       ],
-      final other => _wrong('$key.$name', expected, other),
+      final other => _wrong('$at.glob', globExpected, other),
     };
     try {
       return EntryPoint.project(name, files: globs);
     } on FormatException catch (e) {
-      throw FormatException("$path: '$key': ${e.message}");
+      throw FormatException("$path: '$at': ${e.message}");
     }
   }
 

--- a/lib/src/cli/config.dart
+++ b/lib/src/cli/config.dart
@@ -204,7 +204,7 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
     return values;
   }
 
-  /// The entry-point specs under [key], validated but not yet converted.
+  /// The entry-point specs under [key], validated.
   List<String>? _entryPoints(String key) {
     final values = _strings(key);
     if (values != null) {

--- a/lib/src/cli/config.dart
+++ b/lib/src/cli/config.dart
@@ -144,6 +144,7 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
   Object? _typedValue(String key) => switch (_optionFor(key)) {
     .format => _oneOf(key, formatNames),
     .kinds => _kinds(key),
+    .entryPoint => _entryPoints(key),
     .concurrency => _positiveInt(key),
     final option => switch (option.option) {
       FlagOption() => _boolean(key),
@@ -196,6 +197,19 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
     if (values != null) {
       try {
         parseKinds(values);
+      } on FormatException catch (e) {
+        throw FormatException("$path: '$key': ${e.message}");
+      }
+    }
+    return values;
+  }
+
+  /// The entry-point specs under [key], validated but not yet converted.
+  List<String>? _entryPoints(String key) {
+    final values = _strings(key);
+    if (values != null) {
+      try {
+        parseEntryPoints(values);
       } on FormatException catch (e) {
         throw FormatException("$path: '$key': ${e.message}");
       }

--- a/lib/src/cli/config.dart
+++ b/lib/src/cli/config.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:ciach/src/cli/args.dart';
+import 'package:ciach/src/conventions/entry_points.dart';
 import 'package:collection/collection.dart';
 import 'package:config/config.dart';
 import 'package:path/path.dart' as p;
@@ -144,7 +145,7 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
   Object? _typedValue(String key) => switch (_optionFor(key)) {
     .format => _oneOf(key, formatNames),
     .kinds => _kinds(key),
-    .entryPoint => _entryPoints(key),
+    .entryPoints => _entryPoints(key),
     .concurrency => _positiveInt(key),
     final option => switch (option.option) {
       FlagOption() => _boolean(key),
@@ -204,17 +205,37 @@ class ConfigFile implements ConfigurationBroker<CiachOption<dynamic>> {
     return values;
   }
 
-  /// The entry-point specs under [key], validated.
-  List<String>? _entryPoints(String key) {
-    final values = _strings(key);
-    if (values != null) {
-      try {
-        parseEntryPoints(values);
-      } on FormatException catch (e) {
-        throw FormatException("$path: '$key': ${e.message}");
-      }
+  /// The rules under [key]: a map of declaration name to a file glob, a list
+  /// of globs, or nothing for any file.
+  List<EntryPoint>? _entryPoints(String key) => switch (settings[key]) {
+    null => null,
+    final Map<Object?, Object?> rules => [
+      for (final rule in rules.entries)
+        _entryPoint(key, '${rule.key}', rule.value),
+    ],
+    final other => _wrong(
+      key,
+      'a map of declaration names to file globs',
+      other,
+    ),
+  };
+
+  EntryPoint _entryPoint(String key, String name, Object? files) {
+    const expected = 'a file glob, a list of them, or nothing';
+    final globs = switch (files) {
+      null => const <String>[],
+      final String glob => [glob],
+      final Iterable<Object?> values => [
+        for (final value in values)
+          if (value is String) value else _wrong('$key.$name', expected, value),
+      ],
+      final other => _wrong('$key.$name', expected, other),
+    };
+    try {
+      return EntryPoint.project(name, files: globs);
+    } on FormatException catch (e) {
+      throw FormatException("$path: '$key': ${e.message}");
     }
-    return values;
   }
 
   int? _positiveInt(String key) => switch (settings[key]) {

--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -21,6 +21,7 @@ class ResolvedOptions {
     required this.operators,
     required this.unusedUnionMembers,
     required this.reportToJson,
+    required this.entryPoints,
     required this.setExitIfChanged,
     required this.remove,
     required this.force,
@@ -49,6 +50,9 @@ class ResolvedOptions {
   final bool operators;
   final bool unusedUnionMembers;
   final bool reportToJson;
+
+  /// The project's own entry points, parsed from `--entry-point` specs.
+  final List<EntryPoint> entryPoints;
   final bool setExitIfChanged;
   final bool remove;
   final bool force;
@@ -82,6 +86,7 @@ class ResolvedOptions {
     skipOperators: !operators,
     unusedUnionMembers: unusedUnionMembers,
     reportToJson: reportToJson,
+    entryPoints: entryPoints,
     concurrency: concurrency,
     dartExecutable: dartExecutable ?? this.dartExecutable,
     onProgress: onProgress,
@@ -124,6 +129,8 @@ ResolvedOptions resolveOptions(
     operators: configuration.value(CiachOption.operators),
     unusedUnionMembers: configuration.value(CiachOption.unusedUnionMembers),
     reportToJson: configuration.value(CiachOption.reportToJson),
+    // Already validated by the option; this only converts the specs.
+    entryPoints: parseEntryPoints(configuration.value(CiachOption.entryPoint)),
     setExitIfChanged: configuration.value(CiachOption.setExitIfChanged),
     remove: configuration.value(CiachOption.remove),
     force: configuration.value(CiachOption.force),

--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -51,7 +51,7 @@ class ResolvedOptions {
   final bool unusedUnionMembers;
   final bool reportToJson;
 
-  /// The project's own entry points, parsed from `--entry-point` specs.
+  /// The project's own entry points, from `entry-points` in the config file.
   final List<EntryPoint> entryPoints;
   final bool setExitIfChanged;
   final bool remove;
@@ -129,8 +129,7 @@ ResolvedOptions resolveOptions(
     operators: configuration.value(CiachOption.operators),
     unusedUnionMembers: configuration.value(CiachOption.unusedUnionMembers),
     reportToJson: configuration.value(CiachOption.reportToJson),
-    // Already validated by the option; this only converts the specs.
-    entryPoints: parseEntryPoints(configuration.value(CiachOption.entryPoint)),
+    entryPoints: configuration.value(CiachOption.entryPoints),
     setExitIfChanged: configuration.value(CiachOption.setExitIfChanged),
     remove: configuration.value(CiachOption.remove),
     force: configuration.value(CiachOption.force),

--- a/lib/src/cli/verbose.dart
+++ b/lib/src/cli/verbose.dart
@@ -80,6 +80,7 @@ String _setting(
   .exclude => _value(resolved.excludeGlobs),
   .include => _value(resolved.includeGlobs),
   .generatedSuffix => _value(resolved.additionalGeneratedSuffixes),
+  .entryPoint => _value(resolved.entryPoints),
   .kinds => _kinds(resolved.kinds),
   .format => resolved.format,
   .color => '${resolved.useColor}',

--- a/lib/src/cli/verbose.dart
+++ b/lib/src/cli/verbose.dart
@@ -103,16 +103,12 @@ String _source(ValueSourceType source) => switch (source) {
 };
 
 /// A value as the log reads it: an empty list is `(none)`, a full one is
-/// comma-separated, and a map's valueless keys stand alone.
+/// comma-separated, and a map keeps its braces.
 String _value(Object? value) => switch (value) {
   [] => '(none)',
-  List() => value.join(', '),
+  List() => value.map(_value).join(', '),
   Map() =>
-    value.entries
-        .map(
-          (e) => e.value == null ? '${e.key}' : '${e.key}: ${_value(e.value)}',
-        )
-        .join(', '),
+    '{${value.entries.map((e) => '${e.key}: ${_value(e.value)}').join(', ')}}',
   _ => '$value',
 };
 

--- a/lib/src/cli/verbose.dart
+++ b/lib/src/cli/verbose.dart
@@ -80,7 +80,7 @@ String _setting(
   .exclude => _value(resolved.excludeGlobs),
   .include => _value(resolved.includeGlobs),
   .generatedSuffix => _value(resolved.additionalGeneratedSuffixes),
-  .entryPoint => _value(resolved.entryPoints),
+  .entryPoints => _value(resolved.entryPoints),
   .kinds => _kinds(resolved.kinds),
   .format => resolved.format,
   .color => '${resolved.useColor}',
@@ -103,10 +103,16 @@ String _source(ValueSourceType source) => switch (source) {
 };
 
 /// A value as the log reads it: an empty list is `(none)`, a full one is
-/// comma-separated.
+/// comma-separated, and a map's valueless keys stand alone.
 String _value(Object? value) => switch (value) {
   [] => '(none)',
   List() => value.join(', '),
+  Map() =>
+    value.entries
+        .map(
+          (e) => e.value == null ? '${e.key}' : '${e.key}: ${_value(e.value)}',
+        )
+        .join(', '),
   _ => '$value',
 };
 

--- a/lib/src/conventions/entry_points.dart
+++ b/lib/src/conventions/entry_points.dart
@@ -1,67 +1,43 @@
 import 'package:glob/glob.dart';
 import 'package:path/path.dart' as p;
-import 'package:pro_lsp/pro_lsp.dart' show DocumentSymbol, SymbolKind;
-
-/// The one parameter the `flutter test` bootstrap passes: the test's `main`.
-final _testMainParameter = RegExp(
-  r'^\(\s*FutureOr<void>\s+Function\(\)\s+[A-Za-z_$][A-Za-z0-9_$]*\s*\)$',
-);
+import 'package:pro_lsp/pro_lsp.dart' show DocumentSymbol;
 
 /// A declaration a framework or tool calls by convention, with no source
-/// reference for the search to find.
+/// reference for the search to find: a top-level name in a file.
 ///
-/// A rule spells out the caller's contract — file, name, and where it matters,
-/// kind and signature — and exempts only a declaration meeting all of it.
+/// That is the whole contract the callers apply themselves — flutter_tools
+/// finds `flutter_test_config.dart` by name and generates a call to
+/// `testExecutable` — so a rule is a name plus the files it lives in, nothing
+/// about the declaration's shape. The compiler enforces the shape at the
+/// generated call site.
 final class EntryPoint {
-  /// [name] is `name` or `Container.member`; [file] a POSIX glob relative to
-  /// the package root (`null` for any file); [signature] matches the LSP
-  /// `detail`, i.e. the parameter list. [reason] says who calls it.
-  EntryPoint({
-    required this.name,
-    required this.reason,
-    String? file,
-    this.kind,
-    RegExp? signature,
-  }) : filePattern = file,
-       _file = file == null ? null : Glob(file, context: _posix),
-       _signature = signature;
+  /// [name] is `name` or `Container.member`; [files] are POSIX globs relative
+  /// to the package root, any of which may match (none means any file).
+  EntryPoint({required this.name, required this.reason, this.files = const []})
+    : _globs = [for (final file in files) Glob(file, context: _posix)];
 
-  /// Parses a `<file glob>:<name>` or bare `<name>` spec (the last `:` splits
-  /// them) into a rule matching on file and name alone.
+  /// A rule from the `entry-points` config key.
   ///
-  /// Throws a [FormatException] for an empty name or glob, a name that is not
-  /// an identifier (optionally `Container.member`), or an invalid glob.
-  factory EntryPoint.parse(String spec) {
-    final trimmed = spec.trim();
-    final colon = trimmed.lastIndexOf(':');
-    final file = colon < 0 ? null : trimmed.substring(0, colon).trim();
-    final name = colon < 0 ? trimmed : trimmed.substring(colon + 1).trim();
-    if (name.isEmpty) {
-      throw FormatException(
-        "Entry point '$spec' names no declaration; expected '<file glob>:<name>' or '<name>'.",
-      );
-    }
+  /// Throws a [FormatException] for a [name] that is not an identifier
+  /// (optionally `Container.member`) or a glob that does not parse.
+  factory EntryPoint.project(String name, {List<String> files = const []}) {
     if (!_qualifiedName.hasMatch(name)) {
       throw FormatException(
-        "Entry point '$spec': '$name' is not a declaration name; expected an identifier such as 'registerWith' or 'MyPlugin.registerWith'.",
+        "'$name' is not a declaration name; expected an identifier such as 'registerWith' or 'MyPlugin.registerWith'.",
       );
     }
-    if (file != null && file.isEmpty) {
-      throw FormatException(
-        "Entry point '$spec' has an empty file glob; drop the ':' to match any file.",
-      );
+    for (final file in files) {
+      try {
+        Glob(file, context: _posix);
+      } on FormatException catch (e) {
+        throw FormatException("'$file' is not a valid glob: ${e.message}");
+      }
     }
-    try {
-      return EntryPoint(
-        name: name,
-        file: file,
-        reason: 'listed as an entry point by this project',
-      );
-    } on FormatException catch (e) {
-      throw FormatException(
-        "Entry point '$spec': '$file' is not a valid glob: ${e.message}",
-      );
-    }
+    return EntryPoint(
+      name: name,
+      files: files,
+      reason: 'listed under `entry-points` in the config file',
+    );
   }
 
   static final _posix = p.Context(style: p.Style.posix);
@@ -72,32 +48,22 @@ final class EntryPoint {
   /// `name` for a top-level declaration, `Container.member` for a member.
   final String name;
 
-  /// The file glob as written; `null` matches any file.
-  final String? filePattern;
+  /// The file globs as written; empty matches any file.
+  final List<String> files;
 
   /// Who calls the declaration, for `--verbose`.
   final String reason;
 
-  /// The required kind, or `null` for any.
-  final SymbolKind? kind;
-
-  final Glob? _file;
-  final RegExp? _signature;
+  final List<Glob> _globs;
 
   /// The conventions applied on every run.
   static final builtIn = <EntryPoint>[
-    EntryPoint(
-      name: 'main',
-      kind: .function,
-      reason: 'the program entry point',
-    ),
+    EntryPoint(name: 'main', reason: 'the program entry point'),
     // `flutter test` generates an in-memory bootstrap that imports the nearest
     // `flutter_test_config.dart` and calls `testExecutable(testMain)`.
     EntryPoint(
       name: 'testExecutable',
-      file: '**/flutter_test_config.dart',
-      kind: .function,
-      signature: _testMainParameter,
+      files: const ['**/flutter_test_config.dart'],
       reason: 'called by the `flutter test` bootstrap',
     ),
   ];
@@ -108,25 +74,12 @@ final class EntryPoint {
     final qualified = container == null
         ? symbol.name
         : '$container.${symbol.name}';
-    if (qualified != name) {
-      return false;
-    }
-    if (kind != null && symbol.kind != kind) {
-      return false;
-    }
-    if (_file case final glob? when !glob.matches(relativePath)) {
-      return false;
-    }
-    if (_signature case final signature?
-        when !signature.hasMatch(symbol.detail?.trim() ?? '')) {
-      return false;
-    }
-    return true;
+    return qualified == name &&
+        (_globs.isEmpty || _globs.any((glob) => glob.matches(relativePath)));
   }
 
-  /// The spec form, as `--entry-point` takes it.
   @override
-  String toString() => filePattern == null ? name : '$filePattern:$name';
+  String toString() => files.isEmpty ? name : '$name in ${files.join(' or ')}';
 }
 
 /// [EntryPoint.builtIn] followed by a project's own rules; the first match

--- a/lib/src/conventions/entry_points.dart
+++ b/lib/src/conventions/entry_points.dart
@@ -1,0 +1,175 @@
+import 'package:glob/glob.dart';
+import 'package:path/path.dart' as p;
+import 'package:pro_lsp/pro_lsp.dart' show DocumentSymbol, SymbolKind;
+
+/// The one parameter `flutter test`'s bootstrap passes to `testExecutable`: the
+/// test file's `main`, typed `FutureOr<void> Function()`.
+final _testMainParameter = RegExp(
+  r'^\(\s*FutureOr<void>\s+Function\(\)\s+[A-Za-z_$][A-Za-z0-9_$]*\s*\)$',
+);
+
+/// A declaration a framework or tool invokes by convention, so that no source
+/// in the package ever references it.
+///
+/// The reference search cannot see such a call, so the declaration would read
+/// as dead. Each rule spells out the full contract the caller relies on — the
+/// file the declaration must live in, its name, and where the caller is picky,
+/// its kind and signature — and only a declaration meeting all of it is exempt.
+/// A same-named function elsewhere, or one with a shape the caller could not
+/// invoke, is still reported.
+///
+/// [builtIn] lists the conventions ciach knows; [EntryPoint.parse] builds one
+/// from the `--entry-point` / `entry-point:` spec a project adds for its own.
+final class EntryPoint {
+  /// Creates a rule matching a declaration named [name] — `name` for a
+  /// top-level declaration, `Container.member` for a member — in files matching
+  /// the POSIX glob [file] (relative to the package root; `null` for any file),
+  /// of kind [kind] (`null` for any) whose LSP `detail` (the parameter list)
+  /// satisfies [signature] (`null` for any). [reason] says who calls it.
+  EntryPoint({
+    required this.name,
+    required this.reason,
+    String? file,
+    this.kind,
+    RegExp? signature,
+  }) : filePattern = file,
+       _file = file == null ? null : Glob(file, context: _posix),
+       _signature = signature;
+
+  /// Parses a `<file glob>:<name>` or bare `<name>` spec, as given on the
+  /// command line or in the config file, into a rule that matches on file and
+  /// name alone (any kind, any signature).
+  ///
+  /// The last `:` separates the two, so a glob may not contain one. Throws a
+  /// [FormatException] naming the problem for an empty name, an invalid glob,
+  /// or a name that is not a Dart identifier (optionally `Container.member`).
+  factory EntryPoint.parse(String spec) {
+    final trimmed = spec.trim();
+    final colon = trimmed.lastIndexOf(':');
+    final file = colon < 0 ? null : trimmed.substring(0, colon).trim();
+    final name = colon < 0 ? trimmed : trimmed.substring(colon + 1).trim();
+    if (name.isEmpty) {
+      throw FormatException(
+        "Entry point '$spec' names no declaration; expected '<file glob>:<name>' or '<name>'.",
+      );
+    }
+    if (!_qualifiedName.hasMatch(name)) {
+      throw FormatException(
+        "Entry point '$spec': '$name' is not a declaration name; expected an identifier such as 'registerWith' or 'MyPlugin.registerWith'.",
+      );
+    }
+    if (file != null && file.isEmpty) {
+      throw FormatException(
+        "Entry point '$spec' has an empty file glob; drop the ':' to match any file.",
+      );
+    }
+    try {
+      return EntryPoint(
+        name: name,
+        file: file,
+        reason: 'listed as an entry point by this project',
+      );
+    } on FormatException catch (e) {
+      throw FormatException(
+        "Entry point '$spec': '$file' is not a valid glob: ${e.message}",
+      );
+    }
+  }
+
+  static final _posix = p.Context(style: p.Style.posix);
+  static final _qualifiedName = RegExp(
+    r'^[A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)?$',
+  );
+
+  /// The declaration name: `name` for a top-level one, `Container.member` for
+  /// a member.
+  final String name;
+
+  /// The file glob as written, for display; `null` matches any file.
+  final String? filePattern;
+
+  /// Who invokes the declaration, for `--verbose`.
+  final String reason;
+
+  /// The kind the declaration must have, or `null` for any.
+  final SymbolKind? kind;
+
+  final Glob? _file;
+  final RegExp? _signature;
+
+  /// The conventions ciach applies on every run.
+  static final builtIn = <EntryPoint>[
+    // The program's entry point, in every file that has one: a `bin/` script, a
+    // test, an example.
+    EntryPoint(
+      name: 'main',
+      kind: .function,
+      reason: 'the program entry point',
+    ),
+    // `flutter test` walks up from each test file to the nearest
+    // `flutter_test_config.dart` and generates a bootstrap that imports it and
+    // calls `testExecutable(testMain)`. The bootstrap never lands on disk, so
+    // the call is invisible to the reference search.
+    EntryPoint(
+      name: 'testExecutable',
+      file: '**/flutter_test_config.dart',
+      kind: .function,
+      signature: _testMainParameter,
+      reason: 'called by the `flutter test` bootstrap',
+    ),
+  ];
+
+  /// Whether [symbol], declared in the file at [relativePath] (POSIX, relative
+  /// to the package root) inside [container] (`null` at the top level), meets
+  /// this rule's whole contract.
+  bool matches(String relativePath, DocumentSymbol symbol, String? container) {
+    final qualified = container == null
+        ? symbol.name
+        : '$container.${symbol.name}';
+    if (qualified != name) {
+      return false;
+    }
+    if (kind != null && symbol.kind != kind) {
+      return false;
+    }
+    if (_file case final glob? when !glob.matches(relativePath)) {
+      return false;
+    }
+    if (_signature case final signature?
+        when !signature.hasMatch(symbol.detail?.trim() ?? '')) {
+      return false;
+    }
+    return true;
+  }
+
+  /// The spec form of this rule, as `--entry-point` would take it.
+  @override
+  String toString() => filePattern == null ? name : '$filePattern:$name';
+}
+
+/// The built-in conventions followed by a project's own rules.
+///
+/// A declaration is matched against every rule in turn and the first hit wins;
+/// the order only decides which [EntryPoint.reason] `--verbose` shows.
+final class EntryPoints {
+  /// Creates the rule set: [EntryPoint.builtIn] plus [extra].
+  EntryPoints(List<EntryPoint> extra)
+    : _rules = [...EntryPoint.builtIn, ...extra];
+
+  final List<EntryPoint> _rules;
+
+  /// The first rule [symbol] satisfies, or `null` when it is an ordinary
+  /// declaration. See [EntryPoint.matches] for the arguments.
+  EntryPoint? match(
+    String relativePath,
+    DocumentSymbol symbol,
+    String? container,
+  ) {
+    for (final rule in _rules) {
+      if (rule.matches(relativePath, symbol, container)) {
+        return rule;
+      }
+    }
+    return null;
+  }
+}

--- a/lib/src/conventions/entry_points.dart
+++ b/lib/src/conventions/entry_points.dart
@@ -2,30 +2,20 @@ import 'package:glob/glob.dart';
 import 'package:path/path.dart' as p;
 import 'package:pro_lsp/pro_lsp.dart' show DocumentSymbol, SymbolKind;
 
-/// The one parameter `flutter test`'s bootstrap passes to `testExecutable`: the
-/// test file's `main`, typed `FutureOr<void> Function()`.
+/// The one parameter the `flutter test` bootstrap passes: the test's `main`.
 final _testMainParameter = RegExp(
   r'^\(\s*FutureOr<void>\s+Function\(\)\s+[A-Za-z_$][A-Za-z0-9_$]*\s*\)$',
 );
 
-/// A declaration a framework or tool invokes by convention, so that no source
-/// in the package ever references it.
+/// A declaration a framework or tool calls by convention, with no source
+/// reference for the search to find.
 ///
-/// The reference search cannot see such a call, so the declaration would read
-/// as dead. Each rule spells out the full contract the caller relies on — the
-/// file the declaration must live in, its name, and where the caller is picky,
-/// its kind and signature — and only a declaration meeting all of it is exempt.
-/// A same-named function elsewhere, or one with a shape the caller could not
-/// invoke, is still reported.
-///
-/// [builtIn] lists the conventions ciach knows; [EntryPoint.parse] builds one
-/// from the `--entry-point` / `entry-point:` spec a project adds for its own.
+/// A rule spells out the caller's contract — file, name, and where it matters,
+/// kind and signature — and exempts only a declaration meeting all of it.
 final class EntryPoint {
-  /// Creates a rule matching a declaration named [name] — `name` for a
-  /// top-level declaration, `Container.member` for a member — in files matching
-  /// the POSIX glob [file] (relative to the package root; `null` for any file),
-  /// of kind [kind] (`null` for any) whose LSP `detail` (the parameter list)
-  /// satisfies [signature] (`null` for any). [reason] says who calls it.
+  /// [name] is `name` or `Container.member`; [file] a POSIX glob relative to
+  /// the package root (`null` for any file); [signature] matches the LSP
+  /// `detail`, i.e. the parameter list. [reason] says who calls it.
   EntryPoint({
     required this.name,
     required this.reason,
@@ -36,13 +26,11 @@ final class EntryPoint {
        _file = file == null ? null : Glob(file, context: _posix),
        _signature = signature;
 
-  /// Parses a `<file glob>:<name>` or bare `<name>` spec, as given on the
-  /// command line or in the config file, into a rule that matches on file and
-  /// name alone (any kind, any signature).
+  /// Parses a `<file glob>:<name>` or bare `<name>` spec (the last `:` splits
+  /// them) into a rule matching on file and name alone.
   ///
-  /// The last `:` separates the two, so a glob may not contain one. Throws a
-  /// [FormatException] naming the problem for an empty name, an invalid glob,
-  /// or a name that is not a Dart identifier (optionally `Container.member`).
+  /// Throws a [FormatException] for an empty name or glob, a name that is not
+  /// an identifier (optionally `Container.member`), or an invalid glob.
   factory EntryPoint.parse(String spec) {
     final trimmed = spec.trim();
     final colon = trimmed.lastIndexOf(':');
@@ -81,35 +69,30 @@ final class EntryPoint {
     r'^[A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)?$',
   );
 
-  /// The declaration name: `name` for a top-level one, `Container.member` for
-  /// a member.
+  /// `name` for a top-level declaration, `Container.member` for a member.
   final String name;
 
-  /// The file glob as written, for display; `null` matches any file.
+  /// The file glob as written; `null` matches any file.
   final String? filePattern;
 
-  /// Who invokes the declaration, for `--verbose`.
+  /// Who calls the declaration, for `--verbose`.
   final String reason;
 
-  /// The kind the declaration must have, or `null` for any.
+  /// The required kind, or `null` for any.
   final SymbolKind? kind;
 
   final Glob? _file;
   final RegExp? _signature;
 
-  /// The conventions ciach applies on every run.
+  /// The conventions applied on every run.
   static final builtIn = <EntryPoint>[
-    // The program's entry point, in every file that has one: a `bin/` script, a
-    // test, an example.
     EntryPoint(
       name: 'main',
       kind: .function,
       reason: 'the program entry point',
     ),
-    // `flutter test` walks up from each test file to the nearest
-    // `flutter_test_config.dart` and generates a bootstrap that imports it and
-    // calls `testExecutable(testMain)`. The bootstrap never lands on disk, so
-    // the call is invisible to the reference search.
+    // `flutter test` generates an in-memory bootstrap that imports the nearest
+    // `flutter_test_config.dart` and calls `testExecutable(testMain)`.
     EntryPoint(
       name: 'testExecutable',
       file: '**/flutter_test_config.dart',
@@ -119,9 +102,8 @@ final class EntryPoint {
     ),
   ];
 
-  /// Whether [symbol], declared in the file at [relativePath] (POSIX, relative
-  /// to the package root) inside [container] (`null` at the top level), meets
-  /// this rule's whole contract.
+  /// Whether [symbol], in the file at [relativePath] (POSIX, from the package
+  /// root) inside [container] (`null` at the top level), meets this rule.
   bool matches(String relativePath, DocumentSymbol symbol, String? container) {
     final qualified = container == null
         ? symbol.name
@@ -142,24 +124,20 @@ final class EntryPoint {
     return true;
   }
 
-  /// The spec form of this rule, as `--entry-point` would take it.
+  /// The spec form, as `--entry-point` takes it.
   @override
   String toString() => filePattern == null ? name : '$filePattern:$name';
 }
 
-/// The built-in conventions followed by a project's own rules.
-///
-/// A declaration is matched against every rule in turn and the first hit wins;
-/// the order only decides which [EntryPoint.reason] `--verbose` shows.
+/// [EntryPoint.builtIn] followed by a project's own rules; the first match
+/// wins.
 final class EntryPoints {
-  /// Creates the rule set: [EntryPoint.builtIn] plus [extra].
   EntryPoints(List<EntryPoint> extra)
     : _rules = [...EntryPoint.builtIn, ...extra];
 
   final List<EntryPoint> _rules;
 
-  /// The first rule [symbol] satisfies, or `null` when it is an ordinary
-  /// declaration. See [EntryPoint.matches] for the arguments.
+  /// The first rule [symbol] meets, or `null` for an ordinary declaration.
   EntryPoint? match(
     String relativePath,
     DocumentSymbol symbol,

--- a/lib/src/finder.dart
+++ b/lib/src/finder.dart
@@ -13,6 +13,7 @@ import 'dart:io';
 
 import 'package:ciach/src/candidates.dart';
 import 'package:ciach/src/concurrency.dart';
+import 'package:ciach/src/conventions/entry_points.dart';
 import 'package:ciach/src/conventions/flutter_widgets.dart';
 import 'package:ciach/src/conventions/freezed.dart';
 import 'package:ciach/src/conventions/serialization.dart';
@@ -39,8 +40,8 @@ import 'package:pro_lsp/pro_lsp.dart' show DocumentSymbol, Location;
 /// `Ciach` owns the pipeline (discover → collect → check references → report);
 /// the semantic pieces live in collaborators: [ReferenceClassifier] decides
 /// used/unused, [RemoveSafety] flags findings that can't be auto-removed, and
-/// the `conventions/` rules ([FreezedUnions], serialization and Flutter
-/// widgets) keep framework-driven declarations alive.
+/// the `conventions/` rules ([EntryPoints], [FreezedUnions], serialization and
+/// Flutter widgets) keep framework-driven declarations alive.
 class Ciach {
   /// Creates a finder that runs with the given [options].
   Ciach(this.options);
@@ -54,6 +55,13 @@ class Ciach {
 
   /// Freezed-union tracking, fed as candidates are collected.
   final _freezed = FreezedUnions();
+
+  /// The built-in and project-declared entry points, which are never
+  /// candidates.
+  late final _entryPoints = EntryPoints(options.entryPoints);
+
+  /// Declarations left out as entry points this run, for `--verbose`.
+  final _skippedEntryPoints = <_SkippedEntryPoint>[];
 
   late final _classifier = ReferenceClassifier(
     _sources,
@@ -132,10 +140,11 @@ class Ciach {
       final perFile = await mapPooled(
         files,
         options.concurrency,
-        (path) => _collectCandidatesFor(client, path),
+        (path) => _collectCandidatesFor(client, path, rootPath),
       );
       final candidates = [for (final list in perFile) ...list];
       declarationsChecked = candidates.length;
+      _reportSkippedEntryPoints();
 
       // Phase 2: check references for every candidate through a single global
       // pool, so the server stays saturated instead of stalling between files.
@@ -450,10 +459,32 @@ class Ciach {
     return true;
   }
 
+  /// Narrates, one line each, the declarations skipped as entry points other
+  /// than `main` — too common to be worth a line, and never a surprise.
+  void _reportSkippedEntryPoints() {
+    if (options.onProgress == null) {
+      return;
+    }
+    _skippedEntryPoints.sort((a, b) {
+      final byFile = a.path.compareTo(b.path);
+      return byFile != 0 ? byFile : a.line.compareTo(b.line);
+    });
+    for (final skipped in _skippedEntryPoints) {
+      if (skipped.rule.name == 'main') {
+        continue;
+      }
+      _report(
+        'Skipped ${skipped.path}:${skipped.line} ${skipped.rule.name}: '
+        '${skipped.rule.reason} (entry point ${skipped.rule}).',
+      );
+    }
+  }
+
   /// Fetches the symbols for [path] and returns the declarations worth checking.
   Future<List<Candidate>> _collectCandidatesFor(
     LspClient client,
     String path,
+    String rootPath,
   ) async {
     final content = SourceIndex.readFile(path);
     if (content == null) {
@@ -467,6 +498,7 @@ class Ciach {
     _collectCandidates(
       uri,
       path,
+      relativePosix(path, rootPath),
       symbols,
       null,
       null,
@@ -485,6 +517,7 @@ class Ciach {
   void _collectCandidates(
     Uri uri,
     String path,
+    String relativePath,
     List<DocumentSymbol> symbols,
     String? container,
     DocumentSymbol? containerSymbol,
@@ -494,7 +527,13 @@ class Ciach {
   ) {
     for (final symbol in symbols) {
       _freezed.noteIfAnnotated(path, symbol, strippedLines);
-      if (_shouldConsider(symbol, parentIsEnum, strippedLines)) {
+      if (_shouldConsider(
+        relativePath,
+        symbol,
+        container,
+        parentIsEnum,
+        strippedLines,
+      )) {
         out.add(
           Candidate(
             uri: uri,
@@ -516,6 +555,7 @@ class Ciach {
       _collectCandidates(
         uri,
         path,
+        relativePath,
         symbol.children ?? const [],
         isTypeLike ? symbol.name : container,
         isTypeLike ? symbol : containerSymbol,
@@ -527,7 +567,9 @@ class Ciach {
   }
 
   bool _shouldConsider(
+    String relativePath,
     DocumentSymbol symbol,
+    String? container,
     bool parentIsEnum,
     List<String> strippedLines,
   ) {
@@ -536,8 +578,14 @@ class Ciach {
     )) {
       return false;
     }
-    // The program entry point is never "unused".
-    if (symbol.kind == .function && symbol.name == 'main') {
+    // A framework or tool calls it without a source reference: `main`, or a
+    // convention such as `testExecutable` in `flutter_test_config.dart`.
+    if (_entryPoints.match(relativePath, symbol, container) case final rule?) {
+      _skippedEntryPoints.add((
+        path: relativePath,
+        line: symbol.selectionRange.start.line + 1,
+        rule: rule,
+      ));
       return false;
     }
     if (!isPrivateName(symbol.name) && !options.includePublic) {
@@ -614,3 +662,7 @@ class Ciach {
     return byLine != 0 ? byLine : a.column.compareTo(b.column);
   }
 }
+
+/// A declaration the candidate filter left out as an entry point: where it is
+/// (POSIX path relative to the root, one-based line) and the rule it met.
+typedef _SkippedEntryPoint = ({String path, int line, EntryPoint rule});

--- a/lib/src/finder.dart
+++ b/lib/src/finder.dart
@@ -56,11 +56,9 @@ class Ciach {
   /// Freezed-union tracking, fed as candidates are collected.
   final _freezed = FreezedUnions();
 
-  /// The built-in and project-declared entry points, which are never
-  /// candidates.
   late final _entryPoints = EntryPoints(options.entryPoints);
 
-  /// Declarations left out as entry points this run, for `--verbose`.
+  /// Skipped as entry points this run, for `--verbose`.
   final _skippedEntryPoints = <_SkippedEntryPoint>[];
 
   late final _classifier = ReferenceClassifier(
@@ -459,8 +457,7 @@ class Ciach {
     return true;
   }
 
-  /// Narrates, one line each, the declarations skipped as entry points other
-  /// than `main` — too common to be worth a line, and never a surprise.
+  /// One line per skipped entry point, except the ubiquitous `main`.
   void _reportSkippedEntryPoints() {
     if (options.onProgress == null) {
       return;
@@ -578,8 +575,7 @@ class Ciach {
     )) {
       return false;
     }
-    // A framework or tool calls it without a source reference: `main`, or a
-    // convention such as `testExecutable` in `flutter_test_config.dart`.
+    // Called by a framework or tool, with no source reference to find.
     if (_entryPoints.match(relativePath, symbol, container) case final rule?) {
       _skippedEntryPoints.add((
         path: relativePath,
@@ -663,6 +659,5 @@ class Ciach {
   }
 }
 
-/// A declaration the candidate filter left out as an entry point: where it is
-/// (POSIX path relative to the root, one-based line) and the rule it met.
+/// A skipped entry point: root-relative POSIX path, one-based line, rule met.
 typedef _SkippedEntryPoint = ({String path, int line, EntryPoint rule});

--- a/lib/src/finder.dart
+++ b/lib/src/finder.dart
@@ -61,6 +61,11 @@ class Ciach {
   /// Skipped as entry points this run, for `--verbose`.
   final _skippedEntryPoints = <_SkippedEntryPoint>[];
 
+  /// Types whose member is an entry point, by `(relative path, type name)`:
+  /// the generated call that reaches `MyPlugin.registerWith` names `MyPlugin`
+  /// too, so the type is not a candidate either.
+  final _entryPointContainers = <DeclKey, EntryPoint>{};
+
   late final _classifier = ReferenceClassifier(
     _sources,
     unusedUnionMembers: options.unusedUnionMembers,
@@ -467,12 +472,12 @@ class Ciach {
       return byFile != 0 ? byFile : a.line.compareTo(b.line);
     });
     for (final skipped in _skippedEntryPoints) {
-      if (skipped.rule.name == 'main') {
+      if (skipped.name == 'main') {
         continue;
       }
       _report(
-        'Skipped ${skipped.path}:${skipped.line} ${skipped.rule.name}: '
-        '${skipped.rule.reason}.',
+        'Skipped ${skipped.path}:${skipped.line} ${skipped.name}: '
+        '${skipped.reason}.',
       );
     }
   }
@@ -491,11 +496,12 @@ class Ciach {
     client.didOpen(uri, content);
     final symbols = await client.documentSymbol(uri);
     _sources.cacheLines(path, content.split('\n'));
+    final relativePath = relativePosix(path, rootPath);
     final out = <Candidate>[];
     _collectCandidates(
       uri,
       path,
-      relativePosix(path, rootPath),
+      relativePath,
       symbols,
       null,
       null,
@@ -503,7 +509,37 @@ class Ciach {
       _sources.strippedLines(path),
       out,
     );
-    return out;
+    return _withoutEntryPointContainers(out, relativePath);
+  }
+
+  /// [candidates] less the types a member entry point lives in; see
+  /// [_entryPointContainers]. Their other members stay candidates.
+  List<Candidate> _withoutEntryPointContainers(
+    List<Candidate> candidates,
+    String relativePath,
+  ) {
+    if (_entryPointContainers.isEmpty) {
+      return candidates;
+    }
+    final kept = <Candidate>[];
+    for (final candidate in candidates) {
+      final symbol = candidate.symbol;
+      final rule =
+          candidate.container == null && typeLikeKinds.contains(symbol.kind)
+          ? _entryPointContainers[DeclKey(relativePath, symbol.name)]
+          : null;
+      if (rule == null) {
+        kept.add(candidate);
+        continue;
+      }
+      _skippedEntryPoints.add((
+        path: relativePath,
+        line: symbol.selectionRange.start.line + 1,
+        name: symbol.name,
+        reason: 'declares the entry point ${rule.name}',
+      ));
+    }
+    return kept;
   }
 
   /// Recursively walks the symbol tree, keeping only symbols worth checking,
@@ -580,8 +616,15 @@ class Ciach {
       _skippedEntryPoints.add((
         path: relativePath,
         line: symbol.selectionRange.start.line + 1,
-        rule: rule,
+        name: rule.name,
+        reason: rule.reason,
       ));
+      if (container != null) {
+        _entryPointContainers.putIfAbsent(
+          DeclKey(relativePath, container),
+          () => rule,
+        );
+      }
       return false;
     }
     if (!isPrivateName(symbol.name) && !options.includePublic) {
@@ -659,5 +702,11 @@ class Ciach {
   }
 }
 
-/// A skipped entry point: root-relative POSIX path, one-based line, rule met.
-typedef _SkippedEntryPoint = ({String path, int line, EntryPoint rule});
+/// A skipped entry point: root-relative POSIX path, one-based line, the name
+/// as the rule spells it, and why.
+typedef _SkippedEntryPoint = ({
+  String path,
+  int line,
+  String name,
+  String reason,
+});

--- a/lib/src/finder.dart
+++ b/lib/src/finder.dart
@@ -472,7 +472,7 @@ class Ciach {
       }
       _report(
         'Skipped ${skipped.path}:${skipped.line} ${skipped.rule.name}: '
-        '${skipped.rule.reason} (entry point ${skipped.rule}).',
+        '${skipped.rule.reason}.',
       );
     }
   }

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -114,11 +114,8 @@ class FinderOptions {
   /// and would flag a live serializer. Enable to audit genuinely-dead `toJson`s.
   final bool reportToJson;
 
-  /// Declarations this project's frameworks or tools invoke by convention, with
-  /// no source reference for the search to find, on top of the conventions
-  /// ciach always applies ([EntryPoint.builtIn]: `main`, and `testExecutable`
-  /// in a `flutter_test_config.dart`). A declaration matching one is never a
-  /// candidate, so it is neither reported nor removed.
+  /// The project's own entry points, on top of [EntryPoint.builtIn]. A match
+  /// is never a candidate, so it is neither reported nor removed.
   final List<EntryPoint> entryPoints;
 
   /// How many `textDocument/references` requests to keep in flight at once.

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -8,6 +8,7 @@
  *     - mark-ai-provenance
  */
 
+import 'package:ciach/src/conventions/entry_points.dart';
 import 'package:pro_lsp/pro_lsp.dart' show SymbolKind;
 
 /// A `[start, end)` span within a file, using 0-based line/column positions
@@ -44,6 +45,7 @@ class FinderOptions {
     this.skipOperators = true,
     this.unusedUnionMembers = false,
     this.reportToJson = false,
+    this.entryPoints = const [],
     this.concurrency = 16,
     this.dartExecutable,
     this.onProgress,
@@ -111,6 +113,13 @@ class FinderOptions {
   /// source-level `.toJson()` token, so the reference search can't see that use
   /// and would flag a live serializer. Enable to audit genuinely-dead `toJson`s.
   final bool reportToJson;
+
+  /// Declarations this project's frameworks or tools invoke by convention, with
+  /// no source reference for the search to find, on top of the conventions
+  /// ciach always applies ([EntryPoint.builtIn]: `main`, and `testExecutable`
+  /// in a `flutter_test_config.dart`). A declaration matching one is never a
+  /// candidate, so it is neither reported nor removed.
+  final List<EntryPoint> entryPoints;
 
   /// How many `textDocument/references` requests to keep in flight at once.
   /// Higher values keep the analysis server busier; there are diminishing

--- a/test/config_test.dart
+++ b/test/config_test.dart
@@ -58,6 +58,9 @@ include:
   - 'lib/**'
 generated-suffix:
   - .gc.dart
+entry-point:
+  - 'lib/**_plugin.dart:registerWith'
+  - bootstrap
 kinds: [class, function]
 format: github
 color: true
@@ -78,6 +81,10 @@ dart: /sdk/bin/dart
       expect(resolved.force, isTrue);
       expect(resolved.excludeGlobs, ['test/**', 'tool/**']);
       expect(resolved.includeGlobs, ['lib/**']);
+      expect(resolved.entryPoints.map((e) => '$e'), [
+        'lib/**_plugin.dart:registerWith',
+        'bootstrap',
+      ]);
       expect(resolved.additionalGeneratedSuffixes, ['.gc.dart']);
       expect(resolved.kinds, <SymbolKind>{.class$, .function});
       expect(resolved.format, 'github');
@@ -200,6 +207,22 @@ concurrency: 4
         throwsA(
           isFormatException('ciach.yaml', contains("Unknown kind 'klass'")),
         ),
+      );
+    });
+
+    test('rejects a malformed entry point, naming it', () {
+      expect(
+        () => resolveFile("entry-point: ['lib/**:']"),
+        throwsA(
+          isFormatException(
+            'ciach.yaml',
+            allOf(contains("'entry-point'"), contains('names no declaration')),
+          ),
+        ),
+      );
+      expect(
+        () => resolveFile('entry-point: [1]'),
+        throwsA(isFormatException('ciach.yaml', contains('a list of strings'))),
       );
     });
 
@@ -464,10 +487,18 @@ dart: /sdk/bin/dart
         '.gc.dart',
         '--generated-suffix',
         '.pb.dart',
+        '--entry-point',
+        'bootstrap',
+        '--entry-point',
+        'lib/**_plugin.dart:registerWith',
       ]);
 
       expect(resolved.excludeGlobs, ['test/**', 'tool/**']);
       expect(resolved.additionalGeneratedSuffixes, ['.gc.dart', '.pb.dart']);
+      expect(resolved.entryPoints.map((e) => '$e'), [
+        'bootstrap',
+        'lib/**_plugin.dart:registerWith',
+      ]);
     });
 
     test('explicitly passing a flag at its default value still wins', () {
@@ -568,6 +599,13 @@ dart: /sdk/bin/dart
       );
     });
 
+    test('rejects a malformed --entry-point', () {
+      expect(
+        () => resolve(const ['--entry-point', 'a-b']),
+        throwsA(isUsageException(contains('not a declaration name'))),
+      );
+    });
+
     test('rejects an unknown --kinds value', () {
       expect(
         () => resolve(const ['-k', 'klass']),
@@ -599,6 +637,8 @@ dart: /sdk/bin/dart
         'test/**',
         '-j',
         '4',
+        '--entry-point',
+        'bootstrap',
       ]);
       final options = resolved.finderOptions();
 
@@ -608,6 +648,7 @@ dart: /sdk/bin/dart
       expect(options.skipOverrides, isFalse);
       expect(options.skipOperators, isTrue);
       expect(options.excludeGlobs, ['test/**']);
+      expect(options.entryPoints.map((e) => '$e'), ['bootstrap']);
       expect(options.concurrency, 4);
       expect(options.onProgress, isNull);
     });

--- a/test/config_test.dart
+++ b/test/config_test.dart
@@ -58,9 +58,10 @@ include:
   - 'lib/**'
 generated-suffix:
   - .gc.dart
-entry-point:
-  - 'lib/**_plugin.dart:registerWith'
-  - bootstrap
+entry-points:
+  registerWith: 'lib/**_plugin.dart'
+  bootstrap:
+  Harness.start: [test/a.dart, test/b.dart]
 kinds: [class, function]
 format: github
 color: true
@@ -82,8 +83,9 @@ dart: /sdk/bin/dart
       expect(resolved.excludeGlobs, ['test/**', 'tool/**']);
       expect(resolved.includeGlobs, ['lib/**']);
       expect(resolved.entryPoints.map((e) => '$e'), [
-        'lib/**_plugin.dart:registerWith',
+        'registerWith in lib/**_plugin.dart',
         'bootstrap',
+        'Harness.start in test/a.dart or test/b.dart',
       ]);
       expect(resolved.additionalGeneratedSuffixes, ['.gc.dart']);
       expect(resolved.kinds, <SymbolKind>{.class$, .function});
@@ -97,11 +99,13 @@ dart: /sdk/bin/dart
     });
 
     test('covers every command-line option', () {
-      // Anything settable on the command line is settable in the file.
+      // Anything settable on the command line is settable in the file. The
+      // other way round holds too, but for the `entry-points` map, which has
+      // no command-line spelling.
       final cliOnly = {'help', 'version', 'config', 'no-config'};
       final optionNames = parser.options.keys.toSet().difference(cliOnly);
 
-      expect(configKeys.difference({'path'}), optionNames);
+      expect(configKeys.difference({'path', 'entry-points'}), optionNames);
     });
 
     test('settings lists what the file sets, and only that', () {
@@ -210,20 +214,21 @@ concurrency: 4
       );
     });
 
-    test('rejects a malformed entry point, naming it', () {
-      expect(
-        () => resolveFile("entry-point: ['lib/**:']"),
-        throwsA(
-          isFormatException(
-            'ciach.yaml',
-            allOf(contains("'entry-point'"), contains('names no declaration')),
-          ),
-        ),
-      );
-      expect(
-        () => resolveFile('entry-point: [1]'),
-        throwsA(isFormatException('ciach.yaml', contains('a list of strings'))),
-      );
+    test('rejects a malformed entry point, naming the key', () {
+      final cases = {
+        'entry-points: [a]': 'a map of declaration names',
+        'entry-points: {a-b: }': 'not a declaration name',
+        'entry-points: {foo: 1}': "'entry-points.foo' must be a file glob",
+        'entry-points: {foo: [1]}': "'entry-points.foo' must be a file glob",
+        "entry-points: {foo: 'lib/['}": 'not a valid glob',
+      };
+      for (final MapEntry(key: source, value: message) in cases.entries) {
+        expect(
+          () => resolveFile(source),
+          throwsA(isFormatException('ciach.yaml', contains(message))),
+          reason: 'for $source',
+        );
+      }
     });
 
     test('rejects a non-positive concurrency', () {
@@ -241,7 +246,7 @@ concurrency: 4
     test('checks the type of every key, even one the argv overrides', () {
       // Every option is given on the command line below, so only the eager
       // check when the file is parsed can still catch the bad value. A map fits
-      // no setting, so it is the one wrong value that works for every key.
+      // no setting but `entry-points`, which gets a number instead.
       const everyOption = [
         '--public',
         '--generated',
@@ -276,10 +281,13 @@ concurrency: 4
         expect(
           () => resolve(
             everyOption,
-            .parse('$key: {a: b}', origin: 'ciach.yaml'),
+            .parse(
+              key == 'entry-points' ? '$key: 42' : '$key: {a: b}',
+              origin: 'ciach.yaml',
+            ),
           ),
           throwsA(isFormatException('ciach.yaml', contains("'$key'"))),
-          reason: 'for a map under $key',
+          reason: 'for a wrong value under $key',
         );
       }
     });
@@ -487,18 +495,10 @@ dart: /sdk/bin/dart
         '.gc.dart',
         '--generated-suffix',
         '.pb.dart',
-        '--entry-point',
-        'bootstrap',
-        '--entry-point',
-        'lib/**_plugin.dart:registerWith',
       ]);
 
       expect(resolved.excludeGlobs, ['test/**', 'tool/**']);
       expect(resolved.additionalGeneratedSuffixes, ['.gc.dart', '.pb.dart']);
-      expect(resolved.entryPoints.map((e) => '$e'), [
-        'bootstrap',
-        'lib/**_plugin.dart:registerWith',
-      ]);
     });
 
     test('explicitly passing a flag at its default value still wins', () {
@@ -599,13 +599,6 @@ dart: /sdk/bin/dart
       );
     });
 
-    test('rejects a malformed --entry-point', () {
-      expect(
-        () => resolve(const ['--entry-point', 'a-b']),
-        throwsA(isUsageException(contains('not a declaration name'))),
-      );
-    });
-
     test('rejects an unknown --kinds value', () {
       expect(
         () => resolve(const ['-k', 'klass']),
@@ -637,9 +630,7 @@ dart: /sdk/bin/dart
         'test/**',
         '-j',
         '4',
-        '--entry-point',
-        'bootstrap',
-      ]);
+      ], .parse('entry-points: {bootstrap: }', origin: 'ciach.yaml'));
       final options = resolved.finderOptions();
 
       expect(options.rootPath, p.normalize(p.absolute('.')));

--- a/test/config_test.dart
+++ b/test/config_test.dart
@@ -59,9 +59,11 @@ include:
 generated-suffix:
   - .gc.dart
 entry-points:
-  registerWith: 'lib/**_plugin.dart'
-  bootstrap:
-  Harness.start: [test/a.dart, test/b.dart]
+  - name: registerWith
+    glob: 'lib/**_plugin.dart'
+  - name: bootstrap
+  - name: Harness.start
+    glob: [test/a.dart, test/b.dart]
 kinds: [class, function]
 format: github
 color: true
@@ -100,7 +102,7 @@ dart: /sdk/bin/dart
 
     test('covers every command-line option', () {
       // Anything settable on the command line is settable in the file. The
-      // other way round holds too, but for the `entry-points` map, which has
+      // other way round holds too, but for the `entry-points` list, which has
       // no command-line spelling.
       final cliOnly = {'help', 'version', 'config', 'no-config'};
       final optionNames = parser.options.keys.toSet().difference(cliOnly);
@@ -216,11 +218,17 @@ concurrency: 4
 
     test('rejects a malformed entry point, naming the key', () {
       final cases = {
-        'entry-points: [a]': 'a map of declaration names',
-        'entry-points: {a-b: }': 'not a declaration name',
-        'entry-points: {foo: 1}': "'entry-points.foo' must be a file glob",
-        'entry-points: {foo: [1]}': "'entry-points.foo' must be a file glob",
-        "entry-points: {foo: 'lib/['}": 'not a valid glob',
+        'entry-points: {name: a}': 'a list of entry points',
+        'entry-points: [a]': "'entry-points[0]' must be a map",
+        'entry-points: [{glob: lib/**}]': "'entry-points[0].name' must be",
+        'entry-points: [{name: 1}]': "'entry-points[0].name' must be",
+        'entry-points: [{name: a-b}]': 'not a declaration name',
+        'entry-points: [{name: a, glob: 1}]': "'entry-points[0].glob' must be",
+        'entry-points: [{name: a, glob: [1]}]':
+            "'entry-points[0].glob' must be",
+        "entry-points: [{name: a, glob: 'lib/['}]": 'not a valid glob',
+        'entry-points: [{name: a}, {name: b, file: x}]':
+            "'entry-points[1]' has an unknown field 'file'",
       };
       for (final MapEntry(key: source, value: message) in cases.entries) {
         expect(
@@ -246,7 +254,7 @@ concurrency: 4
     test('checks the type of every key, even one the argv overrides', () {
       // Every option is given on the command line below, so only the eager
       // check when the file is parsed can still catch the bad value. A map fits
-      // no setting but `entry-points`, which gets a number instead.
+      // no setting, so it is the one wrong value that works for every key.
       const everyOption = [
         '--public',
         '--generated',
@@ -281,10 +289,7 @@ concurrency: 4
         expect(
           () => resolve(
             everyOption,
-            .parse(
-              key == 'entry-points' ? '$key: 42' : '$key: {a: b}',
-              origin: 'ciach.yaml',
-            ),
+            .parse('$key: {a: b}', origin: 'ciach.yaml'),
           ),
           throwsA(isFormatException('ciach.yaml', contains("'$key'"))),
           reason: 'for a wrong value under $key',
@@ -630,7 +635,7 @@ dart: /sdk/bin/dart
         'test/**',
         '-j',
         '4',
-      ], .parse('entry-points: {bootstrap: }', origin: 'ciach.yaml'));
+      ], .parse('entry-points: [{name: bootstrap}]', origin: 'ciach.yaml'));
       final options = resolved.finderOptions();
 
       expect(options.rootPath, p.normalize(p.absolute('.')));

--- a/test/entry_points_test.dart
+++ b/test/entry_points_test.dart
@@ -3,12 +3,8 @@ import 'package:pro_lsp/pro_lsp.dart';
 import 'package:test/test.dart';
 
 void main() {
-  /// A symbol as the server reports it: [detail] is the parameter list.
-  DocumentSymbol symbol(
-    String name, {
-    SymbolKind kind = .function,
-    String? detail,
-  }) {
+  /// A symbol as the server reports it; the shape is irrelevant to the rules.
+  DocumentSymbol symbol(String name, {SymbolKind kind = .function}) {
     const range = Range(
       start: Position(line: 0, character: 0),
       end: Position(line: 0, character: 0),
@@ -18,27 +14,35 @@ void main() {
       kind: kind,
       range: range,
       selectionRange: range,
-      detail: detail,
     );
   }
 
-  group('EntryPoint.parse', () {
-    test('a bare name matches in any file', () {
-      final rule = EntryPoint.parse('bootstrap');
+  group('EntryPoint.project', () {
+    test('a bare name matches in any file, whatever the kind', () {
+      final rule = EntryPoint.project('bootstrap');
 
-      expect(rule.name, 'bootstrap');
-      expect(rule.filePattern, isNull);
+      expect(rule.files, isEmpty);
       expect(rule.matches('lib/a.dart', symbol('bootstrap'), null), isTrue);
       expect(rule.matches('bin/b.dart', symbol('bootstrap'), null), isTrue);
+      expect(
+        rule.matches('lib/a.dart', symbol('bootstrap', kind: .variable), null),
+        isTrue,
+      );
       expect(rule.matches('lib/a.dart', symbol('bootstrapped'), null), isFalse);
     });
 
-    test('a glob narrows the file', () {
-      final rule = EntryPoint.parse('lib/**_plugin.dart:registerWith');
+    test('globs narrow the file, any of them matching', () {
+      final rule = EntryPoint.project(
+        'registerWith',
+        files: ['lib/**_plugin.dart', 'bin/**'],
+      );
 
-      expect(rule.filePattern, 'lib/**_plugin.dart');
       expect(
         rule.matches('lib/src/my_plugin.dart', symbol('registerWith'), null),
+        isTrue,
+      );
+      expect(
+        rule.matches('bin/tool.dart', symbol('registerWith'), null),
         isTrue,
       );
       expect(
@@ -48,80 +52,44 @@ void main() {
     });
 
     test('a qualified name matches a member of that container only', () {
-      final rule = EntryPoint.parse('MyPlugin.registerWith');
+      final rule = EntryPoint.project('MyPlugin.registerWith');
+      final member = symbol('registerWith', kind: .method);
 
-      expect(
-        rule.matches(
-          'lib/a.dart',
-          symbol('registerWith', kind: .method),
-          'MyPlugin',
-        ),
-        isTrue,
-      );
-      expect(
-        rule.matches(
-          'lib/a.dart',
-          symbol('registerWith', kind: .method),
-          'Other',
-        ),
-        isFalse,
-      );
+      expect(rule.matches('lib/a.dart', member, 'MyPlugin'), isTrue);
+      expect(rule.matches('lib/a.dart', member, 'Other'), isFalse);
       expect(rule.matches('lib/a.dart', symbol('registerWith'), null), isFalse);
     });
 
-    test('a parsed rule accepts any kind and signature', () {
-      final rule = EntryPoint.parse('handler');
+    test('a bare name never matches a member', () {
+      final rule = EntryPoint.project('registerWith');
 
-      expect(rule.kind, isNull);
       expect(
-        rule.matches('x.dart', symbol('handler', kind: .variable), null),
-        isTrue,
-      );
-      expect(
-        rule.matches(
-          'x.dart',
-          symbol('handler', detail: '(int a, String b)'),
-          null,
-        ),
-        isTrue,
+        rule.matches('lib/a.dart', symbol('registerWith', kind: .method), 'P'),
+        isFalse,
       );
     });
 
-    test('trims whitespace and prints back as the spec', () {
-      expect('${EntryPoint.parse(' test/**:setUpAll ')}', 'test/**:setUpAll');
-      expect('${EntryPoint.parse('bootstrap')}', 'bootstrap');
-    });
-
-    test('rejects an empty name', () {
-      for (final spec in ['', '   ', 'lib/**:', 'lib/**:  ']) {
-        expect(
-          () => EntryPoint.parse(spec),
-          throwsA(isFormatException(contains('names no declaration'))),
-          reason: "for '$spec'",
-        );
-      }
+    test('prints as the name and its files', () {
+      expect('${EntryPoint.project('bootstrap')}', 'bootstrap');
+      expect(
+        '${EntryPoint.project('run', files: ['a/**', 'b/**'])}',
+        'run in a/** or b/**',
+      );
     });
 
     test('rejects a name that is not an identifier', () {
-      for (final name in ['a-b', '1abc', 'a.b.c', 'a b', 'A.']) {
+      for (final name in ['', 'a-b', '1abc', 'a.b.c', 'a b', 'A.']) {
         expect(
-          () => EntryPoint.parse(name),
+          () => EntryPoint.project(name),
           throwsA(isFormatException(contains('not a declaration name'))),
           reason: "for '$name'",
         );
       }
     });
 
-    test('rejects an empty glob rather than silently matching nothing', () {
-      expect(
-        () => EntryPoint.parse(':main'),
-        throwsA(isFormatException(contains('empty file glob'))),
-      );
-    });
-
     test('rejects an invalid glob, naming it', () {
       expect(
-        () => EntryPoint.parse('lib/[:x'),
+        () => EntryPoint.project('x', files: ['lib/[']),
         throwsA(isFormatException(contains("'lib/[' is not a valid glob"))),
       );
     });
@@ -130,73 +98,48 @@ void main() {
   group('built-in conventions', () {
     final rules = EntryPoints(const []);
 
-    test('main is an entry point in every file, as a function only', () {
+    test('main is an entry point in every file, but not as a member', () {
       expect(rules.match('bin/app.dart', symbol('main'), null)?.name, 'main');
       expect(rules.match('test/a_test.dart', symbol('main'), null), isNotNull);
-      // A `main` method or field is an ordinary declaration.
       expect(
         rules.match('lib/a.dart', symbol('main', kind: .method), 'Runner'),
-        isNull,
-      );
-      expect(
-        rules.match('lib/a.dart', symbol('main', kind: .variable), null),
         isNull,
       );
     });
 
     group('testExecutable', () {
-      const detail = '(FutureOr<void> Function() testMain)';
-
-      test('in a flutter_test_config.dart with the bootstrap signature', () {
+      test('in a flutter_test_config.dart at any depth', () {
         for (final path in [
           'test/flutter_test_config.dart',
           'flutter_test_config.dart',
           'integration_test/nested/flutter_test_config.dart',
         ]) {
-          final rule = rules.match(
-            path,
-            symbol('testExecutable', detail: detail),
-            null,
-          );
+          final rule = rules.match(path, symbol('testExecutable'), null);
           expect(rule?.name, 'testExecutable', reason: 'for $path');
           expect(rule?.reason, contains('flutter test'));
         }
       });
 
-      test('is not exempt in any other file', () {
+      test('whatever its shape — the bootstrap calls it regardless', () {
         expect(
           rules.match(
-            'test/test_config.dart',
-            symbol('testExecutable', detail: detail),
+            'test/flutter_test_config.dart',
+            symbol('testExecutable', kind: .variable),
             null,
           ),
-          isNull,
-        );
-        expect(
-          rules.match(
-            'test/my_flutter_test_config.dart',
-            symbol('testExecutable', detail: detail),
-            null,
-          ),
-          isNull,
+          isNotNull,
         );
       });
 
-      test('is not exempt with a shape the bootstrap could not call', () {
-        for (final wrong in [
-          '()',
-          '(int retries)',
-          '(Function() a, int b)',
-          null,
+      test('is not exempt in any other file', () {
+        for (final path in [
+          'test/test_config.dart',
+          'test/my_flutter_test_config.dart',
         ]) {
           expect(
-            rules.match(
-              'test/flutter_test_config.dart',
-              symbol('testExecutable', detail: wrong),
-              null,
-            ),
+            rules.match(path, symbol('testExecutable'), null),
             isNull,
-            reason: 'for $wrong',
+            reason: 'for $path',
           );
         }
       });
@@ -205,7 +148,7 @@ void main() {
         expect(
           rules.match(
             'test/flutter_test_config.dart',
-            symbol('testExecutable', kind: .method, detail: detail),
+            symbol('testExecutable', kind: .method),
             'Config',
           ),
           isNull,
@@ -215,7 +158,9 @@ void main() {
   });
 
   test('a project rule is consulted after the built-in ones', () {
-    final rules = EntryPoints([EntryPoint.parse('tool/**:main')]);
+    final rules = EntryPoints([
+      EntryPoint.project('main', files: ['tool/**']),
+    ]);
 
     expect(
       rules.match('tool/gen.dart', symbol('main'), null)?.reason,
@@ -224,9 +169,9 @@ void main() {
     expect(rules.match('lib/a.dart', symbol('serve'), null), isNull);
     expect(
       EntryPoints([
-        EntryPoint.parse('serve'),
+        EntryPoint.project('serve'),
       ]).match('lib/a.dart', symbol('serve'), null)?.reason,
-      contains('this project'),
+      contains('entry-points'),
     );
   });
 }

--- a/test/entry_points_test.dart
+++ b/test/entry_points_test.dart
@@ -3,8 +3,7 @@ import 'package:pro_lsp/pro_lsp.dart';
 import 'package:test/test.dart';
 
 void main() {
-  /// A symbol as the analysis server reports it: [detail] carries the
-  /// parenthesized parameter list.
+  /// A symbol as the server reports it: [detail] is the parameter list.
   DocumentSymbol symbol(
     String name, {
     SymbolKind kind = .function,
@@ -218,7 +217,6 @@ void main() {
   test('a project rule is consulted after the built-in ones', () {
     final rules = EntryPoints([EntryPoint.parse('tool/**:main')]);
 
-    // Still the built-in `main`, with its reason.
     expect(
       rules.match('tool/gen.dart', symbol('main'), null)?.reason,
       'the program entry point',

--- a/test/entry_points_test.dart
+++ b/test/entry_points_test.dart
@@ -1,0 +1,238 @@
+import 'package:ciach/src/conventions/entry_points.dart';
+import 'package:pro_lsp/pro_lsp.dart';
+import 'package:test/test.dart';
+
+void main() {
+  /// A symbol as the analysis server reports it: [detail] carries the
+  /// parenthesized parameter list.
+  DocumentSymbol symbol(
+    String name, {
+    SymbolKind kind = .function,
+    String? detail,
+  }) {
+    const range = Range(
+      start: Position(line: 0, character: 0),
+      end: Position(line: 0, character: 0),
+    );
+    return DocumentSymbol(
+      name: name,
+      kind: kind,
+      range: range,
+      selectionRange: range,
+      detail: detail,
+    );
+  }
+
+  group('EntryPoint.parse', () {
+    test('a bare name matches in any file', () {
+      final rule = EntryPoint.parse('bootstrap');
+
+      expect(rule.name, 'bootstrap');
+      expect(rule.filePattern, isNull);
+      expect(rule.matches('lib/a.dart', symbol('bootstrap'), null), isTrue);
+      expect(rule.matches('bin/b.dart', symbol('bootstrap'), null), isTrue);
+      expect(rule.matches('lib/a.dart', symbol('bootstrapped'), null), isFalse);
+    });
+
+    test('a glob narrows the file', () {
+      final rule = EntryPoint.parse('lib/**_plugin.dart:registerWith');
+
+      expect(rule.filePattern, 'lib/**_plugin.dart');
+      expect(
+        rule.matches('lib/src/my_plugin.dart', symbol('registerWith'), null),
+        isTrue,
+      );
+      expect(
+        rule.matches('lib/src/my_helper.dart', symbol('registerWith'), null),
+        isFalse,
+      );
+    });
+
+    test('a qualified name matches a member of that container only', () {
+      final rule = EntryPoint.parse('MyPlugin.registerWith');
+
+      expect(
+        rule.matches(
+          'lib/a.dart',
+          symbol('registerWith', kind: .method),
+          'MyPlugin',
+        ),
+        isTrue,
+      );
+      expect(
+        rule.matches(
+          'lib/a.dart',
+          symbol('registerWith', kind: .method),
+          'Other',
+        ),
+        isFalse,
+      );
+      expect(rule.matches('lib/a.dart', symbol('registerWith'), null), isFalse);
+    });
+
+    test('a parsed rule accepts any kind and signature', () {
+      final rule = EntryPoint.parse('handler');
+
+      expect(rule.kind, isNull);
+      expect(
+        rule.matches('x.dart', symbol('handler', kind: .variable), null),
+        isTrue,
+      );
+      expect(
+        rule.matches(
+          'x.dart',
+          symbol('handler', detail: '(int a, String b)'),
+          null,
+        ),
+        isTrue,
+      );
+    });
+
+    test('trims whitespace and prints back as the spec', () {
+      expect('${EntryPoint.parse(' test/**:setUpAll ')}', 'test/**:setUpAll');
+      expect('${EntryPoint.parse('bootstrap')}', 'bootstrap');
+    });
+
+    test('rejects an empty name', () {
+      for (final spec in ['', '   ', 'lib/**:', 'lib/**:  ']) {
+        expect(
+          () => EntryPoint.parse(spec),
+          throwsA(isFormatException(contains('names no declaration'))),
+          reason: "for '$spec'",
+        );
+      }
+    });
+
+    test('rejects a name that is not an identifier', () {
+      for (final name in ['a-b', '1abc', 'a.b.c', 'a b', 'A.']) {
+        expect(
+          () => EntryPoint.parse(name),
+          throwsA(isFormatException(contains('not a declaration name'))),
+          reason: "for '$name'",
+        );
+      }
+    });
+
+    test('rejects an empty glob rather than silently matching nothing', () {
+      expect(
+        () => EntryPoint.parse(':main'),
+        throwsA(isFormatException(contains('empty file glob'))),
+      );
+    });
+
+    test('rejects an invalid glob, naming it', () {
+      expect(
+        () => EntryPoint.parse('lib/[:x'),
+        throwsA(isFormatException(contains("'lib/[' is not a valid glob"))),
+      );
+    });
+  });
+
+  group('built-in conventions', () {
+    final rules = EntryPoints(const []);
+
+    test('main is an entry point in every file, as a function only', () {
+      expect(rules.match('bin/app.dart', symbol('main'), null)?.name, 'main');
+      expect(rules.match('test/a_test.dart', symbol('main'), null), isNotNull);
+      // A `main` method or field is an ordinary declaration.
+      expect(
+        rules.match('lib/a.dart', symbol('main', kind: .method), 'Runner'),
+        isNull,
+      );
+      expect(
+        rules.match('lib/a.dart', symbol('main', kind: .variable), null),
+        isNull,
+      );
+    });
+
+    group('testExecutable', () {
+      const detail = '(FutureOr<void> Function() testMain)';
+
+      test('in a flutter_test_config.dart with the bootstrap signature', () {
+        for (final path in [
+          'test/flutter_test_config.dart',
+          'flutter_test_config.dart',
+          'integration_test/nested/flutter_test_config.dart',
+        ]) {
+          final rule = rules.match(
+            path,
+            symbol('testExecutable', detail: detail),
+            null,
+          );
+          expect(rule?.name, 'testExecutable', reason: 'for $path');
+          expect(rule?.reason, contains('flutter test'));
+        }
+      });
+
+      test('is not exempt in any other file', () {
+        expect(
+          rules.match(
+            'test/test_config.dart',
+            symbol('testExecutable', detail: detail),
+            null,
+          ),
+          isNull,
+        );
+        expect(
+          rules.match(
+            'test/my_flutter_test_config.dart',
+            symbol('testExecutable', detail: detail),
+            null,
+          ),
+          isNull,
+        );
+      });
+
+      test('is not exempt with a shape the bootstrap could not call', () {
+        for (final wrong in [
+          '()',
+          '(int retries)',
+          '(Function() a, int b)',
+          null,
+        ]) {
+          expect(
+            rules.match(
+              'test/flutter_test_config.dart',
+              symbol('testExecutable', detail: wrong),
+              null,
+            ),
+            isNull,
+            reason: 'for $wrong',
+          );
+        }
+      });
+
+      test('is not exempt as a member', () {
+        expect(
+          rules.match(
+            'test/flutter_test_config.dart',
+            symbol('testExecutable', kind: .method, detail: detail),
+            'Config',
+          ),
+          isNull,
+        );
+      });
+    });
+  });
+
+  test('a project rule is consulted after the built-in ones', () {
+    final rules = EntryPoints([EntryPoint.parse('tool/**:main')]);
+
+    // Still the built-in `main`, with its reason.
+    expect(
+      rules.match('tool/gen.dart', symbol('main'), null)?.reason,
+      'the program entry point',
+    );
+    expect(rules.match('lib/a.dart', symbol('serve'), null), isNull);
+    expect(
+      EntryPoints([
+        EntryPoint.parse('serve'),
+      ]).match('lib/a.dart', symbol('serve'), null)?.reason,
+      contains('this project'),
+    );
+  });
+}
+
+/// A [FormatException] whose message matches [message].
+Matcher isFormatException(Matcher message) =>
+    isA<FormatException>().having((e) => e.message, 'message', message);

--- a/test/finder_test.dart
+++ b/test/finder_test.dart
@@ -969,10 +969,10 @@ void main() {
 
       final skipped = lines.where((l) => l.startsWith('Skipped ')).toList();
       const bootstrapLine =
-          'Skipped lib/scenarios/entry_points.dart:27 bootstrap: listed as an '
+          'Skipped lib/scenarios/entry_points.dart:17 bootstrap: listed as an '
           'entry point by this project (entry point bootstrap).';
       const testExecutableLine =
-          'Skipped test/flutter_test_config.dart:8 testExecutable: called by '
+          'Skipped test/flutter_test_config.dart:6 testExecutable: called by '
           'the `flutter test` bootstrap (entry point '
           '**/flutter_test_config.dart:testExecutable).';
       expect(skipped, [bootstrapLine, testExecutableLine]);

--- a/test/finder_test.dart
+++ b/test/finder_test.dart
@@ -915,7 +915,9 @@ void main() {
         // Wrong file.
         'lib/scenarios/entry_points.dart:testExecutable',
         'lib/scenarios/entry_points.dart:integrationMain',
+        'lib/scenarios/entry_points.dart:Plugin',
         'lib/scenarios/entry_points.dart:Plugin.registerWith',
+        'lib/scenarios/entry_points.dart:Plugin.other',
         'lib/scenarios/entry_points.dart:bootstrap',
         // The right file exempts `testExecutable` whatever its shape, and
         // nothing beside it.
@@ -942,13 +944,11 @@ void main() {
 
         expect(located(result), {
           'lib/scenarios/entry_points.dart:testExecutable',
+          // The member rule keeps the type it lives in — the generated call
+          // names it too — but not the type's other members.
+          'lib/scenarios/entry_points.dart:Plugin.other',
           'lib/scenarios/entry_points/flutter_test_config.dart:deadHelperNextToConfig',
         });
-        // `Plugin` is kept alive by `integrationMain`, not by its member's rule.
-        expect(
-          result.unused.map((d) => d.qualifiedName),
-          isNot(contains('Plugin')),
-        );
       },
     );
 
@@ -970,13 +970,22 @@ void main() {
     test('narrates each skipped entry point other than main', () async {
       final lines = <String>[];
       await runEntryPoints(
-        entryPoints: [EntryPoint.project('bootstrap')],
+        entryPoints: [
+          EntryPoint.project('bootstrap'),
+          EntryPoint.project('Plugin.registerWith'),
+        ],
         onProgress: lines.add,
       );
 
       final skipped = lines.where((l) => l.startsWith('Skipped ')).toList();
+      const plugin =
+          'Skipped lib/scenarios/entry_points.dart:14 Plugin: declares the '
+          'entry point Plugin.registerWith.';
+      const registerWith =
+          'Skipped lib/scenarios/entry_points.dart:15 Plugin.registerWith: '
+          'listed under `entry-points` in the config file.';
       const bootstrap =
-          'Skipped lib/scenarios/entry_points.dart:17 bootstrap: listed under '
+          'Skipped lib/scenarios/entry_points.dart:20 bootstrap: listed under '
           '`entry-points` in the config file.';
       const byShape =
           'Skipped lib/scenarios/entry_points/flutter_test_config.dart:4 '
@@ -984,7 +993,7 @@ void main() {
       const real =
           'Skipped test/flutter_test_config.dart:6 testExecutable: called by '
           'the `flutter test` bootstrap.';
-      expect(skipped, [bootstrap, byShape, real]);
+      expect(skipped, [plugin, registerWith, bootstrap, byShape, real]);
       expect(lines, isNot(contains(contains(' main:'))));
     });
   });

--- a/test/finder_test.dart
+++ b/test/finder_test.dart
@@ -13,6 +13,7 @@ library;
 
 import 'dart:io';
 
+import 'package:ciach/src/conventions/entry_points.dart';
 import 'package:ciach/src/finder.dart';
 import 'package:ciach/src/models.dart';
 import 'package:collection/collection.dart';
@@ -49,6 +50,8 @@ void main() {
     // dedicated tests; exclude them from the default-run assertions.
     List<String> exclude = const ['lib/scenarios/**'],
     List<String> include = const [],
+    List<EntryPoint> entryPoints = const [],
+    void Function(String message)? onProgress,
   }) => Ciach(
     .new(
       rootPath: fixturePath,
@@ -58,6 +61,8 @@ void main() {
       kinds: kinds ?? FinderOptions.defaultKinds,
       excludeGlobs: exclude,
       includeGlobs: include,
+      entryPoints: entryPoints,
+      onProgress: onProgress,
     ),
   ).run();
 
@@ -240,6 +245,9 @@ void main() {
     expect(unused, isNot(contains('Vector2')));
     // `main` is an entry point and is always skipped.
     expect(unused, isNot(contains('main')));
+    // So is `testExecutable` in test/flutter_test_config.dart, which only the
+    // `flutter test` bootstrap calls.
+    expect(unused, isNot(contains('testExecutable')));
     // Skipped because it is annotated with @override.
     expect(unused, isNot(contains('Dog.sound')));
   });
@@ -880,6 +888,101 @@ void main() {
         // The fixture's own entry point, which nothing calls.
         'exerciseDotShorthands',
       });
+    });
+  });
+
+  group('entry points', () {
+    Future<FinderResult> runEntryPoints({
+      List<EntryPoint> entryPoints = const [],
+      void Function(String message)? onProgress,
+    }) => runFinder(
+      include: [
+        'lib/scenarios/entry_points.dart',
+        'lib/scenarios/entry_points/**',
+        'test/**',
+      ],
+      exclude: const [],
+      entryPoints: entryPoints,
+      onProgress: onProgress,
+    );
+
+    /// `path:qualifiedName`, since the fixture has two `testExecutable`s.
+    Set<String> located(FinderResult result) => {
+      for (final d in result.unused) '${d.filePath}:${d.qualifiedName}',
+    };
+
+    test('exempts a declaration only when it meets the whole contract', () async {
+      expect(located(await runEntryPoints()), {
+        // Right name and shape, wrong file.
+        'lib/scenarios/entry_points.dart:testExecutable',
+        'lib/scenarios/entry_points.dart:integrationMain',
+        'lib/scenarios/entry_points.dart:Plugin.registerWith',
+        'lib/scenarios/entry_points.dart:bootstrap',
+        // Right file and name, but a shape the bootstrap could not call…
+        'lib/scenarios/entry_points/flutter_test_config.dart:testExecutable',
+        // …and the file name alone exempts nothing beside it.
+        'lib/scenarios/entry_points/flutter_test_config.dart:deadHelperNextToConfig',
+        // The real one in test/flutter_test_config.dart is not here.
+      });
+    });
+
+    test(
+      'a project lists its own, by file and name, member, or bare name',
+      () async {
+        final result = await runEntryPoints(
+          entryPoints: [
+            EntryPoint.parse('lib/scenarios/entry_points.dart:integrationMain'),
+            EntryPoint.parse('**/entry_points.dart:Plugin.registerWith'),
+            EntryPoint.parse('bootstrap'),
+          ],
+        );
+
+        expect(located(result), {
+          'lib/scenarios/entry_points.dart:testExecutable',
+          'lib/scenarios/entry_points/flutter_test_config.dart:testExecutable',
+          'lib/scenarios/entry_points/flutter_test_config.dart:deadHelperNextToConfig',
+        });
+        // The class whose member is an entry point is still reported when it is
+        // itself unreferenced — it is not here only because `integrationMain`
+        // names it.
+        expect(
+          result.unused.map((d) => d.qualifiedName),
+          isNot(contains('Plugin')),
+        );
+      },
+    );
+
+    test(
+      'a project rule with a glob matching no scanned file changes nothing',
+      () async {
+        final result = await runEntryPoints(
+          entryPoints: [EntryPoint.parse('bin/**:bootstrap')],
+        );
+        expect(
+          located(result),
+          contains('lib/scenarios/entry_points.dart:bootstrap'),
+        );
+      },
+    );
+
+    test('narrates each skipped entry point other than main', () async {
+      final lines = <String>[];
+      await runEntryPoints(
+        entryPoints: [EntryPoint.parse('bootstrap')],
+        onProgress: lines.add,
+      );
+
+      final skipped = lines.where((l) => l.startsWith('Skipped ')).toList();
+      const bootstrapLine =
+          'Skipped lib/scenarios/entry_points.dart:27 bootstrap: listed as an '
+          'entry point by this project (entry point bootstrap).';
+      const testExecutableLine =
+          'Skipped test/flutter_test_config.dart:8 testExecutable: called by '
+          'the `flutter test` bootstrap (entry point '
+          '**/flutter_test_config.dart:testExecutable).';
+      expect(skipped, [bootstrapLine, testExecutableLine]);
+      // Every test file has a `main`; a line each would drown the log.
+      expect(lines, isNot(contains(contains(' main:'))));
     });
   });
 

--- a/test/finder_test.dart
+++ b/test/finder_test.dart
@@ -910,15 +910,15 @@ void main() {
       for (final d in result.unused) '${d.filePath}:${d.qualifiedName}',
     };
 
-    test('exempts a declaration only when it meets the whole contract', () async {
+    test('exempts a declaration by file and name only', () async {
       expect(located(await runEntryPoints()), {
         // Wrong file.
         'lib/scenarios/entry_points.dart:testExecutable',
         'lib/scenarios/entry_points.dart:integrationMain',
         'lib/scenarios/entry_points.dart:Plugin.registerWith',
         'lib/scenarios/entry_points.dart:bootstrap',
-        // Wrong signature, and the file name exempts nothing beside it.
-        'lib/scenarios/entry_points/flutter_test_config.dart:testExecutable',
+        // The right file exempts `testExecutable` whatever its shape, and
+        // nothing beside it.
         'lib/scenarios/entry_points/flutter_test_config.dart:deadHelperNextToConfig',
       });
     });
@@ -928,15 +928,20 @@ void main() {
       () async {
         final result = await runEntryPoints(
           entryPoints: [
-            EntryPoint.parse('lib/scenarios/entry_points.dart:integrationMain'),
-            EntryPoint.parse('**/entry_points.dart:Plugin.registerWith'),
-            EntryPoint.parse('bootstrap'),
+            EntryPoint.project(
+              'integrationMain',
+              files: ['lib/scenarios/entry_points.dart'],
+            ),
+            EntryPoint.project(
+              'Plugin.registerWith',
+              files: ['**/entry_points.dart'],
+            ),
+            EntryPoint.project('bootstrap'),
           ],
         );
 
         expect(located(result), {
           'lib/scenarios/entry_points.dart:testExecutable',
-          'lib/scenarios/entry_points/flutter_test_config.dart:testExecutable',
           'lib/scenarios/entry_points/flutter_test_config.dart:deadHelperNextToConfig',
         });
         // `Plugin` is kept alive by `integrationMain`, not by its member's rule.
@@ -948,10 +953,12 @@ void main() {
     );
 
     test(
-      'a project rule with a glob matching no scanned file changes nothing',
+      'a project rule whose globs match no scanned file changes nothing',
       () async {
         final result = await runEntryPoints(
-          entryPoints: [EntryPoint.parse('bin/**:bootstrap')],
+          entryPoints: [
+            EntryPoint.project('bootstrap', files: ['bin/**']),
+          ],
         );
         expect(
           located(result),
@@ -963,19 +970,21 @@ void main() {
     test('narrates each skipped entry point other than main', () async {
       final lines = <String>[];
       await runEntryPoints(
-        entryPoints: [EntryPoint.parse('bootstrap')],
+        entryPoints: [EntryPoint.project('bootstrap')],
         onProgress: lines.add,
       );
 
       final skipped = lines.where((l) => l.startsWith('Skipped ')).toList();
-      const bootstrapLine =
-          'Skipped lib/scenarios/entry_points.dart:17 bootstrap: listed as an '
-          'entry point by this project (entry point bootstrap).';
-      const testExecutableLine =
+      const bootstrap =
+          'Skipped lib/scenarios/entry_points.dart:17 bootstrap: listed under '
+          '`entry-points` in the config file.';
+      const byShape =
+          'Skipped lib/scenarios/entry_points/flutter_test_config.dart:4 '
+          'testExecutable: called by the `flutter test` bootstrap.';
+      const real =
           'Skipped test/flutter_test_config.dart:6 testExecutable: called by '
-          'the `flutter test` bootstrap (entry point '
-          '**/flutter_test_config.dart:testExecutable).';
-      expect(skipped, [bootstrapLine, testExecutableLine]);
+          'the `flutter test` bootstrap.';
+      expect(skipped, [bootstrap, byShape, real]);
       expect(lines, isNot(contains(contains(' main:'))));
     });
   });

--- a/test/finder_test.dart
+++ b/test/finder_test.dart
@@ -245,8 +245,7 @@ void main() {
     expect(unused, isNot(contains('Vector2')));
     // `main` is an entry point and is always skipped.
     expect(unused, isNot(contains('main')));
-    // So is `testExecutable` in test/flutter_test_config.dart, which only the
-    // `flutter test` bootstrap calls.
+    // So is `testExecutable` in test/flutter_test_config.dart.
     expect(unused, isNot(contains('testExecutable')));
     // Skipped because it is annotated with @override.
     expect(unused, isNot(contains('Dog.sound')));
@@ -913,16 +912,14 @@ void main() {
 
     test('exempts a declaration only when it meets the whole contract', () async {
       expect(located(await runEntryPoints()), {
-        // Right name and shape, wrong file.
+        // Wrong file.
         'lib/scenarios/entry_points.dart:testExecutable',
         'lib/scenarios/entry_points.dart:integrationMain',
         'lib/scenarios/entry_points.dart:Plugin.registerWith',
         'lib/scenarios/entry_points.dart:bootstrap',
-        // Right file and name, but a shape the bootstrap could not call…
+        // Wrong signature, and the file name exempts nothing beside it.
         'lib/scenarios/entry_points/flutter_test_config.dart:testExecutable',
-        // …and the file name alone exempts nothing beside it.
         'lib/scenarios/entry_points/flutter_test_config.dart:deadHelperNextToConfig',
-        // The real one in test/flutter_test_config.dart is not here.
       });
     });
 
@@ -942,9 +939,7 @@ void main() {
           'lib/scenarios/entry_points/flutter_test_config.dart:testExecutable',
           'lib/scenarios/entry_points/flutter_test_config.dart:deadHelperNextToConfig',
         });
-        // The class whose member is an entry point is still reported when it is
-        // itself unreferenced — it is not here only because `integrationMain`
-        // names it.
+        // `Plugin` is kept alive by `integrationMain`, not by its member's rule.
         expect(
           result.unused.map((d) => d.qualifiedName),
           isNot(contains('Plugin')),
@@ -981,7 +976,6 @@ void main() {
           'the `flutter test` bootstrap (entry point '
           '**/flutter_test_config.dart:testExecutable).';
       expect(skipped, [bootstrapLine, testExecutableLine]);
-      // Every test file has a `main`; a line each would drown the log.
       expect(lines, isNot(contains(contains(' main:'))));
     });
   });

--- a/test/verbose_test.dart
+++ b/test/verbose_test.dart
@@ -16,7 +16,7 @@ void main() {
       final lines = describeConfigSource(
         .parse(
           "public: false\nexclude: ['test/**']\n"
-          "entry-points: {bootstrap: , registerWith: [lib/**, bin/**]}",
+          'entry-points: {bootstrap: , registerWith: [lib/**, bin/**]}',
           origin: '/c.yaml',
         ),
         projectDir: '/pkg',

--- a/test/verbose_test.dart
+++ b/test/verbose_test.dart
@@ -16,7 +16,7 @@ void main() {
       final lines = describeConfigSource(
         .parse(
           "public: false\nexclude: ['test/**']\n"
-          'entry-points: {bootstrap: , registerWith: [lib/**, bin/**]}',
+          'entry-points: [{name: bootstrap}, {name: registerWith, glob: [lib/**, bin/**]}]',
           origin: '/c.yaml',
         ),
         projectDir: '/pkg',
@@ -27,7 +27,7 @@ void main() {
         '  It sets 3 options:',
         '    public: false',
         '    exclude: test/**',
-        '    entry-points: bootstrap, registerWith: lib/**, bin/**',
+        '    entry-points: {name: bootstrap}, {name: registerWith, glob: lib/**, bin/**}',
       ]);
     });
 
@@ -134,7 +134,7 @@ void main() {
       final configuration = resolveConfiguration(
         parser.parse(const ['--no-public']),
         .parse(
-          'format: json\nremove: true\nentry-points: {registerWith: lib/**}',
+          'format: json\nremove: true\nentry-points: [{name: registerWith, glob: lib/**}]',
           origin: 'c.yaml',
         ),
       );

--- a/test/verbose_test.dart
+++ b/test/verbose_test.dart
@@ -14,15 +14,20 @@ void main() {
   group('describeConfigSource', () {
     test('names the file it read and every option it set', () {
       final lines = describeConfigSource(
-        .parse("public: false\nexclude: ['test/**']", origin: '/c.yaml'),
+        .parse(
+          "public: false\nexclude: ['test/**']\n"
+          "entry-points: {bootstrap: , registerWith: [lib/**, bin/**]}",
+          origin: '/c.yaml',
+        ),
         projectDir: '/pkg',
       );
 
       expect(lines, [
         'Read config from /c.yaml.',
-        '  It sets 2 options:',
+        '  It sets 3 options:',
         '    public: false',
         '    exclude: test/**',
+        '    entry-points: bootstrap, registerWith: lib/**, bin/**',
       ]);
     });
 
@@ -123,16 +128,15 @@ void main() {
       expect(lines, contains('  exclude: test/** (command line)'));
       expect(lines, contains('  concurrency: 4 (command line)'));
       expect(lines, contains('  dart: /sdk/bin/dart (auto-detected)'));
-      expect(
-        describe(const ['--entry-point', 'lib/**:registerWith']),
-        contains('  entry-point: lib/**:registerWith (command line)'),
-      );
     });
 
     test('names the layer each value came from', () {
       final configuration = resolveConfiguration(
         parser.parse(const ['--no-public']),
-        .parse('format: json\nremove: true', origin: 'c.yaml'),
+        .parse(
+          'format: json\nremove: true\nentry-points: {registerWith: lib/**}',
+          origin: 'c.yaml',
+        ),
       );
       final lines = describeSettings(
         configuration,
@@ -147,6 +151,10 @@ void main() {
       expect(lines, contains('  public: false (command line)'));
       expect(lines, contains('  format: json (config file)'));
       expect(lines, contains('  remove: true (config file)'));
+      expect(
+        lines,
+        contains('  entry-points: registerWith in lib/** (config file)'),
+      );
       expect(lines, contains('  concurrency: 16 (default)'));
       expect(lines, contains('  color: false (auto-detected)'));
     });
@@ -157,7 +165,7 @@ void main() {
       expect(lines, contains('  exclude: (none) (default)'));
       expect(lines, contains('  include: (none) (default)'));
       expect(lines, contains('  generated-suffix: (none) (default)'));
-      expect(lines, contains('  entry-point: (none) (default)'));
+      expect(lines, contains('  entry-points: (none) (default)'));
     });
 
     test('lists the kinds, all of them by default', () {

--- a/test/verbose_test.dart
+++ b/test/verbose_test.dart
@@ -123,6 +123,10 @@ void main() {
       expect(lines, contains('  exclude: test/** (command line)'));
       expect(lines, contains('  concurrency: 4 (command line)'));
       expect(lines, contains('  dart: /sdk/bin/dart (auto-detected)'));
+      expect(
+        describe(const ['--entry-point', 'lib/**:registerWith']),
+        contains('  entry-point: lib/**:registerWith (command line)'),
+      );
     });
 
     test('names the layer each value came from', () {
@@ -153,6 +157,7 @@ void main() {
       expect(lines, contains('  exclude: (none) (default)'));
       expect(lines, contains('  include: (none) (default)'));
       expect(lines, contains('  generated-suffix: (none) (default)'));
+      expect(lines, contains('  entry-point: (none) (default)'));
     });
 
     test('lists the kinds, all of them by default', () {

--- a/website/lib/pages/docs_page.dart
+++ b/website/lib/pages/docs_page.dart
@@ -107,8 +107,9 @@ const _skips = [
   ('main', 'The entry point is never unused.', null),
   (
     'testExecutable in flutter_test_config.dart',
-    'Called by the `flutter test` bootstrap, which never lands on disk.',
-    '--entry-point',
+    'Called by the `flutter test` bootstrap, which never lands on disk; '
+        '`entry-points:` in ciach.yaml adds more.',
+    null,
   ),
   (
     '@override members',
@@ -649,8 +650,8 @@ class DocsPage extends StatelessComponent {
                   li(
                     rich(
                       'Entry points other than `main` and `flutter test`’s '
-                      '`testExecutable` need listing with `--entry-point` or '
-                      "`@pragma('vm:entry-point')`.",
+                      '`testExecutable` need listing under `entry-points` in '
+                      "ciach.yaml or `@pragma('vm:entry-point')`.",
                     ),
                   ),
                   li(

--- a/website/lib/pages/docs_page.dart
+++ b/website/lib/pages/docs_page.dart
@@ -106,6 +106,11 @@ const _comparison = [
 const _skips = [
   ('main', 'The entry point is never unused.', null),
   (
+    'testExecutable in flutter_test_config.dart',
+    'Called by the `flutter test` bootstrap, which never lands on disk.',
+    '--entry-point',
+  ),
+  (
     '@override members',
     'Reached polymorphically or by a framework.',
     '--overrides',
@@ -643,7 +648,8 @@ class DocsPage extends StatelessComponent {
                   ),
                   li(
                     rich(
-                      'Entry points other than `main` need excluding or '
+                      'Entry points other than `main` and `flutter test`’s '
+                      '`testExecutable` need listing with `--entry-point` or '
                       "`@pragma('vm:entry-point')`.",
                     ),
                   ),


### PR DESCRIPTION
Fixes #49

## Summary

`flutter test` generates an in-memory bootstrap that calls `testExecutable` from the nearest `flutter_test_config.dart`. Nothing on disk references the function, so ciach reported it as unused and deleted it under `--remove`.

This generalizes the `main` skip into **entry points**: declarations a tool calls from generated code. A rule is a name plus the files it may live in; the declaration's signature is not checked.

## Key changes

- **`lib/src/conventions/entry_points.dart`**: `EntryPoint` (name, file globs, reason) and `EntryPoints` (built-in rules followed by the project's own). Built in: `main` in any file, and `testExecutable` in `**/flutter_test_config.dart`.
- **`entry-points` in `ciach.yaml`**: a list of rules, each a `name` (`myBuilder`, `MyPlugin.registerWith`) with an optional `glob` (one, or a list). Config-file only, so it is the one setting without a flag. Malformed entries are usage errors naming the file and the field.
- **A member rule keeps its type**: `MyPlugin.registerWith` also exempts `MyPlugin`, since the generated call names the type too; its other members are still checked.
- **Finder**: the candidate filter consults the rules; `--verbose` names each skipped entry point other than `main`.
- **Tests and docs**: unit tests for the rules and the config parsing, finder tests on new `example/` fixtures, README, `--help`, CHANGELOG, website skip table.

```yaml
entry-points:
  - name: MyPlugin.registerWith   # a member: `Type.member`, no type parameters
    glob: 'lib/my_plugin.dart'    # one glob or a list; omit for any file
  - name: myBuilder               # a build.yaml builder factory
    glob: 'lib/builder.dart'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSG3mjCaM75vRPatyyCy2z